### PR TITLE
docs: align website colors with Rsbuild

### DIFF
--- a/website/theme/index.scss
+++ b/website/theme/index.scss
@@ -1,21 +1,15 @@
 :root {
-  --rp-c-brand: #564341;
-  --rp-c-brand-dark: #463634;
-  --rp-c-brand-darker: #392c2a;
-  --rp-c-brand-light: #735b57;
-  --rp-c-brand-lighter: #8a716c;
+  --rp-c-brand: #ff5e00;
+  --rp-c-brand-dark: var(--rp-c-brand);
+  --rp-c-brand-darker: #ff704d;
+  --rp-c-brand-light: #ff7524;
+  --rp-c-brand-lighter: #ff7524;
   --rp-c-link: var(--rp-c-brand);
-  --rp-c-brand-tint: rgba(86, 67, 65, 0.08);
+  --rp-c-brand-tint: rgba(255, 94, 0, 0.07);
 }
 
 .dark {
-  --rp-c-brand: #eded91;
-  --rp-c-brand-dark: #d9d978;
-  --rp-c-brand-darker: #c5c564;
-  --rp-c-brand-light: #f2f2ad;
-  --rp-c-brand-lighter: #f6f6c4;
-  --rp-c-link: var(--rp-c-brand);
-  --rp-c-brand-tint: rgba(237, 237, 145, 0.08);
+  --rp-c-link: var(--rp-c-brand-light);
 }
 
 /* Keep document content visually centered when a page has no sidebar. */


### PR DESCRIPTION
This PR aligns the documentation website's brand palette with Rsbuild so the related projects share a consistent visual identity. It reuses Rsbuild's orange Rspress theme variables for both light and dark modes while preserving Rstack's existing layout and components.