### PR TITLE
docs(skills): add migration skill section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Welcome to try it out and share feedback through issues and discussions!
 
 ## Skills
 
-Rstack CLI is still new and does not have complete documentation yet.
-
 ### Best practice
+
+Rstack CLI is still new and does not have complete documentation yet.
 
 Installing the Rstack CLI skill so the agent can understand how to use it:
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,20 @@ Welcome to try it out and share feedback through issues and discussions!
 
 Rstack CLI is still new and does not have complete documentation yet.
 
+### Best practice
+
 Installing the Rstack CLI skill so the agent can understand how to use it:
 
 ```bash
 npx skills add rstackjs/rstack-cli --skill rstack-cli-best-practices
+```
+
+### Migration
+
+Installing the migration skill so the agent can migrate existing projects to Rstack CLI:
+
+```bash
+npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

Rstack CLI provides separate best-practice and migration skills, but the README currently documents only the best-practice skill. This PR splits the Skills section into Best practice and Migration subsections and adds the migration skill installation command.