### PR TITLE
feat: support function-based staged config

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/references/lint-staged.mdx
+++ b/.agents/skills/migrate-to-rstack-cli/references/lint-staged.mdx
@@ -5,7 +5,7 @@ Read this reference when the project uses the `lint-staged` binary, a lint-stage
 ## Steps
 
 1. Replace direct `lint-staged` script invocations with `rs staged`.
-2. Move a plain task map into `define.staged` in `rstack.config.*`.
+2. Move the lint-staged config into `define.staged` in `rstack.config.*`.
 3. Remove the old manifest key or config file.
 4. Remove the direct `lint-staged` dependency only when no script, config, or programmatic API still uses it.
 

--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -4,10 +4,7 @@ import type { RslibConfigDefinition } from '@rslib/core';
 import type { RslintConfig } from '@rslint/core';
 import type { UserConfig, UserConfigAsyncFn } from '@rspress/core';
 import type { RstestConfigExport } from '@rstest/core';
-
-export type StagedTask = string | string[];
-
-export type StagedConfig = Record<string, StagedTask>;
+import type { StagedConfig } from './staged.js';
 
 export type RslintConfigDefinition = RslintConfig | (() => Promise<RslintConfig>);
 export type RspressConfigDefinition = UserConfig | UserConfigAsyncFn;

--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -2,6 +2,27 @@ import { parseArgs } from 'node:util';
 import { color } from 'rslog';
 import { loadRstackConfig } from './config.js';
 
+export type StagedSyncTaskGenerator = (stagedFileNames: readonly string[]) => string | string[];
+
+export type StagedAsyncTaskGenerator = (
+  stagedFileNames: readonly string[],
+) => Promise<string | string[]>;
+
+export type StagedTaskGenerator = StagedSyncTaskGenerator | StagedAsyncTaskGenerator;
+
+export type StagedFunctionTask = {
+  title: string;
+  task: (stagedFileNames: readonly string[]) => void | Promise<void>;
+};
+
+export type StagedTask =
+  | string
+  | StagedFunctionTask
+  | StagedTaskGenerator
+  | (string | StagedTaskGenerator)[];
+
+export type StagedConfig = Record<string, StagedTask> | StagedTaskGenerator;
+
 const stagedHelpMessage = `Rstack v${RSTACK_VERSION}
 
 ${color.cyan('Usage')}:


### PR DESCRIPTION
lint-staged accepts function-based configurations, but `define.staged` previously only typed plain task maps. This PR aligns the staged config types with lint-staged 16.4, including sync and async generators and function tasks, so these configurations can migrate to Rstack. It also updates the migration guidance to cover general lint-staged configs.