### PR TITLE
chore(deps): upgrade Rslib to v1.0.0-beta.0

### DIFF
--- a/packages/rstack/src/rslibConfig.ts
+++ b/packages/rstack/src/rslibConfig.ts
@@ -4,8 +4,7 @@ import { loadRstackConfig, type Configs } from './config.js';
 const resolveRslibConfig = async (configs: Configs, params: ConfigParams): Promise<RslibConfig> => {
   const libConfig = configs.lib;
   if (!libConfig) {
-    // TODO: should allow empty object to be returned
-    return { lib: [{}] };
+    return {};
   }
   if (typeof libConfig === 'function') {
     return libConfig(params);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ catalogs:
       specifier: ^2.1.0
       version: 2.1.0
     '@rslib/core':
-      specifier: ~0.23.2
-      version: 0.23.2
+      specifier: ~1.0.0-beta.0
+      version: 1.0.0-beta.0
     '@rslint/core':
       specifier: ~0.6.5
       version: 0.6.5
@@ -247,7 +247,7 @@ importers:
         version: 2.1.6
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.23.2(typescript@7.0.2)
+        version: 1.0.0-beta.0(typescript@7.0.2)
       '@rslint/core':
         specifier: 'catalog:'
         version: 0.6.5
@@ -266,7 +266,7 @@ importers:
         version: 0.11.1(@rsbuild/core@2.1.6)(@rstest/core@0.11.1)
       '@rstest/adapter-rslib':
         specifier: 'catalog:'
-        version: 0.11.1(@rslib/core@0.23.2)(@rstest/core@0.11.1)(typescript@7.0.2)
+        version: 0.11.1(@rslib/core@1.0.0-beta.0)(@rstest/core@0.11.1)(typescript@7.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -539,13 +539,13 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rslib/core@0.23.2':
-    resolution: {integrity: sha512-KxSp+/y0BJ1O4oKwxX4ydBY7/ZVeJCUpWAmQniCIct8mTxIQFPGO/ibKbKq2IxZYqRuRpM8g+Dtyq0VbEQf9HQ==}
+  '@rslib/core@1.0.0-beta.0':
+    resolution: {integrity: sha512-l+NKLyVBnNPZ2WQoyVM8KoKhi4/mwo96A2fYqcPBXWg0nBJUdaIyJ5sJKAMxa39LR2a15ItShDHKYrQ48aUTbw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      typescript: ^5 || ^6 || ^7.0.1-0
+      typescript: ^5 || ^6 || ^7
     peerDependenciesMeta:
       '@microsoft/api-extractor':
         optional: true
@@ -1758,18 +1758,15 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rsbuild-plugin-dts@0.23.2:
-    resolution: {integrity: sha512-Ve8WOSPyTBjxH40O/6fChJtflL7yqcUtt5zbF0eHDM4hIt35jqLocRlSdCxFJdQm0blTjl6+hkmPa/vNI06ArA==}
+  rsbuild-plugin-dts@1.0.0-beta.0:
+    resolution: {integrity: sha512-+WOBPjcADvQPdjQuIiNI6LLQgDFnwSDo7tl1Yn/sXmUH8YISp5PveSEU08B7ABPeiTgBUdevUnVrb8f/deYaxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-      '@typescript/native-preview': ^7.0.0-0
-      typescript: ^5 || ^6 || ^7.0.1-0
+      '@rsbuild/core': ^2.0.0
+      typescript: ^5 || ^6 || ^7
     peerDependenciesMeta:
       '@microsoft/api-extractor':
-        optional: true
-      '@typescript/native-preview':
         optional: true
       typescript:
         optional: true
@@ -2160,15 +2157,14 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rslib/core@0.23.2(typescript@7.0.2)':
+  '@rslib/core@1.0.0-beta.0(typescript@7.0.2)':
     dependencies:
       '@rsbuild/core': 2.1.6
-      rsbuild-plugin-dts: 0.23.2(@rsbuild/core@2.1.6)(typescript@7.0.2)
+      rsbuild-plugin-dts: 1.0.0-beta.0(@rsbuild/core@2.1.6)(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-      - '@typescript/native-preview'
       - core-js
 
   '@rslint/core@0.6.5':
@@ -2404,9 +2400,9 @@ snapshots:
       '@rsbuild/core': 2.1.6
       '@rstest/core': 0.11.1(happy-dom@20.10.6)
 
-  '@rstest/adapter-rslib@0.11.1(@rslib/core@0.23.2)(@rstest/core@0.11.1)(typescript@7.0.2)':
+  '@rstest/adapter-rslib@0.11.1(@rslib/core@1.0.0-beta.0)(@rstest/core@0.11.1)(typescript@7.0.2)':
     dependencies:
-      '@rslib/core': 0.23.2(typescript@7.0.2)
+      '@rslib/core': 1.0.0-beta.0(typescript@7.0.2)
       '@rstest/core': 0.11.1(happy-dom@20.10.6)
     optionalDependencies:
       typescript: 7.0.2
@@ -3716,7 +3712,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rsbuild-plugin-dts@0.23.2(@rsbuild/core@2.1.6)(typescript@7.0.2):
+  rsbuild-plugin-dts@1.0.0-beta.0(@rsbuild/core@2.1.6)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.1.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ cleanupUnusedCatalogs: true
 catalog:
   '@rsbuild/core': '~2.1.6'
   '@rsbuild/plugin-react': '^2.1.0'
-  '@rslib/core': '~0.23.2'
+  '@rslib/core': '~1.0.0-beta.0'
   '@rslint/core': '~0.6.5'
   '@rspress/core': '^2.0.17'
   '@rstackjs/load-config': ^0.1.2


### PR DESCRIPTION
## Summary

This PR upgrades Rslib to v1.0.0-beta.0 to adopt its latest pre-release behavior and compatibility updates.

When `define.lib` is omitted, Rstack now returns an empty Rslib config and relies on Rslib's new default library output instead of injecting `lib: [{}]`.

## Related Links

- https://github.com/web-infra-dev/rslib/releases/tag/v1.0.0-beta.0