### PR TITLE
chore: update repository references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ permissions: {}
 jobs:
   validate_inputs:
     name: Validate Inputs
-    if: github.repository == 'rstackjs/rstack' && github.event_name == 'workflow_dispatch'
+    if: github.repository == 'rstackjs/rstack-cli' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Validate npm tag confirmation
@@ -52,7 +52,7 @@ jobs:
 
   release:
     name: Release
-    if: github.repository == 'rstackjs/rstack' && github.event_name == 'workflow_dispatch'
+    if: github.repository == 'rstackjs/rstack-cli' && github.event_name == 'workflow_dispatch'
     needs: validate_inputs
     runs-on: ubuntu-latest
     environment: npm

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <a href="https://npmjs.com/package/rstack?activeTab=readme"><img src="https://img.shields.io/npm/v/rstack?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>
   <a href="https://npmcharts.com/compare/rstack"><img src="https://img.shields.io/npm/dm/rstack.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="downloads" /></a>
   <a href="https://nodejs.org/en/about/previous-releases"><img src="https://img.shields.io/node/v/rstack.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="node version"></a>
-  <a href="https://github.com/rstackjs/rstack/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="license" /></a>
+  <a href="https://github.com/rstackjs/rstack-cli/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="license" /></a>
 </p>
 
 Rstack CLI brings the Rstack toolchain together for JavaScript development, with one CLI, one configuration, and one consistent workflow.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rstack-monorepo",
   "private": true,
   "license": "MIT",
-  "repository": "https://github.com/rstackjs/rstack",
+  "repository": "https://github.com/rstackjs/rstack-cli",
   "type": "module",
   "scripts": {
     "build": "pnpm --filter './packages/**' build",

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -2,7 +2,7 @@
   "name": "rstack",
   "version": "0.0.3",
   "license": "MIT",
-  "repository": "https://github.com/rstackjs/rstack",
+  "repository": "https://github.com/rstackjs/rstack-cli",
   "bin": {
     "rs": "./bin/rs.js",
     "rstack": "./bin/rs.js"


### PR DESCRIPTION
This PR updates stale repository references after the repository was renamed to `rstack-cli`. It restores the release workflow guards and aligns the README and package metadata with the canonical GitHub URL.