### PR TITLE
perf: upgrade rslog to v2.2.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ catalogs:
       specifier: ^19.2.7
       version: 19.2.7
     rslog:
-      specifier: ^2.1.3
-      version: 2.1.3
+      specifier: ^2.2.0
+      version: 2.2.0
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
@@ -269,7 +269,7 @@ importers:
         version: 16.4.0
       rslog:
         specifier: 'catalog:'
-        version: 2.1.3
+        version: 2.2.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1643,8 +1643,8 @@ packages:
       typescript:
         optional: true
 
-  rslog@2.1.3:
-    resolution: {integrity: sha512-DCUkRKUBR1lSpHKRcxNvHaYwGrUVf9MsoE1u6gd0CF37I8vwwtWc4b+FA9OwYZ4QA/shslzAYorD3MMfd+Rs/Q==}
+  rslog@2.2.0:
+    resolution: {integrity: sha512-aTYPzpoq1NrQYB8uK3mXEZgXoLva5lqMfnFNrPLZALsIx7vD1Q+HTp+fuu2aRHV3PJTg63ARDZ8MT0Lth4SoNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   scheduler@0.27.0:
@@ -3509,7 +3509,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  rslog@2.1.3: {}
+  rslog@2.2.0: {}
 
   scheduler@0.27.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,7 +33,7 @@ catalog:
   'oxfmt': '^0.56.0'
   'react': '^19.2.7'
   'react-dom': '^19.2.7'
-  rslog: ^2.1.3
+  rslog: ^2.2.0
   'typescript': '^6.0.3'
 
 dedupePeers: true
@@ -54,6 +54,7 @@ minimumReleaseAgeExclude:
   - '@rstest/*'
   - '@rslint/*'
   - '@rstackjs/*'
+  - 'rslog'
   - '@rstack-dev/doc-ui'
   - 'rsbuild-plugin-*'
   - '@swc/*'


### PR DESCRIPTION
## Summary

Upgrade rslog from v2.1.3 to v2.2.0.

In benchmark of `rs --version` with 300 samples per version on Node.js 24.12.0, median startup time decreased from 29.00 ms to 27.56 ms (about 5.0%). 

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8089
- https://github.com/rstackjs/rslog/releases/tag/v2.2.0