### PR TITLE
feat: add verbose option to staged command

### DIFF
--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -11,6 +11,7 @@ Runs lint-staged with tasks from define.staged in rstack.config.
 Options:
   --allow-empty                      allow empty commits when tasks revert all staged changes
   -p, --concurrent <number|boolean>  the number of tasks to run concurrently, or false for serial
+  -v, --verbose                      show task output even when tasks succeed; by default only failed output is shown
   -h, --help                         Display this help message`;
 
 export async function runStagedCLI(args: string[]): Promise<void> {
@@ -21,6 +22,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
       allowEmpty: { type: 'boolean' },
       concurrent: { type: 'string', short: 'p' },
       help: { type: 'boolean', short: 'h' },
+      verbose: { type: 'boolean', short: 'v' },
     },
     allowPositionals: false,
     strict: true,
@@ -47,6 +49,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
     allowEmpty: values['allow-empty'] ?? values.allowEmpty ?? false,
     concurrent: values.concurrent === undefined ? true : JSON.parse(values.concurrent),
     config: stagedConfig,
+    verbose: values.verbose ?? false,
   });
   if (!success) {
     process.exitCode = 1;

--- a/packages/rstack/test/cli/staged/index.test.ts
+++ b/packages/rstack/test/cli/staged/index.test.ts
@@ -25,6 +25,8 @@ define.staged({ '*.txt': 'node revert.mjs' });
 for (const file of process.argv.slice(2)) {
   writeFileSync(file, 'initial\\n');
 }
+
+console.log('staged task output');
 `,
     ),
     writeFile(path.join(cwd, 'file.txt'), 'initial\n'),
@@ -66,6 +68,7 @@ test('should display the staged help message', ({ execCli, expect }) => {
   expect(output).toContain('Usage:\n  $ rs staged [options]');
   expect(output).toContain('Runs lint-staged with tasks from define.staged in rstack.config.');
   expect(output).toContain('--allow-empty');
+  expect(output).toContain('-v, --verbose');
   expect(output).toContain('-h, --help');
 });
 
@@ -85,14 +88,19 @@ test('should allow an empty commit with --allow-empty', async ({ execCli }) => {
   });
 });
 
-test('should run staged tasks with --concurrent false', async ({ execCli }) => {
-  await withGitFixture((cwd) => {
-    execCli(`staged --allow-empty --concurrent false`, { cwd });
+for (const option of ['--concurrent false', '-p 1']) {
+  test(`should run staged tasks with ${option}`, async ({ execCli }) => {
+    await withGitFixture((cwd) => {
+      execCli(`staged --allow-empty ${option}`, { cwd });
+    });
   });
-});
+}
 
-test('should run staged tasks with -p 1', async ({ execCli }) => {
-  await withGitFixture((cwd) => {
-    execCli(`staged --allow-empty -p 1`, { cwd });
+for (const option of ['--verbose', '-v']) {
+  test(`should show successful task output with ${option}`, async ({ execCli, expect }) => {
+    await withGitFixture((cwd) => {
+      const output = execCli(`staged --allow-empty ${option}`, { cwd });
+      expect(output).toContain('staged task output');
+    });
   });
-});
+}


### PR DESCRIPTION
This PR adds `-v, --verbose` support to `rs staged` so successful task output can be shown when needed, while preserving the default quiet-on-success behavior. Integration tests verify both long and short forms against actual task output. The concurrent option cases are also consolidated into a shared `for...of` test.