### PR TITLE
docs: add documentation example

### DIFF
--- a/examples/documentation/README.md
+++ b/examples/documentation/README.md
@@ -1,0 +1,29 @@
+# Rspress website
+
+## Setup
+
+Install the dependencies:
+
+```bash
+npm install
+```
+
+## Get started
+
+Start the dev server:
+
+```bash
+npm run dev
+```
+
+Build the website for production:
+
+```bash
+npm run build
+```
+
+Preview the production build locally:
+
+```bash
+npm run preview
+```

--- a/examples/documentation/docs/_nav.json
+++ b/examples/documentation/docs/_nav.json
@@ -1,0 +1,11 @@
+[
+  {
+    "text": "API",
+    "link": "/api/",
+    "activeMatch": "/api/"
+  },
+  {
+    "text": "Document",
+    "link": "https://rspress.rs/"
+  }
+]

--- a/examples/documentation/docs/api/_meta.json
+++ b/examples/documentation/docs/api/_meta.json
@@ -1,0 +1,1 @@
+["index", "commands"]

--- a/examples/documentation/docs/api/commands.mdx
+++ b/examples/documentation/docs/api/commands.mdx
@@ -1,0 +1,7 @@
+# Commands
+
+## dev
+
+## build
+
+## preview

--- a/examples/documentation/docs/api/index.mdx
+++ b/examples/documentation/docs/api/index.mdx
@@ -1,0 +1,6 @@
+---
+title: API Overview
+overview: true
+---
+
+This is an API Overview page which outlines all the available APIs.

--- a/examples/documentation/docs/index.md
+++ b/examples/documentation/docs/index.md
@@ -1,0 +1,18 @@
+---
+pageType: home
+
+hero:
+  name: My Site
+  text: A cool website!
+  tagline: This is the tagline
+  actions:
+    - theme: brand
+      text: Quick Start
+      link: /api/
+    - theme: alt
+      text: GitHub
+      link: https://github.com/web-infra-dev/rspress
+  image:
+    src: https://assets.rspack.rs/rspress/rspress-logo.svg
+    alt: Logo
+---

--- a/examples/documentation/package.json
+++ b/examples/documentation/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@examples/documentation",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rs doc build",
+    "dev": "rs doc",
+    "lint": "rs lint",
+    "preview": "rs doc preview"
+  },
+  "dependencies": {
+    "rstack": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  }
+}

--- a/examples/documentation/rstack.config.ts
+++ b/examples/documentation/rstack.config.ts
@@ -1,0 +1,17 @@
+import { define } from 'rstack';
+import path from 'node:path';
+
+define.doc({
+  root: path.join(import.meta.dirname, 'docs'),
+  title: 'My Site',
+});
+
+define.lint(async () => {
+  const { js, ts, reactPlugin, reactHooksPlugin } = await import('@rslint/core');
+  return [
+    js.configs.recommended,
+    ts.configs.recommended,
+    reactPlugin.configs.recommended,
+    reactHooksPlugin.configs.recommended,
+  ];
+});

--- a/examples/documentation/rstack.config.ts
+++ b/examples/documentation/rstack.config.ts
@@ -7,7 +7,7 @@ define.doc({
 });
 
 define.lint(async () => {
-  const { js, ts, reactPlugin, reactHooksPlugin } = await import('@rslint/core');
+  const { js, ts, reactPlugin, reactHooksPlugin } = await import('rstack/lint');
   return [
     js.configs.recommended,
     ts.configs.recommended,

--- a/examples/documentation/tsconfig.json
+++ b/examples/documentation/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2020"],
+    "jsx": "react-jsx",
+    "target": "ES2020",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["rstack/types", "node"],
+    "useDefineForClassFields": true,
+
+    /* modules */
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+
+    /* type checking */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["docs", "rstack.config.ts"],
+  "mdx": {
+    "checkMdx": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,23 +167,20 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rstack
     devDependencies:
-      '@rslint/core':
-        specifier: ^0.5.3
-        version: 0.5.3
       '@types/node':
-        specifier: ^22.8.1
-        version: 22.20.1
+        specifier: 'catalog:'
+        version: 24.13.2
       '@types/react':
-        specifier: ^19.2.17
+        specifier: 'catalog:'
         version: 19.2.17
       '@types/react-dom':
-        specifier: ^19.2.3
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
       react:
-        specifier: ^19.2.7
+        specifier: 'catalog:'
         version: 19.2.7
       react-dom:
-        specifier: ^19.2.7
+        specifier: 'catalog:'
         version: 19.2.7(react@19.2.7)
 
   examples/lib-node:
@@ -537,15 +534,6 @@ packages:
       typescript:
         optional: true
 
-  '@rslint/core@0.5.3':
-    resolution: {integrity: sha512-7s7Yb9L0mwI2sl06G5HTI7ENd1iJiGYFVWbHjeJbXa7bLM5rPwkgWsYMRZo4kYQIYqpqD4Oqraor+zawEcunkw==}
-    hasBin: true
-    peerDependencies:
-      jiti: ^2.0.0
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-
   '@rslint/core@0.6.5':
     resolution: {integrity: sha512-BAy65hSKOhHrma20Rxqf1DTyGNYBSQGBeo21JKc0bgHzbkTbUcyPSz6EpdI3woDe0HqwGmOsl/tPTGqKvgsz3g==}
     hasBin: true
@@ -554,26 +542,6 @@ packages:
     peerDependenciesMeta:
       jiti:
         optional: true
-
-  '@rslint/darwin-arm64@0.5.3':
-    resolution: {integrity: sha512-g/VSIw1/slkvQsNRbHpImAip/sCjEaqE/Z5ZE6plL7GXdeztWckSevu+J5v07JmILvebJ7ZUgFvMw/ydTdxofw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rslint/darwin-x64@0.5.3':
-    resolution: {integrity: sha512-+29fPLRjkNVQW7DAtgNkQH6rYg1CdjJYHhBhRHT8TJWU8+N3GrhWjbxEvW9XThkABpDqsxAGS86wCE060QuRpQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rslint/linux-arm64@0.5.3':
-    resolution: {integrity: sha512-gpvnMVVP0wPe0T9qeITkaBB9WldxQPnJP8u314cG4sDyGV/qISKvUOPPk4AM3YG0f4UU7FA9gUySLptHLcDOFw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rslint/linux-x64@0.5.3':
-    resolution: {integrity: sha512-/ZzTWlZwi+Ff74tbnGYgLUc7YTDVsNuaL3EeZFuFIYk02Lge9UCCJywMExoLVTdhrZh7fRWu6nlS6sf1/okb8g==}
-    cpu: [x64]
-    os: [linux]
 
   '@rslint/native-darwin-arm64@0.6.5':
     resolution: {integrity: sha512-5HDBqR1XgZ29pNEjSnm/YccWpwEWEl9d8rUQZkbDUz3x2VWylfok8Ty1qjDHVAas1k01euMS1YJA4/nku9N0Iw==}
@@ -616,16 +584,6 @@ packages:
 
   '@rslint/native-win32-x64-msvc@0.6.5':
     resolution: {integrity: sha512-7iQozrpTvh/Vj7x5jTYaG+9zKWJkiXz0PgemFNUMIXLCZHWsJffPy7D1ls5q2Rfe6hshFJ9d6UxGk1KmLpZQiw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rslint/win32-arm64@0.5.3':
-    resolution: {integrity: sha512-l5T5VeKQKjLMpUqahU/UDRV0UQcjvxN+r6bOSl+do0xCsYXpfEiI6HlE33//+VilJ120t2SI5e8Hnidaha3XEw==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rslint/win32-x64@0.5.3':
-    resolution: {integrity: sha512-aPbtXTNeM9A5pA3krRzEaHGA6RLLkG5k8naNWGIfQnwfjMCk6vzjTyL6Wceg6Oq+qjTDnBLzU3RqZhpXwPeJ7w==}
     cpu: [x64]
     os: [win32]
 
@@ -937,9 +895,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@22.20.1':
-    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
-
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
@@ -1161,15 +1116,6 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
-  fdir@6.5.0:
-    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
 
   flexsearch@0.8.212:
     resolution: {integrity: sha512-wSyJr1GUWoOOIISRu+X2IXiOcVfg9qqBRyCPRUdLMIGJqPzMo+jMRlvE83t14v1j0dRMEaBbER/adQjp6Du2pw==}
@@ -1756,10 +1702,6 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -1780,9 +1722,6 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -2069,18 +2008,6 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rslint/core@0.5.3':
-    dependencies:
-      picomatch: 4.0.4
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@rslint/darwin-arm64': 0.5.3
-      '@rslint/darwin-x64': 0.5.3
-      '@rslint/linux-arm64': 0.5.3
-      '@rslint/linux-x64': 0.5.3
-      '@rslint/win32-arm64': 0.5.3
-      '@rslint/win32-x64': 0.5.3
-
   '@rslint/core@0.6.5':
     dependencies:
       picomatch: 4.0.4
@@ -2093,18 +2020,6 @@ snapshots:
       '@rslint/native-linux-x64-musl': 0.6.5
       '@rslint/native-win32-arm64-msvc': 0.6.5
       '@rslint/native-win32-x64-msvc': 0.6.5
-
-  '@rslint/darwin-arm64@0.5.3':
-    optional: true
-
-  '@rslint/darwin-x64@0.5.3':
-    optional: true
-
-  '@rslint/linux-arm64@0.5.3':
-    optional: true
-
-  '@rslint/linux-x64@0.5.3':
-    optional: true
 
   '@rslint/native-darwin-arm64@0.6.5':
     optional: true
@@ -2128,12 +2043,6 @@ snapshots:
     optional: true
 
   '@rslint/native-win32-x64-msvc@0.6.5':
-    optional: true
-
-  '@rslint/win32-arm64@0.5.3':
-    optional: true
-
-  '@rslint/win32-x64@0.5.3':
     optional: true
 
   '@rspack/binding-darwin-arm64@2.1.2':
@@ -2466,10 +2375,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@22.20.1':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@24.13.2':
     dependencies:
       undici-types: 7.18.2
@@ -2656,10 +2561,6 @@ snapshots:
   eventemitter3@5.0.4: {}
 
   extend@3.0.2: {}
-
-  fdir@6.5.0(picomatch@4.0.4):
-    optionalDependencies:
-      picomatch: 4.0.4
 
   flexsearch@0.8.212: {}
 
@@ -3669,11 +3570,6 @@ snapshots:
 
   tinyexec@1.2.4: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinypool@2.1.0: {}
 
   toggle-selection@1.0.6: {}
@@ -3685,8 +3581,6 @@ snapshots:
   tslib@2.8.1: {}
 
   typescript@6.0.3: {}
-
-  undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,31 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
+  examples/documentation:
+    dependencies:
+      rstack:
+        specifier: workspace:*
+        version: link:../../packages/rstack
+    devDependencies:
+      '@rslint/core':
+        specifier: ^0.5.3
+        version: 0.5.3
+      '@types/node':
+        specifier: ^22.8.1
+        version: 22.20.1
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+
   examples/lib-node:
     devDependencies:
       '@types/node':
@@ -512,6 +537,15 @@ packages:
       typescript:
         optional: true
 
+  '@rslint/core@0.5.3':
+    resolution: {integrity: sha512-7s7Yb9L0mwI2sl06G5HTI7ENd1iJiGYFVWbHjeJbXa7bLM5rPwkgWsYMRZo4kYQIYqpqD4Oqraor+zawEcunkw==}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
   '@rslint/core@0.6.5':
     resolution: {integrity: sha512-BAy65hSKOhHrma20Rxqf1DTyGNYBSQGBeo21JKc0bgHzbkTbUcyPSz6EpdI3woDe0HqwGmOsl/tPTGqKvgsz3g==}
     hasBin: true
@@ -520,6 +554,26 @@ packages:
     peerDependenciesMeta:
       jiti:
         optional: true
+
+  '@rslint/darwin-arm64@0.5.3':
+    resolution: {integrity: sha512-g/VSIw1/slkvQsNRbHpImAip/sCjEaqE/Z5ZE6plL7GXdeztWckSevu+J5v07JmILvebJ7ZUgFvMw/ydTdxofw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rslint/darwin-x64@0.5.3':
+    resolution: {integrity: sha512-+29fPLRjkNVQW7DAtgNkQH6rYg1CdjJYHhBhRHT8TJWU8+N3GrhWjbxEvW9XThkABpDqsxAGS86wCE060QuRpQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rslint/linux-arm64@0.5.3':
+    resolution: {integrity: sha512-gpvnMVVP0wPe0T9qeITkaBB9WldxQPnJP8u314cG4sDyGV/qISKvUOPPk4AM3YG0f4UU7FA9gUySLptHLcDOFw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rslint/linux-x64@0.5.3':
+    resolution: {integrity: sha512-/ZzTWlZwi+Ff74tbnGYgLUc7YTDVsNuaL3EeZFuFIYk02Lge9UCCJywMExoLVTdhrZh7fRWu6nlS6sf1/okb8g==}
+    cpu: [x64]
+    os: [linux]
 
   '@rslint/native-darwin-arm64@0.6.5':
     resolution: {integrity: sha512-5HDBqR1XgZ29pNEjSnm/YccWpwEWEl9d8rUQZkbDUz3x2VWylfok8Ty1qjDHVAas1k01euMS1YJA4/nku9N0Iw==}
@@ -562,6 +616,16 @@ packages:
 
   '@rslint/native-win32-x64-msvc@0.6.5':
     resolution: {integrity: sha512-7iQozrpTvh/Vj7x5jTYaG+9zKWJkiXz0PgemFNUMIXLCZHWsJffPy7D1ls5q2Rfe6hshFJ9d6UxGk1KmLpZQiw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rslint/win32-arm64@0.5.3':
+    resolution: {integrity: sha512-l5T5VeKQKjLMpUqahU/UDRV0UQcjvxN+r6bOSl+do0xCsYXpfEiI6HlE33//+VilJ120t2SI5e8Hnidaha3XEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rslint/win32-x64@0.5.3':
+    resolution: {integrity: sha512-aPbtXTNeM9A5pA3krRzEaHGA6RLLkG5k8naNWGIfQnwfjMCk6vzjTyL6Wceg6Oq+qjTDnBLzU3RqZhpXwPeJ7w==}
     cpu: [x64]
     os: [win32]
 
@@ -873,6 +937,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
@@ -1094,6 +1161,15 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   flexsearch@0.8.212:
     resolution: {integrity: sha512-wSyJr1GUWoOOIISRu+X2IXiOcVfg9qqBRyCPRUdLMIGJqPzMo+jMRlvE83t14v1j0dRMEaBbER/adQjp6Du2pw==}
@@ -1680,6 +1756,10 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -1700,6 +1780,9 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -1977,14 +2060,26 @@ snapshots:
 
   '@rslib/core@0.23.2(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.1.4
-      rsbuild-plugin-dts: 0.23.2(@rsbuild/core@2.1.4)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.5
+      rsbuild-plugin-dts: 0.23.2(@rsbuild/core@2.1.5)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
       - core-js
+
+  '@rslint/core@0.5.3':
+    dependencies:
+      picomatch: 4.0.4
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@rslint/darwin-arm64': 0.5.3
+      '@rslint/darwin-x64': 0.5.3
+      '@rslint/linux-arm64': 0.5.3
+      '@rslint/linux-x64': 0.5.3
+      '@rslint/win32-arm64': 0.5.3
+      '@rslint/win32-x64': 0.5.3
 
   '@rslint/core@0.6.5':
     dependencies:
@@ -1998,6 +2093,18 @@ snapshots:
       '@rslint/native-linux-x64-musl': 0.6.5
       '@rslint/native-win32-arm64-msvc': 0.6.5
       '@rslint/native-win32-x64-msvc': 0.6.5
+
+  '@rslint/darwin-arm64@0.5.3':
+    optional: true
+
+  '@rslint/darwin-x64@0.5.3':
+    optional: true
+
+  '@rslint/linux-arm64@0.5.3':
+    optional: true
+
+  '@rslint/linux-x64@0.5.3':
+    optional: true
 
   '@rslint/native-darwin-arm64@0.6.5':
     optional: true
@@ -2021,6 +2128,12 @@ snapshots:
     optional: true
 
   '@rslint/native-win32-x64-msvc@0.6.5':
+    optional: true
+
+  '@rslint/win32-arm64@0.5.3':
+    optional: true
+
+  '@rslint/win32-x64@0.5.3':
     optional: true
 
   '@rspack/binding-darwin-arm64@2.1.2':
@@ -2226,7 +2339,7 @@ snapshots:
 
   '@rstest/core@0.11.0(happy-dom@20.10.6)':
     dependencies:
-      '@rsbuild/core': 2.1.4
+      '@rsbuild/core': 2.1.5
       '@types/chai': 5.2.3
     optionalDependencies:
       happy-dom: 20.10.6
@@ -2352,6 +2465,10 @@ snapshots:
   '@types/mdx@2.0.14': {}
 
   '@types/ms@2.1.0': {}
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@24.13.2':
     dependencies:
@@ -2539,6 +2656,10 @@ snapshots:
   eventemitter3@5.0.4: {}
 
   extend@3.0.2: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   flexsearch@0.8.212: {}
 
@@ -3470,10 +3591,10 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rsbuild-plugin-dts@0.23.2(@rsbuild/core@2.1.4)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.23.2(@rsbuild/core@2.1.5)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.4
+      '@rsbuild/core': 2.1.5
     optionalDependencies:
       typescript: 6.0.3
 
@@ -3548,6 +3669,11 @@ snapshots:
 
   tinyexec@1.2.4: {}
 
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@2.1.0: {}
 
   toggle-selection@1.0.6: {}
@@ -3559,6 +3685,8 @@ snapshots:
   tslib@2.8.1: {}
 
   typescript@6.0.3: {}
+
+  undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
 


### PR DESCRIPTION
## Summary

This PR adds a documentation example for building an Rspress site with Rstack. It includes starter docs content, Rstack doc/lint configuration, package scripts, TypeScript settings, and the workspace lockfile update.