### PR TITLE
test: suppress CLI logs during test runs

### DIFF
--- a/packages/rstack/test/helpers/cli.ts
+++ b/packages/rstack/test/helpers/cli.ts
@@ -26,6 +26,7 @@ export const execCli: ExecCli = (command, options = {}) => {
 
   try {
     const output = execSync(`${RSTACK_BIN_PATH} ${command}`, {
+      stdio: 'pipe',
       ...execOptions,
       env: {
         ...process.env,


### PR DESCRIPTION
## Summary

Pipe child stdio so output remains captured by `logHelper` and is only replayed for failed tests.