### PR TITLE
feat: add quiet option to staged command

### DIFF
--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -12,6 +12,7 @@ Options:
   --allow-empty                      Allow empty commits when tasks revert all staged changes
   -p, --concurrent <number|boolean>  The number of tasks to run concurrently, or false for serial
   --no-stash                         Disable the backup stash. Implies "--no-revert".
+  -q, --quiet                        Disable lint-staged's own console output
   -v, --verbose                      Show task output even when tasks succeed; by default only failed output is shown
   -h, --help                         Display this help message`;
 
@@ -24,6 +25,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
       concurrent: { type: 'string', short: 'p' },
       help: { type: 'boolean', short: 'h' },
       'no-stash': { type: 'boolean' },
+      quiet: { type: 'boolean', short: 'q' },
       verbose: { type: 'boolean', short: 'v' },
     },
     allowPositionals: false,
@@ -51,6 +53,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
     allowEmpty: values['allow-empty'] ?? values.allowEmpty ?? false,
     concurrent: values.concurrent === undefined ? true : JSON.parse(values.concurrent),
     config: stagedConfig,
+    quiet: values.quiet ?? false,
     stash: !values['no-stash'],
     verbose: values.verbose ?? false,
   });

--- a/packages/rstack/test/cli/staged/index.test.ts
+++ b/packages/rstack/test/cli/staged/index.test.ts
@@ -69,6 +69,7 @@ test('should display the staged help message', ({ execCli, expect }) => {
   expect(output).toContain('Runs lint-staged with tasks from define.staged in rstack.config.');
   expect(output).toContain('--allow-empty');
   expect(output).toContain('--no-stash');
+  expect(output).toContain('-q, --quiet');
   expect(output).toContain('-v, --verbose');
   expect(output).toContain('-h, --help');
 });
@@ -112,3 +113,12 @@ test('should run staged tasks without a backup stash', async ({ execCli, expect 
     expect(output).toContain('Skipping backup because `--no-stash` was used');
   });
 });
+
+for (const option of ['--quiet', '-q']) {
+  test(`should suppress lint-staged output with ${option}`, async ({ execCli, expect }) => {
+    await withGitFixture((cwd) => {
+      const output = execCli(`staged --allow-empty ${option}`, { cwd });
+      expect(output).toBe('');
+    });
+  });
+}


### PR DESCRIPTION
This PR adds `-q, --quiet` support to `rs staged` for hooks that need to suppress lint-staged's own console output. The option maps directly to lint-staged's `quiet` API while preserving the default `false` behavior. Integration tests verify that both long and short forms produce no stdout.