### PR TITLE
test: reload config when imported file changes

### DIFF
--- a/packages/rstack/test/config/reload-app-config/index.test.ts
+++ b/packages/rstack/test/config/reload-app-config/index.test.ts
@@ -48,3 +48,28 @@ define.app({
 
   await expectFile(dist2);
 }, 30_000);
+
+test('should reload config when an imported file changes', async ({ execCliAsync, logHelper }) => {
+  const configFile = path.join(import.meta.dirname, 'test-temp-import.config.ts');
+  const importedFile = path.join(import.meta.dirname, 'test-temp-imported.ts');
+
+  await writeFile(importedFile, '');
+  await writeFile(
+    configFile,
+    `import { define } from 'rstack';
+import './test-temp-imported.ts';
+
+define.app({
+  server: { port: ${await getRandomPort()} },
+});
+`,
+  );
+
+  execCliAsync('dev --config test-temp-import.config.ts');
+  await logHelper.expectBuildEnd();
+  logHelper.clearLogs();
+
+  await writeFile(importedFile, '// changed\n');
+
+  await logHelper.expectLog('restarting server as test-temp-imported.ts changed');
+}, 30_000);


### PR DESCRIPTION
## Summary

This PR adds a minimal integration test for config dependency watching. It changes a file imported by the Rstack config and verifies that the development server reloads.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/27