### PR TITLE
feat: add concurrent option to staged command

### DIFF
--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -9,8 +9,9 @@ Usage:
 Runs lint-staged with tasks from define.staged in rstack.config.
 
 Options:
-  --allow-empty  Allow empty commits when tasks revert all staged changes
-  -h, --help     Display this help message`;
+  --allow-empty                      allow empty commits when tasks revert all staged changes
+  -p, --concurrent <number|boolean>  the number of tasks to run concurrently, or false for serial
+  -h, --help                         Display this help message`;
 
 export async function runStagedCLI(args: string[]): Promise<void> {
   const { values } = parseArgs({
@@ -18,6 +19,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
     options: {
       'allow-empty': { type: 'boolean' },
       allowEmpty: { type: 'boolean' },
+      concurrent: { type: 'string', short: 'p' },
       help: { type: 'boolean', short: 'h' },
     },
     allowPositionals: false,
@@ -43,6 +45,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
   );
   const success = await lintStaged({
     allowEmpty: values['allow-empty'] ?? values.allowEmpty ?? false,
+    concurrent: values.concurrent === undefined ? true : JSON.parse(values.concurrent),
     config: stagedConfig,
   });
   if (!success) {

--- a/packages/rstack/test/cli/staged/index.test.ts
+++ b/packages/rstack/test/cli/staged/index.test.ts
@@ -79,8 +79,20 @@ test('should prevent an empty commit by default', async ({ execCli, expect }) =>
   });
 });
 
-test(`should allow an empty commit with --allow-empty`, async ({ execCli }) => {
+test('should allow an empty commit with --allow-empty', async ({ execCli }) => {
   await withGitFixture((cwd) => {
     execCli(`staged --allow-empty`, { cwd });
+  });
+});
+
+test('should run staged tasks with --concurrent false', async ({ execCli }) => {
+  await withGitFixture((cwd) => {
+    execCli(`staged --allow-empty --concurrent false`, { cwd });
+  });
+});
+
+test('should run staged tasks with -p 1', async ({ execCli }) => {
+  await withGitFixture((cwd) => {
+    execCli(`staged --allow-empty -p 1`, { cwd });
   });
 });


### PR DESCRIPTION
This PR adds `-p, --concurrent <number|boolean>` to `rs staged` so Git hooks can control lint-staged task concurrency. Values follow lint-staged CLI semantics and are parsed into booleans or numbers, while the default remains `true`. Integration tests cover serial execution and a numeric concurrency limit.