### PR TITLE
fix: reload Rstack config without module cache

### DIFF
--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -109,6 +109,7 @@ export const loadRstackConfig = async (): Promise<Configs> => {
     await loadConfig({
       loader: 'native',
       exportName: false,
+      fresh: true,
       ...(state.configPath !== undefined
         ? { path: state.configPath }
         : {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ catalogs:
       specifier: ^2.0.17
       version: 2.0.17
     '@rstackjs/load-config':
-      specifier: ^0.1.1
-      version: 0.1.1
+      specifier: ^0.1.2
+      version: 0.1.2
     '@rstest/adapter-rsbuild':
       specifier: ~0.11.0
       version: 0.11.0
@@ -86,7 +86,7 @@ importers:
     devDependencies:
       '@rstackjs/load-config':
         specifier: 'catalog:'
-        version: 0.1.1
+        version: 0.1.2
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -770,8 +770,8 @@ packages:
   '@rspress/shared@2.0.17':
     resolution: {integrity: sha512-ZzpZ4hm5svgwU0w5CpTLZy4vFD3uPo8+gXtWMOREYMzwfzJeHqwOyXwxHf6byGpx85mVK5DQqMDi61meAS7ZUw==}
 
-  '@rstackjs/load-config@0.1.1':
-    resolution: {integrity: sha512-YYtqGoM5DrrmZLGaYSUAC66qhhfjAfwXVvBScGJIfPXGa878rK0SJeO6b44W2pYfikm8yefzyV0OeedWO/PKkw==}
+  '@rstackjs/load-config@0.1.2':
+    resolution: {integrity: sha512-6hChPVosmh2rzEt1M1CvGpsaE/+gGlt51ci5pbyd4Bd1FXyH+Owlg99ECvdcWtD7zdDwDM3jGkQL05xn9oWSIA==}
     peerDependencies:
       jiti: ^2.0.0
     peerDependenciesMeta:
@@ -2242,7 +2242,7 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rstackjs/load-config@0.1.1': {}
+  '@rstackjs/load-config@0.1.2': {}
 
   '@rstest/adapter-rsbuild@0.11.0(@rsbuild/core@2.1.4)(@rstest/core@0.11.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ catalog:
   '@rslib/core': '~0.23.2'
   '@rslint/core': '~0.6.5'
   '@rspress/core': '^2.0.17'
-  '@rstackjs/load-config': ^0.1.1
+  '@rstackjs/load-config': ^0.1.2
   '@rstest/adapter-rsbuild': '~0.11.0'
   '@rstest/adapter-rslib': '~0.11.0'
   '@rstest/core': '~0.11.0'


### PR DESCRIPTION
This PR ensures repeated Rstack config loads re-evaluate the config instead of returning empty state from the ESM module cache. It enables fresh native loading and updates `@rstackjs/load-config` to v0.1.2 so config evaluation errors propagate without retrying.

## Related Links

- https://github.com/rstackjs/load-config/releases/tag/v0.1.2