### PR TITLE
feat: add relative option to staged command

### DIFF
--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -13,6 +13,7 @@ Options:
   -p, --concurrent <number|boolean>  The number of tasks to run concurrently, or false for serial
   --no-stash                         Disable the backup stash. Implies "--no-revert".
   -q, --quiet                        Disable lint-staged's own console output
+  -r, --relative                     Pass relative filepaths to tasks
   -v, --verbose                      Show task output even when tasks succeed; by default only failed output is shown
   -h, --help                         Display this help message`;
 
@@ -26,6 +27,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
       help: { type: 'boolean', short: 'h' },
       'no-stash': { type: 'boolean' },
       quiet: { type: 'boolean', short: 'q' },
+      relative: { type: 'boolean', short: 'r' },
       verbose: { type: 'boolean', short: 'v' },
     },
     allowPositionals: false,
@@ -54,6 +56,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
     concurrent: values.concurrent === undefined ? true : JSON.parse(values.concurrent),
     config: stagedConfig,
     quiet: values.quiet ?? false,
+    relative: values.relative ?? false,
     stash: !values['no-stash'],
     verbose: values.verbose ?? false,
   });

--- a/packages/rstack/test/cli/staged/index.test.ts
+++ b/packages/rstack/test/cli/staged/index.test.ts
@@ -27,6 +27,7 @@ for (const file of process.argv.slice(2)) {
 }
 
 console.log('staged task output');
+console.log('staged file:', process.argv[2]);
 `,
     ),
     writeFile(path.join(cwd, 'file.txt'), 'initial\n'),
@@ -70,6 +71,7 @@ test('should display the staged help message', ({ execCli, expect }) => {
   expect(output).toContain('--allow-empty');
   expect(output).toContain('--no-stash');
   expect(output).toContain('-q, --quiet');
+  expect(output).toContain('-r, --relative');
   expect(output).toContain('-v, --verbose');
   expect(output).toContain('-h, --help');
 });
@@ -119,6 +121,15 @@ for (const option of ['--quiet', '-q']) {
     await withGitFixture((cwd) => {
       const output = execCli(`staged --allow-empty ${option}`, { cwd });
       expect(output).toBe('');
+    });
+  });
+}
+
+for (const option of ['--relative', '-r']) {
+  test(`should pass relative filepaths with ${option}`, async ({ execCli, expect }) => {
+    await withGitFixture((cwd) => {
+      const output = execCli(`staged --allow-empty --verbose ${option}`, { cwd });
+      expect(output).toContain('staged file: file.txt');
     });
   });
 }


### PR DESCRIPTION
This PR adds `-r, --relative` support to `rs staged` for tasks that need paths relative to the current working directory. The option maps directly to lint-staged's `relative` API while preserving the default absolute-path behavior. Integration tests verify that both forms pass `file.txt` instead of an absolute path.