### PR TITLE
feat: restart dev server on config changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Dist
 node_modules
 dist/
+dist-*/
 test-results
 doc_build
 

--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -1,4 +1,4 @@
-import { loadConfig } from '@rstackjs/load-config';
+import { loadConfig, type LoadConfigResult } from '@rstackjs/load-config';
 import type { RsbuildConfigDefinition } from '@rsbuild/core';
 import type { RslibConfigDefinition } from '@rslib/core';
 import type { RslintConfig } from '@rslint/core';
@@ -16,6 +16,10 @@ export type Configs = {
   test?: RstestConfigExport;
   lint?: RslintConfigDefinition;
   staged?: StagedConfig;
+};
+
+type LoadedRstackConfig = Pick<LoadConfigResult, 'filePath' | 'dependencies'> & {
+  configs: Configs;
 };
 
 type ConfigState = {
@@ -101,12 +105,12 @@ export const define: Define = {
   staged: (config) => setConfig('staged', config),
 };
 
-export const loadRstackConfig = async (): Promise<Configs> => {
+export const loadRstackConfigWithMeta = async (): Promise<LoadedRstackConfig> => {
   const state = getConfigState();
   state.configs = {};
 
   try {
-    await loadConfig({
+    const { filePath, dependencies } = await loadConfig({
       loader: 'native',
       exportName: false,
       fresh: true,
@@ -122,8 +126,17 @@ export const loadRstackConfig = async (): Promise<Configs> => {
           }),
     });
 
-    return state.configs;
+    return {
+      configs: state.configs,
+      filePath,
+      dependencies,
+    };
   } finally {
     state.configs = {};
   }
+};
+
+export const loadRstackConfig = async (): Promise<Configs> => {
+  const { configs } = await loadRstackConfigWithMeta();
+  return configs;
 };

--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -105,7 +105,7 @@ export const define: Define = {
   staged: (config) => setConfig('staged', config),
 };
 
-export const loadRstackConfigWithMeta = async (): Promise<LoadedRstackConfig> => {
+export const loadRstackConfig = async (): Promise<LoadedRstackConfig> => {
   const state = getConfigState();
   state.configs = {};
 
@@ -134,9 +134,4 @@ export const loadRstackConfigWithMeta = async (): Promise<LoadedRstackConfig> =>
   } finally {
     state.configs = {};
   }
-};
-
-export const loadRstackConfig = async (): Promise<Configs> => {
-  const { configs } = await loadRstackConfigWithMeta();
-  return configs;
 };

--- a/packages/rstack/src/rsbuildConfig.ts
+++ b/packages/rstack/src/rsbuildConfig.ts
@@ -1,5 +1,5 @@
-import type { RsbuildConfigDefinition, ConfigParams } from '@rsbuild/core';
-import { loadRstackConfig, type Configs } from './config.js';
+import { mergeRsbuildConfig, type RsbuildConfigDefinition, type ConfigParams } from '@rsbuild/core';
+import { loadRstackConfigWithMeta, type Configs } from './config.js';
 
 const resolveRsbuildConfig = async (configs: Configs, params: ConfigParams) => {
   const appConfig = configs.app;
@@ -13,8 +13,21 @@ const resolveRsbuildConfig = async (configs: Configs, params: ConfigParams) => {
 };
 
 const loadRsbuildConfig: RsbuildConfigDefinition = async (params) => {
-  const configs = await loadRstackConfig();
-  return resolveRsbuildConfig(configs, params);
+  const { configs, filePath, dependencies } = await loadRstackConfigWithMeta();
+  const config = await resolveRsbuildConfig(configs, params);
+
+  if (!filePath) {
+    return config;
+  }
+
+  return mergeRsbuildConfig(config, {
+    dev: {
+      watchFiles: {
+        paths: [filePath, ...dependencies],
+        type: 'reload-server',
+      },
+    },
+  });
 };
 
 export default loadRsbuildConfig;

--- a/packages/rstack/src/rsbuildConfig.ts
+++ b/packages/rstack/src/rsbuildConfig.ts
@@ -1,5 +1,5 @@
 import { mergeRsbuildConfig, type RsbuildConfigDefinition, type ConfigParams } from '@rsbuild/core';
-import { loadRstackConfigWithMeta, type Configs } from './config.js';
+import { loadRstackConfig, type Configs } from './config.js';
 
 const resolveRsbuildConfig = async (configs: Configs, params: ConfigParams) => {
   const appConfig = configs.app;
@@ -13,7 +13,7 @@ const resolveRsbuildConfig = async (configs: Configs, params: ConfigParams) => {
 };
 
 const loadRsbuildConfig: RsbuildConfigDefinition = async (params) => {
-  const { configs, filePath, dependencies } = await loadRstackConfigWithMeta();
+  const { configs, filePath, dependencies } = await loadRstackConfig();
   const config = await resolveRsbuildConfig(configs, params);
 
   if (!filePath) {

--- a/packages/rstack/src/rslibConfig.ts
+++ b/packages/rstack/src/rslibConfig.ts
@@ -14,7 +14,7 @@ const resolveRslibConfig = async (configs: Configs, params: ConfigParams): Promi
 };
 
 const loadRslibConfig = (async (params: ConfigParams) => {
-  const configs = await loadRstackConfig();
+  const { configs } = await loadRstackConfig();
   return resolveRslibConfig(configs, params);
 }) as RslibConfigDefinition;
 

--- a/packages/rstack/src/rslintConfig.ts
+++ b/packages/rstack/src/rslintConfig.ts
@@ -1,7 +1,7 @@
 import { loadRstackConfig } from './config.js';
 import type { RslintConfig } from '@rslint/core';
 
-const configs = await loadRstackConfig();
+const { configs } = await loadRstackConfig();
 const lintExports = configs.lint ?? [];
 
 let lintConfig: RslintConfig;

--- a/packages/rstack/src/rspressConfig.ts
+++ b/packages/rstack/src/rspressConfig.ts
@@ -13,6 +13,6 @@ const resolveRspressConfig = async (configs: Configs): Promise<UserConfig> => {
 };
 
 export default async (): Promise<UserConfig> => {
-  const configs = await loadRstackConfig();
+  const { configs } = await loadRstackConfig();
   return resolveRspressConfig(configs);
 };

--- a/packages/rstack/src/rstestConfig.ts
+++ b/packages/rstack/src/rstestConfig.ts
@@ -56,7 +56,7 @@ const resolveRstestConfig = async (configs: Configs) => {
 };
 
 const loadRstestConfig = (async (params: ConfigParams) => {
-  const configs = await loadRstackConfig();
+  const { configs } = await loadRstackConfig();
   const testConfig = await resolveRstestConfig(configs);
   return extendsConfig(configs, testConfig, params);
 }) as RstestConfigExport;

--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -65,7 +65,7 @@ export async function runStagedCLI(args: string[]): Promise<void> {
     return;
   }
 
-  const configs = await loadRstackConfig();
+  const { configs } = await loadRstackConfig();
   const stagedConfig = configs.staged;
   if (!stagedConfig) {
     throw new Error(

--- a/packages/rstack/test/config/reload-app-config/.gitignore
+++ b/packages/rstack/test/config/reload-app-config/.gitignore
@@ -1,2 +1,0 @@
-rstack.config.ts
-dist-2/

--- a/packages/rstack/test/config/reload-app-config/.gitignore
+++ b/packages/rstack/test/config/reload-app-config/.gitignore
@@ -1,0 +1,2 @@
+rstack.config.ts
+dist-2/

--- a/packages/rstack/test/config/reload-app-config/index.test.ts
+++ b/packages/rstack/test/config/reload-app-config/index.test.ts
@@ -1,0 +1,50 @@
+import { rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { expectFile, getRandomPort, test } from '#test-helpers';
+
+test('should restart dev server and reload config when Rstack config changes', async ({
+  execCliAsync,
+}) => {
+  const dist1 = path.join(import.meta.dirname, 'dist');
+  const dist2 = path.join(import.meta.dirname, 'dist-2');
+  const configFile = path.join(import.meta.dirname, 'rstack.config.ts');
+
+  await rm(dist1, { recursive: true, force: true });
+  await rm(dist2, { recursive: true, force: true });
+  await rm(configFile, { force: true });
+
+  await writeFile(
+    configFile,
+    `import { define } from 'rstack';
+
+define.app({
+  dev: {
+    writeToDisk: true,
+  },
+  server: { port: ${await getRandomPort()} },
+});
+`,
+  );
+
+  execCliAsync('dev');
+
+  await expectFile(dist1);
+
+  await writeFile(
+    configFile,
+    `import { define } from 'rstack';
+
+define.app({
+  dev: {
+    writeToDisk: true,
+  },
+  output: {
+    distPath: 'dist-2',
+  },
+  server: { port: ${await getRandomPort()} },
+});
+`,
+  );
+
+  await expectFile(dist2);
+}, 30_000);

--- a/packages/rstack/test/config/reload-app-config/index.test.ts
+++ b/packages/rstack/test/config/reload-app-config/index.test.ts
@@ -7,7 +7,7 @@ test('should restart dev server and reload config when Rstack config changes', a
 }) => {
   const dist1 = path.join(import.meta.dirname, 'dist');
   const dist2 = path.join(import.meta.dirname, 'dist-2');
-  const configFile = path.join(import.meta.dirname, 'rstack.config.ts');
+  const configFile = path.join(import.meta.dirname, 'test-temp-rstack.config.ts');
 
   await rm(dist1, { recursive: true, force: true });
   await rm(dist2, { recursive: true, force: true });
@@ -26,7 +26,7 @@ define.app({
 `,
   );
 
-  execCliAsync('dev');
+  execCliAsync('dev --config test-temp-rstack.config.ts');
 
   await expectFile(dist1);
 

--- a/packages/rstack/test/config/reload-app-config/src/index.js
+++ b/packages/rstack/test/config/reload-app-config/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello!');


### PR DESCRIPTION
`rs dev` previously watched only Rstack's internal Rsbuild bridge, so changes to the actual Rstack config did not restart the server. This PR exposes the loaded config path and relative dependencies, then merges them into Rsbuild's `reload-server` watch list while preserving user-defined watchers. The integration test follows Rsbuild's reload-config pattern and reuses shared CLI, port, and file polling helpers.