### PR TITLE
docs(skills): clarify define config migration

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/SKILL.md
+++ b/.agents/skills/migrate-to-rstack-cli/SKILL.md
@@ -16,7 +16,7 @@ Read every matching reference before editing. Load only the tools present in the
 - `@rstest/core`, `@rstest/adapter-*`, `rstest.config.*`, `rstest` commands, or test imports: [rstest.mdx](references/rstest.mdx)
 - `@rslint/core`, `rslint.config.*`, `rslint` commands, or lint imports: [rslint.mdx](references/rslint.mdx)
 - `@rspress/core`, `rspress.config.*`, `rspress` commands, themes, or plugins: [rspress.mdx](references/rspress.mdx)
-- `lint-staged`, its dotfile configs, `lint-staged.config.*`, or a `lint-staged` manifest key: [lint-staged.mdx](references/lint-staged.mdx)
+- `lint-staged`, `nano-staged`, their configs: [lint-staged.mdx](references/lint-staged.mdx)
 
 ## Workflow
 
@@ -34,7 +34,9 @@ Underlying Rsbuild, Rslib, Rstest, and Rslint packages remain transitive depende
 
 ## Configuration Rules
 
-Use one of the default names: `rstack.config.ts`, `.js`, `.mts`, or `.mjs`. Use `rs -c <path>` or `rs --config <path>` for a custom path.
+Use one of the default names: `rstack.config.ts`, `.js`, `.mts`, or `.mjs`.
+
+Use `rs -c <path>` or `rs --config <path>` only for a custom path.
 
 ```ts
 import { define } from 'rstack';
@@ -56,3 +58,5 @@ define.lint(async () => {
   return [js.configs.recommended, ts.configs.recommended];
 });
 ```
+
+Rstack loads TypeScript configs as native ESM. Preserve runtime-resolvable file extensions, replace CommonJS globals such as `__dirname`.

--- a/.agents/skills/migrate-to-rstack-cli/references/rsbuild.mdx
+++ b/.agents/skills/migrate-to-rstack-cli/references/rsbuild.mdx
@@ -5,7 +5,7 @@ Read this reference when the project uses `@rsbuild/core`, `rsbuild.config.*`, `
 ## Steps
 
 1. Replace `rsbuild dev`, `rsbuild build`, and `rsbuild preview` with `rs dev`, `rs build`, and `rs preview`. Preserve supported arguments after the new command.
-2. Move the old config export into `define.app`. Preserve async functions, config parameters, plugins, and all options.
+2. Move the old config export into `define.app`, replacing Rsbuild's `defineConfig()` wrapper and import. Preserve async functions, config parameters, plugins, and all options.
 3. Replace custom `--config` paths with the migrated `rstack.config.*` path.
 4. Replace Rsbuild client and type references:
    - `/// <reference types="@rsbuild/core/types" />` to `/// <reference types="rstack/types" />`

--- a/.agents/skills/migrate-to-rstack-cli/references/rslib.mdx
+++ b/.agents/skills/migrate-to-rstack-cli/references/rslib.mdx
@@ -5,7 +5,7 @@ Read this reference when the project uses `@rslib/core`, `rslib.config.*`, `rsli
 ## Steps
 
 1. Replace the `rslib` executable prefix with `rs lib`. Preserve supported arguments after `rs lib`.
-2. Rename or replace the `rslib.config.*` with `rstack.config.*`, then move its export into `define.lib`. Preserve async functions, config parameters, plugins, and all options.
+2. Rename or replace the `rslib.config.*` with `rstack.config.*`, then move its export into `define.lib`, replacing Rslib's `defineConfig()` wrapper and import. Preserve async functions, config parameters, plugins, and all options.
 3. Keep build plugins, but verify that Rsbuild plugin peer ranges support the core version installed through `rstack`. Upgrade incompatible plugins before migrating.
 4. Replace `@rslib/core/types` references with `rstack/types` where applicable.
 5. Replace custom `--config` paths with the migrated `rstack.config.*` path.

--- a/.agents/skills/migrate-to-rstack-cli/references/rslint.mdx
+++ b/.agents/skills/migrate-to-rstack-cli/references/rslint.mdx
@@ -5,7 +5,7 @@ Read this reference when the project uses `@rslint/core`, `rslint.config.*`, `rs
 ## Steps
 
 1. Replace the `rslint` executable prefix with `rs lint`. For example, replace `rslint --fix` with `rs lint --fix`.
-2. Move the old config into `define.lint`. Dynamically import presets from `rstack/lint` inside an async config function.
+2. Move the old config into `define.lint`, replacing Rslint's `defineConfig()` wrapper and import. Dynamically import presets from `rstack/lint` inside an async config function.
 3. Replace direct config/API imports from `@rslint/core` with exports from `rstack/lint` where available.
 4. Replace custom `--config` paths with the migrated `rstack.config.*` path.
 5. Remove `@rslint/core` only when no uncovered direct runtime API remains. Delete `rslint.config.*`.

--- a/.agents/skills/migrate-to-rstack-cli/references/rspress.mdx
+++ b/.agents/skills/migrate-to-rstack-cli/references/rspress.mdx
@@ -6,7 +6,7 @@ Read this reference when the project uses `@rspress/core`, `rspress.config.*`, `
 
 1. Keep `@rspress/core` installed as a direct dependency. `rs doc` requires this optional Rstack peer dependency.
 2. Replace the `rspress` executable prefix with `rs doc`: `rspress dev` to `rs doc`, `rspress build` to `rs doc build`, and `rspress preview` to `rs doc preview`. Preserve supported arguments.
-3. Rename or replace the `rspress.config.*` with `rstack.config.*`, then move its export into `define.doc`. Preserve async functions, themes, plugins, and all options.
+3. Rename or replace the `rspress.config.*` with `rstack.config.*`, then move its export into `define.doc`, replacing Rspress's `defineConfig()` wrapper and import. Preserve async functions, themes, plugins, and all options.
 4. Replace custom `--config` paths with the migrated `rstack.config.*` path.
 5. Keep Rspress-specific type imports from `@rspress/core`; Rstack does not re-export them.
 6. Keep themes, plugins, and docs UI packages. Delete `rspress.config.*` only after the migrated docs commands load equivalent config.

--- a/.agents/skills/migrate-to-rstack-cli/references/rstest.mdx
+++ b/.agents/skills/migrate-to-rstack-cli/references/rstest.mdx
@@ -5,7 +5,7 @@ Read this reference when the project uses `@rstest/core`, `@rstest/adapter-rsbui
 ## Steps
 
 1. Replace the `rstest` executable prefix with `rs test`. Preserve supported arguments, such as `-w`, after `rs test`.
-2. Move test options into `define.test`.
+2. Move test options into `define.test`, replacing Rstest's `defineConfig()` wrapper and import.
 3. Remove standard `withRsbuildConfig()` or `withRslibConfig()` wiring only when `define.app` or `define.lib` is registered by the same `rstack.config.*` loaded by `rs test`. Rstack derives that extension unless `define.test` sets `extends`.
 4. Preserve explicit custom `extends` values. Keep any adapter or package still imported by that custom extension.
 5. Replace imports and TypeScript `types` entries:


### PR DESCRIPTION
This PR clarifies the migration skill so standalone `defineConfig()` wrappers are replaced by the corresponding `define.*` registrations. It also refines staged-file detection, custom config path, and native ESM guidance.