### PR TITLE
refactor: load config with shared config loader package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "pnpm --filter './packages/**' test"
   },
   "devDependencies": {
+    "@rstackjs/load-config": "catalog:",
     "@types/node": "catalog:",
     "cspell-ban-words": "catalog:",
     "husky": "catalog:",

--- a/packages/rstack/rslib.config.ts
+++ b/packages/rstack/rslib.config.ts
@@ -18,4 +18,7 @@ export default defineConfig({
       RSTACK_VERSION: JSON.stringify(pkgJson.version),
     },
   },
+  output: {
+    externals: ['jiti'],
+  },
 });

--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -1,4 +1,5 @@
-import { loadConfig, type RsbuildConfigDefinition } from '@rsbuild/core';
+import { loadConfig } from '@rstackjs/load-config';
+import type { RsbuildConfigDefinition } from '@rsbuild/core';
 import type { RslibConfigDefinition } from '@rslib/core';
 import type { RslintConfig } from '@rslint/core';
 import type { UserConfig, UserConfigAsyncFn } from '@rspress/core';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ catalogs:
     '@rspress/core':
       specifier: ^2.0.17
       version: 2.0.17
+    '@rstackjs/load-config':
+      specifier: ^0.1.1
+      version: 0.1.1
     '@rstest/adapter-rsbuild':
       specifier: ~0.11.0
       version: 0.11.0
@@ -78,6 +81,9 @@ importers:
 
   .:
     devDependencies:
+      '@rstackjs/load-config':
+        specifier: 'catalog:'
+        version: 0.1.1
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -735,6 +741,14 @@ packages:
 
   '@rspress/shared@2.0.17':
     resolution: {integrity: sha512-ZzpZ4hm5svgwU0w5CpTLZy4vFD3uPo8+gXtWMOREYMzwfzJeHqwOyXwxHf6byGpx85mVK5DQqMDi61meAS7ZUw==}
+
+  '@rstackjs/load-config@0.1.1':
+    resolution: {integrity: sha512-YYtqGoM5DrrmZLGaYSUAC66qhhfjAfwXVvBScGJIfPXGa878rK0SJeO6b44W2pYfikm8yefzyV0OeedWO/PKkw==}
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   '@rstest/adapter-rsbuild@0.11.0':
     resolution: {integrity: sha512-otrR3yqQ5Uyskm0hu8c0fjP1eFk6bMJALnYhUl6V1CKp/monoowFMa6XEqdY2d4aHv6oa8XWGLfU4LWne1Vg9A==}
@@ -2195,6 +2209,8 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - core-js
+
+  '@rstackjs/load-config@0.1.1': {}
 
   '@rstest/adapter-rsbuild@0.11.0(@rsbuild/core@2.1.4)(@rstest/core@0.11.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ catalog:
   '@rslib/core': '~0.23.2'
   '@rslint/core': '~0.6.5'
   '@rspress/core': '^2.0.17'
+  '@rstackjs/load-config': ^0.1.1
   '@rstest/adapter-rsbuild': '~0.11.0'
   '@rstest/adapter-rslib': '~0.11.0'
   '@rstest/core': '~0.11.0'
@@ -51,6 +52,7 @@ minimumReleaseAgeExclude:
   - '@rspress/*'
   - '@rstest/*'
   - '@rslint/*'
+  - '@rstackjs/*'
   - '@rstack-dev/doc-ui'
   - 'rsbuild-plugin-*'
   - '@swc/*'

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -6,5 +6,6 @@ rslint
 rspack
 rspress
 rstack
+rstackjs
 rstest
 turborepo


### PR DESCRIPTION
## Summary

This PR switches Rstack config loading to `@rstackjs/load-config` so user config resolution can use the shared Rstack loader instead of the Rsbuild loader. It adds the package to the workspace catalog, keeps `jiti` external in the CLI bundle, and updates the spelling dictionary for the new package scope.