### PR TITLE
fix: prefer app config for Rstest

### DIFF
--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -26,7 +26,7 @@ Use `rs -h` for top-level help, and `rs <command> -h` for command help where sup
 
 Key behavior:
 
-- `rs test` extends `define.app` through `@rstest/adapter-rsbuild` and `define.lib` through `@rstest/adapter-rslib` unless `define.test` already sets `extends`.
+- Unless `define.test` already sets `extends`, `rs test` extends `define.app` through `@rstest/adapter-rsbuild` or falls back to `define.lib` through `@rstest/adapter-rslib`. The app config takes precedence when both are defined.
 - `rs doc` requires the optional `@rspress/core` dependency.
 
 ## rstack.config.ts

--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -68,8 +68,8 @@ type Define = {
    *
    * This config is used by the `rs test` command.
    *
-   * If `define.app` is also used, Rstest automatically extends the app config unless
-   * `extends` is set explicitly.
+   * Unless `extends` is set explicitly, Rstest automatically extends `define.app` or
+   * falls back to `define.lib`. The app config takes precedence when both are defined.
    */
   test: (config: RstestConfigExport) => void;
   /**

--- a/packages/rstack/src/rstestConfig.ts
+++ b/packages/rstack/src/rstestConfig.ts
@@ -7,6 +7,8 @@ const extendsConfig = async (configs: Configs, testConfig: RstestConfig, params:
     return testConfig;
   }
 
+  // Prefer the app when both app and lib are defined. Merging both adapters can
+  // introduce conflicting runtime, resolve, and source transform settings.
   const appConfig = configs.app;
   if (appConfig) {
     const { withRsbuildConfig } = await import(
@@ -15,9 +17,12 @@ const extendsConfig = async (configs: Configs, testConfig: RstestConfig, params:
     );
     const config = typeof appConfig === 'function' ? await appConfig(params) : appConfig;
 
-    testConfig.extends = withRsbuildConfig({
-      config,
-    });
+    return {
+      ...testConfig,
+      extends: withRsbuildConfig({
+        config,
+      }),
+    };
   }
 
   const libConfig = configs.lib;
@@ -28,9 +33,12 @@ const extendsConfig = async (configs: Configs, testConfig: RstestConfig, params:
     );
     const config = typeof libConfig === 'function' ? await libConfig(params) : libConfig;
 
-    testConfig.extends = withRslibConfig({
-      config,
-    });
+    return {
+      ...testConfig,
+      extends: withRslibConfig({
+        config,
+      }),
+    };
   }
 
   return testConfig;

--- a/packages/rstack/test/config/define-app-lib/fixture.ts
+++ b/packages/rstack/test/config/define-app-lib/fixture.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'rstack/test';
+
+declare const RSTACK_INHERITED_CONFIG: string;
+
+test('inherits the app config', () => {
+  expect(RSTACK_INHERITED_CONFIG).toBe('app');
+});

--- a/packages/rstack/test/config/define-app-lib/index.test.ts
+++ b/packages/rstack/test/config/define-app-lib/index.test.ts
@@ -1,0 +1,5 @@
+import { test } from '#test-helpers';
+
+test('should prefer define.app when app and lib are both defined', ({ execCli }) => {
+  execCli('test');
+});

--- a/packages/rstack/test/config/define-app-lib/rstack.config.ts
+++ b/packages/rstack/test/config/define-app-lib/rstack.config.ts
@@ -1,0 +1,22 @@
+import { define } from 'rstack';
+
+define.app({
+  source: {
+    define: {
+      RSTACK_INHERITED_CONFIG: JSON.stringify('app'),
+    },
+  },
+});
+
+define.lib({
+  lib: [{}],
+  source: {
+    define: {
+      RSTACK_INHERITED_CONFIG: JSON.stringify('lib'),
+    },
+  },
+});
+
+define.test({
+  include: ['./fixture.ts'],
+});


### PR DESCRIPTION
When both `define.app` and `define.lib` are present, the lib adapter currently overwrites the app adapter used by `rs test`.