### PR TITLE
feat: export Rslib APIs from rstack/lib

### DIFF
--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -75,6 +75,7 @@ Prefer Rstack-exported paths:
 
 | Instead of                | Prefer                   |
 | ------------------------- | ------------------------ |
+| `@rslib/core`             | `rstack/lib`             |
 | `@rstest/core`            | `rstack/test`            |
 | `@rslint/core`            | `rstack/lint`            |
 | `@rsbuild/core/types`     | `rstack/types`           |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ pnpm lib
 pnpm doc
 ```
 
+## API imports
+
+Rstack re-exports the APIs of its underlying tools through dedicated entry points:
+
+| Tool   | Import path   |
+| ------ | ------------- |
+| Rslib  | `rstack/lib`  |
+| Rslint | `rstack/lint` |
+| Rstest | `rstack/test` |
+
+For example, import Rstest APIs without adding `@rstest/core` as a direct dependency:
+
+```ts
+import { expect, test } from 'rstack/test';
+```
+
 ## Credits
 
 Rstack CLI is inspired by:

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -23,6 +23,10 @@
       "types": "./dist/test.d.ts",
       "default": "./dist/test.js"
     },
+    "./lib": {
+      "types": "./dist/lib.d.ts",
+      "default": "./dist/lib.js"
+    },
     "./lint": {
       "types": "./dist/lint.d.ts",
       "default": "./dist/lint.js"

--- a/packages/rstack/rslib.config.ts
+++ b/packages/rstack/rslib.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       rslintConfig: './src/rslintConfig.ts',
       rspressConfig: './src/rspressConfig.ts',
       rstestConfig: './src/rstestConfig.ts',
+      lib: './src/lib.ts',
       lint: './src/lint.ts',
       test: './src/test.ts',
     },

--- a/packages/rstack/src/lib.ts
+++ b/packages/rstack/src/lib.ts
@@ -1,0 +1,9 @@
+/**
+ * Re-export @rslib/core APIs so users can import library APIs from `rstack/lib`.
+ *
+ * @example
+ * ```ts
+ * import { defineConfig } from 'rstack/lib';
+ * ```
+ */
+export * from '@rslib/core';

--- a/packages/rstack/test/exports/lib-subpath/index.test.ts
+++ b/packages/rstack/test/exports/lib-subpath/index.test.ts
@@ -1,0 +1,8 @@
+import * as rslib from '@rslib/core';
+import { expect, test } from 'rstack/test';
+
+test('should expose all Rslib APIs from `rstack/lib`', async () => {
+  const lib = await import('rstack/lib');
+
+  expect(lib).toEqual(rslib);
+});

--- a/packages/rstack/test/tsconfig.json
+++ b/packages/rstack/test/tsconfig.json
@@ -7,6 +7,7 @@
     "types": ["node"],
     "paths": {
       "rstack": ["../src/index.ts"],
+      "rstack/lib": ["../src/lib.ts"],
       "rstack/lint": ["../src/lint.ts"],
       "rstack/test": ["../src/test.ts"],
       "#test-helpers": ["./helpers/index.ts"]


### PR DESCRIPTION
This PR adds a `rstack/lib` entry point so Rstack CLI users can access Rslib APIs without declaring `@rslib/core` as a direct dependency.
