### PR TITLE
feat: export Rsbuild APIs from rstack/app

### DIFF
--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -75,6 +75,7 @@ Prefer Rstack-exported paths:
 
 | Instead of                | Prefer                   |
 | ------------------------- | ------------------------ |
+| `@rsbuild/core`           | `rstack/app`             |
 | `@rslib/core`             | `rstack/lib`             |
 | `@rstest/core`            | `rstack/test`            |
 | `@rslint/core`            | `rstack/lint`            |

--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ pnpm doc
 
 Rstack re-exports the APIs of its underlying tools through dedicated entry points:
 
-| Tool   | Import path   |
-| ------ | ------------- |
-| Rslib  | `rstack/lib`  |
-| Rslint | `rstack/lint` |
-| Rstest | `rstack/test` |
+| Tool    | Import path   |
+| ------- | ------------- |
+| Rsbuild | `rstack/app`  |
+| Rslib   | `rstack/lib`  |
+| Rslint  | `rstack/lint` |
+| Rstest  | `rstack/test` |
 
 For example, import Rstest APIs without adding `@rstest/core` as a direct dependency:
 

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./app": {
+      "types": "./dist/app.d.ts",
+      "default": "./dist/app.js"
+    },
     "./test": {
       "types": "./dist/test.d.ts",
       "default": "./dist/test.js"

--- a/packages/rstack/rslib.config.ts
+++ b/packages/rstack/rslib.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       rslintConfig: './src/rslintConfig.ts',
       rspressConfig: './src/rspressConfig.ts',
       rstestConfig: './src/rstestConfig.ts',
+      app: './src/app.ts',
       lib: './src/lib.ts',
       lint: './src/lint.ts',
       test: './src/test.ts',

--- a/packages/rstack/src/app.ts
+++ b/packages/rstack/src/app.ts
@@ -1,0 +1,9 @@
+/**
+ * Re-export @rsbuild/core APIs so users can import application APIs from `rstack/app`.
+ *
+ * @example
+ * ```ts
+ * import { createRsbuild } from 'rstack/app';
+ * ```
+ */
+export * from '@rsbuild/core';

--- a/packages/rstack/test/exports/app-subpath/index.test.ts
+++ b/packages/rstack/test/exports/app-subpath/index.test.ts
@@ -1,0 +1,8 @@
+import * as rsbuild from '@rsbuild/core';
+import { expect, test } from 'rstack/test';
+
+test('should expose all Rsbuild APIs from `rstack/app`', async () => {
+  const app = await import('rstack/app');
+
+  expect(app).toEqual(rsbuild);
+});

--- a/packages/rstack/test/tsconfig.json
+++ b/packages/rstack/test/tsconfig.json
@@ -7,6 +7,7 @@
     "types": ["node"],
     "paths": {
       "rstack": ["../src/index.ts"],
+      "rstack/app": ["../src/app.ts"],
       "rstack/lib": ["../src/lib.ts"],
       "rstack/lint": ["../src/lint.ts"],
       "rstack/test": ["../src/test.ts"],


### PR DESCRIPTION
This PR adds a `rstack/app` entry point so Rstack CLI users can access Rsbuild APIs without declaring `@rsbuild/core` as a direct dependency.