### PR TITLE
release: v0.0.4

### DIFF
--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rstack",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "repository": "https://github.com/rstackjs/rstack-cli",
   "bin": {


### PR DESCRIPTION
## Summary

- bump the `rstack` package version from `0.0.3` to `0.0.4`

## Validation

- commit hooks completed successfully
- confirmed the PR diff contains only the package version change