### PR TITLE
docs: update lint-staged migration guidance

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/references/lint-staged.mdx
+++ b/.agents/skills/migrate-to-rstack-cli/references/lint-staged.mdx
@@ -20,6 +20,8 @@ define.staged({
 });
 ```
 
-## Unsupported Cases
+Function configs are supported.
 
-Do not carry lint-staged CLI flags to `rs staged`; they are not forwarded. Keep standalone lint-staged when the workflow requires function-based configs, CLI options, or behavior outside a plain task map.
+## CLI Options
+
+Run `rs staged -h` for supported options.


### PR DESCRIPTION
This PR updates the lint-staged migration reference to reflect function config and CLI option support in `rs staged`. It points users to `rs staged -h` for the current supported option list.