### PR TITLE
perf: reduce Rstack CLI startup time

### DIFF
--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -59,6 +59,7 @@
     "@rstest/adapter-rslib": "catalog:",
     "@types/node": "catalog:",
     "lint-staged": "catalog:",
+    "rslog": "catalog:",
     "typescript": "catalog:"
   },
   "peerDependencies": {

--- a/packages/rstack/src/cli/index.ts
+++ b/packages/rstack/src/cli/index.ts
@@ -1,5 +1,5 @@
 import { setupCommands } from './commands.js';
-import { logger } from '@rsbuild/core';
+import { logger } from 'rslog';
 
 export async function runCLI(): Promise<void> {
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ catalogs:
     react-dom:
       specifier: ^19.2.7
       version: 19.2.7
+    rslog:
+      specifier: ^2.1.3
+      version: 2.1.3
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
@@ -264,6 +267,9 @@ importers:
       lint-staged:
         specifier: 'catalog:'
         version: 16.4.0
+      rslog:
+        specifier: 'catalog:'
+        version: 2.1.3
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1636,6 +1642,10 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  rslog@2.1.3:
+    resolution: {integrity: sha512-DCUkRKUBR1lSpHKRcxNvHaYwGrUVf9MsoE1u6gd0CF37I8vwwtWc4b+FA9OwYZ4QA/shslzAYorD3MMfd+Rs/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3498,6 +3508,8 @@ snapshots:
       '@rsbuild/core': 2.1.5
     optionalDependencies:
       typescript: 6.0.3
+
+  rslog@2.1.3: {}
 
   scheduler@0.27.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ catalog:
   'oxfmt': '^0.56.0'
   'react': '^19.2.7'
   'react-dom': '^19.2.7'
+  rslog: ^2.1.3
   'typescript': '^6.0.3'
 
 dedupePeers: true

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -3,6 +3,7 @@ oxfmt
 rsbuild
 rslib
 rslint
+rslog
 rspack
 rspress
 rstack


### PR DESCRIPTION
## Summary

This PR imports the CLI logger directly from `rslog` so `rs lint` no longer eagerly loads `@rsbuild/core` and `@rspack/core`. It adds `rslog` to the workspace catalog as a development dependency, allowing Rslib to bundle it into the CLI output.

## Performance

Measured with Hyperfine (`--warmup 5 --runs 40`) and `node --run lint -- --help` to isolate CLI startup:

| Run order | `@rsbuild/core` | `rslog` | Reduction |
| --- | ---: | ---: | ---: |
| Existing → new | 90.9 ± 7.4 ms | 75.9 ± 6.6 ms | 15.0 ms (16.5%) |
| New → existing | 87.9 ± 4.6 ms | 75.5 ± 5.4 ms | 12.4 ms (14.1%) |

Full lint runs remain dominated by file scanning and type checking, whose variance is larger than this fixed startup gain.