### PR TITLE
refactor: defer staged option defaults to lint-staged

### DIFF
--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -56,15 +56,15 @@ export async function runStagedCLI(args: string[]): Promise<void> {
     'lint-staged'
   );
   const success = await lintStaged({
-    allowEmpty: values['allow-empty'] ?? values.allowEmpty ?? false,
-    concurrent: values.concurrent === undefined ? true : JSON.parse(values.concurrent),
+    allowEmpty: values['allow-empty'] ?? values.allowEmpty,
+    concurrent: values.concurrent === undefined ? undefined : JSON.parse(values.concurrent),
     config: stagedConfig,
     cwd: values.cwd,
-    debug: values.debug ?? false,
-    quiet: values.quiet ?? false,
-    relative: values.relative ?? false,
-    stash: !values['no-stash'],
-    verbose: values.verbose ?? false,
+    debug: values.debug,
+    quiet: values.quiet,
+    relative: values.relative,
+    stash: values['no-stash'] ? false : undefined,
+    verbose: values.verbose,
   });
   if (!success) {
     process.exitCode = 1;


### PR DESCRIPTION
This PR stops duplicating lint-staged defaults in the `rs staged` wrapper. Unspecified CLI options are forwarded as `undefined`, preserving lint-staged's own defaults and conditional interactions