### PR TITLE
feat: add no-stash option to staged command

### DIFF
--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -9,9 +9,10 @@ Usage:
 Runs lint-staged with tasks from define.staged in rstack.config.
 
 Options:
-  --allow-empty                      allow empty commits when tasks revert all staged changes
-  -p, --concurrent <number|boolean>  the number of tasks to run concurrently, or false for serial
-  -v, --verbose                      show task output even when tasks succeed; by default only failed output is shown
+  --allow-empty                      Allow empty commits when tasks revert all staged changes
+  -p, --concurrent <number|boolean>  The number of tasks to run concurrently, or false for serial
+  --no-stash                         Disable the backup stash. Implies "--no-revert".
+  -v, --verbose                      Show task output even when tasks succeed; by default only failed output is shown
   -h, --help                         Display this help message`;
 
 export async function runStagedCLI(args: string[]): Promise<void> {
@@ -22,6 +23,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
       allowEmpty: { type: 'boolean' },
       concurrent: { type: 'string', short: 'p' },
       help: { type: 'boolean', short: 'h' },
+      'no-stash': { type: 'boolean' },
       verbose: { type: 'boolean', short: 'v' },
     },
     allowPositionals: false,
@@ -49,6 +51,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
     allowEmpty: values['allow-empty'] ?? values.allowEmpty ?? false,
     concurrent: values.concurrent === undefined ? true : JSON.parse(values.concurrent),
     config: stagedConfig,
+    stash: !values['no-stash'],
     verbose: values.verbose ?? false,
   });
   if (!success) {

--- a/packages/rstack/test/cli/staged/index.test.ts
+++ b/packages/rstack/test/cli/staged/index.test.ts
@@ -68,6 +68,7 @@ test('should display the staged help message', ({ execCli, expect }) => {
   expect(output).toContain('Usage:\n  $ rs staged [options]');
   expect(output).toContain('Runs lint-staged with tasks from define.staged in rstack.config.');
   expect(output).toContain('--allow-empty');
+  expect(output).toContain('--no-stash');
   expect(output).toContain('-v, --verbose');
   expect(output).toContain('-h, --help');
 });
@@ -104,3 +105,10 @@ for (const option of ['--verbose', '-v']) {
     });
   });
 }
+
+test('should run staged tasks without a backup stash', async ({ execCli, expect }) => {
+  await withGitFixture((cwd) => {
+    const output = execCli('staged --allow-empty --no-stash 2>&1', { cwd });
+    expect(output).toContain('Skipping backup because `--no-stash` was used');
+  });
+});


### PR DESCRIPTION
This PR adds `--no-stash` support to `rs staged` for workflows that need to skip lint-staged's backup stash, while preserving the default `stash: true` behavior. The flag maps to `stash: false` and retains lint-staged's implied no-revert behavior and warning. Staged help descriptions are also normalized to sentence case.