### PR TITLE
feat: add cwd option to staged command

### DIFF
--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -11,6 +11,7 @@ Runs lint-staged with tasks from define.staged in rstack.config.
 Options:
   --allow-empty                      Allow empty commits when tasks revert all staged changes
   -p, --concurrent <number|boolean>  The number of tasks to run concurrently, or false for serial
+  --cwd <path>                       Working directory to run all tasks in
   --no-stash                         Disable the backup stash. Implies "--no-revert".
   -q, --quiet                        Disable lint-staged's own console output
   -r, --relative                     Pass relative filepaths to tasks
@@ -24,6 +25,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
       'allow-empty': { type: 'boolean' },
       allowEmpty: { type: 'boolean' },
       concurrent: { type: 'string', short: 'p' },
+      cwd: { type: 'string' },
       help: { type: 'boolean', short: 'h' },
       'no-stash': { type: 'boolean' },
       quiet: { type: 'boolean', short: 'q' },
@@ -55,6 +57,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
     allowEmpty: values['allow-empty'] ?? values.allowEmpty ?? false,
     concurrent: values.concurrent === undefined ? true : JSON.parse(values.concurrent),
     config: stagedConfig,
+    cwd: values.cwd,
     quiet: values.quiet ?? false,
     relative: values.relative ?? false,
     stash: !values['no-stash'],

--- a/packages/rstack/test/cli/staged/index.test.ts
+++ b/packages/rstack/test/cli/staged/index.test.ts
@@ -69,6 +69,7 @@ test('should display the staged help message', ({ execCli, expect }) => {
   expect(output).toContain('Usage:\n  $ rs staged [options]');
   expect(output).toContain('Runs lint-staged with tasks from define.staged in rstack.config.');
   expect(output).toContain('--allow-empty');
+  expect(output).toContain('--cwd <path>');
   expect(output).toContain('--no-stash');
   expect(output).toContain('-q, --quiet');
   expect(output).toContain('-r, --relative');
@@ -133,3 +134,14 @@ for (const option of ['--relative', '-r']) {
     });
   });
 }
+
+test('should run staged tasks in the specified cwd', async ({ execCli, expect }) => {
+  await withGitFixture((cwd) => {
+    const configPath = path.join(cwd, 'rstack.config.ts');
+    const output = execCli(
+      `--config ${JSON.stringify(configPath)} staged --allow-empty --cwd ${JSON.stringify(cwd)} --relative --verbose`,
+      { cwd: path.dirname(cwd) },
+    );
+    expect(output).toContain('staged file: file.txt');
+  });
+});


### PR DESCRIPTION
This PR adds `--cwd <path>` support to `rs staged` so lint-staged can operate on a Git repository other than the CLI process directory. The option maps directly to lint-staged's `cwd` API. Integration coverage starts the CLI outside the fixture repository and verifies that tasks receive the expected relative file path from the specified cwd.