### PR TITLE
fix: reset config state after loading

### DIFF
--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -103,23 +103,26 @@ export const define: Define = {
 
 export const loadRstackConfig = async (): Promise<Configs> => {
   const state = getConfigState();
-
-  await loadConfig({
-    loader: 'native',
-    exportName: false,
-    ...(state.configPath !== undefined
-      ? { path: state.configPath }
-      : {
-          configFileNames: [
-            'rstack.config.ts',
-            'rstack.config.js',
-            'rstack.config.mts',
-            'rstack.config.mjs',
-          ],
-        }),
-  });
-
-  const result = state.configs;
   state.configs = {};
-  return result;
+
+  try {
+    await loadConfig({
+      loader: 'native',
+      exportName: false,
+      ...(state.configPath !== undefined
+        ? { path: state.configPath }
+        : {
+            configFileNames: [
+              'rstack.config.ts',
+              'rstack.config.js',
+              'rstack.config.mts',
+              'rstack.config.mjs',
+            ],
+          }),
+    });
+
+    return state.configs;
+  } finally {
+    state.configs = {};
+  }
 };

--- a/packages/rstack/test/config/load-state/index.test.ts
+++ b/packages/rstack/test/config/load-state/index.test.ts
@@ -1,0 +1,17 @@
+import path from 'node:path';
+import { expect, test } from 'rstack/test';
+import { getConfigState, loadRstackConfig } from '../../../src/config.ts';
+
+test('should reset config state before and after loading', async () => {
+  const state = getConfigState();
+  state.configs = { app: {} };
+  state.configPath = path.join(import.meta.dirname, 'rstack.config.ts');
+
+  try {
+    await expect(loadRstackConfig()).rejects.toThrow('test config error');
+    expect(state.configs).toEqual({});
+  } finally {
+    state.configs = {};
+    delete state.configPath;
+  }
+});

--- a/packages/rstack/test/config/load-state/rstack.config.ts
+++ b/packages/rstack/test/config/load-state/rstack.config.ts
@@ -1,0 +1,4 @@
+import { define } from 'rstack';
+
+define.app({});
+throw new Error('test config error');


### PR DESCRIPTION
This PR prevents stale Rstack configuration from leaking across config loads. It clears the shared config state before loading and uses `finally` to clean it after both successful and failed loads, with regression coverage for a config that registers `define.app` before throwing.