### PR TITLE
feat: add debug option to staged command

### DIFF
--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -12,6 +12,7 @@ Options:
   --allow-empty                      Allow empty commits when tasks revert all staged changes
   -p, --concurrent <number|boolean>  The number of tasks to run concurrently, or false for serial
   --cwd <path>                       Working directory to run all tasks in
+  -d, --debug                        Print additional debug information
   --no-stash                         Disable the backup stash. Implies "--no-revert".
   -q, --quiet                        Disable lint-staged's own console output
   -r, --relative                     Pass relative filepaths to tasks
@@ -26,6 +27,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
       allowEmpty: { type: 'boolean' },
       concurrent: { type: 'string', short: 'p' },
       cwd: { type: 'string' },
+      debug: { type: 'boolean', short: 'd' },
       help: { type: 'boolean', short: 'h' },
       'no-stash': { type: 'boolean' },
       quiet: { type: 'boolean', short: 'q' },
@@ -58,6 +60,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
     concurrent: values.concurrent === undefined ? true : JSON.parse(values.concurrent),
     config: stagedConfig,
     cwd: values.cwd,
+    debug: values.debug ?? false,
     quiet: values.quiet ?? false,
     relative: values.relative ?? false,
     stash: !values['no-stash'],

--- a/packages/rstack/test/cli/staged/index.test.ts
+++ b/packages/rstack/test/cli/staged/index.test.ts
@@ -70,6 +70,7 @@ test('should display the staged help message', ({ execCli, expect }) => {
   expect(output).toContain('Runs lint-staged with tasks from define.staged in rstack.config.');
   expect(output).toContain('--allow-empty');
   expect(output).toContain('--cwd <path>');
+  expect(output).toContain('-d, --debug');
   expect(output).toContain('--no-stash');
   expect(output).toContain('-q, --quiet');
   expect(output).toContain('-r, --relative');
@@ -97,6 +98,15 @@ for (const option of ['--concurrent false', '-p 1']) {
   test(`should run staged tasks with ${option}`, async ({ execCli }) => {
     await withGitFixture((cwd) => {
       execCli(`staged --allow-empty ${option}`, { cwd });
+    });
+  });
+}
+
+for (const option of ['--debug', '-d']) {
+  test(`should print debug output with ${option}`, async ({ execCli, expect }) => {
+    await withGitFixture((cwd) => {
+      const output = execCli(`staged --allow-empty ${option} 2>&1`, { cwd });
+      expect(output).toContain('lint-staged:');
     });
   });
 }


### PR DESCRIPTION
This PR adds `-d, --debug` support to `rs staged` so lint-staged diagnostics can be enabled directly from the Rstack CLI. The option maps to lint-staged's `debug` API while preserving the default `false` behavior. Integration tests verify that both forms emit lint-staged debug namespaces.