### PR TITLE
docs(skills): clarify migration guidance

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/references/rslib.mdx
+++ b/.agents/skills/migrate-to-rstack-cli/references/rslib.mdx
@@ -5,7 +5,7 @@ Read this reference when the project uses `@rslib/core`, `rslib.config.*`, `rsli
 ## Steps
 
 1. Replace the `rslib` executable prefix with `rs lib`. Preserve supported arguments after `rs lib`.
-2. Move the old config export into `define.lib`. Preserve async functions, config parameters, plugins, and all options.
+2. Rename or replace the `rslib.config.*` with `rstack.config.*`, then move its export into `define.lib`. Preserve async functions, config parameters, plugins, and all options.
 3. Keep build plugins, but verify that Rsbuild plugin peer ranges support the core version installed through `rstack`. Upgrade incompatible plugins before migrating.
 4. Replace `@rslib/core/types` references with `rstack/types` where applicable.
 5. Replace custom `--config` paths with the migrated `rstack.config.*` path.
@@ -26,4 +26,4 @@ If tests also use Rstest, read [rstest.mdx](rstest.mdx). `rs test` derives an Rs
 
 ## Validate
 
-Run the migrated library build script and compare its outputs.
+Run every migrated library build from its directory and compare its outputs.

--- a/.agents/skills/migrate-to-rstack-cli/references/rspress.mdx
+++ b/.agents/skills/migrate-to-rstack-cli/references/rspress.mdx
@@ -6,7 +6,7 @@ Read this reference when the project uses `@rspress/core`, `rspress.config.*`, `
 
 1. Keep `@rspress/core` installed as a direct dependency. `rs doc` requires this optional Rstack peer dependency.
 2. Replace the `rspress` executable prefix with `rs doc`: `rspress dev` to `rs doc`, `rspress build` to `rs doc build`, and `rspress preview` to `rs doc preview`. Preserve supported arguments.
-3. Move the old config export into `define.doc`. Preserve async functions, themes, plugins, and all options.
+3. Rename or replace the `rspress.config.*` with `rstack.config.*`, then move its export into `define.doc`. Preserve async functions, themes, plugins, and all options.
 4. Replace custom `--config` paths with the migrated `rstack.config.*` path.
 5. Keep Rspress-specific type imports from `@rspress/core`; Rstack does not re-export them.
 6. Keep themes, plugins, and docs UI packages. Delete `rspress.config.*` only after the migrated docs commands load equivalent config.

--- a/.agents/skills/migrate-to-rstack-cli/references/rstest.mdx
+++ b/.agents/skills/migrate-to-rstack-cli/references/rstest.mdx
@@ -6,7 +6,7 @@ Read this reference when the project uses `@rstest/core`, `@rstest/adapter-rsbui
 
 1. Replace the `rstest` executable prefix with `rs test`. Preserve supported arguments, such as `-w`, after `rs test`.
 2. Move test options into `define.test`.
-3. When `define.app` or `define.lib` exists, remove standard `withRsbuildConfig()` or `withRslibConfig()` wiring and its adapter dependency. Rstack derives that extension unless `define.test` sets `extends`.
+3. Remove standard `withRsbuildConfig()` or `withRslibConfig()` wiring only when `define.app` or `define.lib` is registered by the same `rstack.config.*` loaded by `rs test`. Rstack derives that extension unless `define.test` sets `extends`.
 4. Preserve explicit custom `extends` values. Keep any adapter or package still imported by that custom extension.
 5. Replace imports and TypeScript `types` entries:
    - `@rstest/core` to `rstack/test`
@@ -28,4 +28,4 @@ define.test({
 
 ## Validate
 
-Run the migrated test script.
+Run the migrated test script. Follow repository requirements such as building before tests.


### PR DESCRIPTION
## Summary

Clarifies the Rslib, Rspress, and Rstest migration instructions so configuration files and derived test extensions are handled correctly.

Updates validation guidance to account for per-directory library builds and repository-specific pre-test requirements.