### PR TITLE
docs: complete build command guide

### DIFF
--- a/website/docs/en/guide/cli/build.mdx
+++ b/website/docs/en/guide/cli/build.mdx
@@ -1,7 +1,45 @@
 # build
 
-TODO.
+The `rs build` command uses [Rsbuild](https://rsbuild.rs/guide/basic/cli#rsbuild-build) to build an application for production.
+
+## Usage
+
+```bash
+rs build [options]
+```
+
+The command loads the application configuration registered with [`define.app()`](../configuration#define-app).
+
+## Options
+
+`rs build` supports the same build options as Rsbuild. See the [Rsbuild CLI documentation](https://rsbuild.rs/guide/basic/cli#rsbuild-build) for details.
+
+Examples:
+
+```bash
+# Write output files to the output directory
+rs build --dist-path output
+
+# Generate source maps for the output files
+rs build --source-map
+
+# Rebuild when files change
+rs build --watch
+```
 
 ## Configuration
 
-See [`define.app()`](../configuration#define-app).
+Configure the production build through [`define.app()`](../configuration#define-app) in the [Rstack configuration file](/guide/configuration#configuration-file). It accepts the standard [Rsbuild configuration](https://rsbuild.rs/config/):
+
+```ts title="rstack.config.ts"
+import { define } from 'rstack';
+
+define.app({
+  output: {
+    distPath: {
+      root: 'output',
+    },
+    sourceMap: true,
+  },
+});
+```

--- a/website/docs/en/guide/cli/dev.mdx
+++ b/website/docs/en/guide/cli/dev.mdx
@@ -8,7 +8,7 @@ The `rs dev` command starts the [Rsbuild development server](https://rsbuild.rs/
 rs dev [options]
 ```
 
-The command loads the application configuration registered with [`define.app()`](../configuration#define-app). When the Rstack configuration file or one of its imported dependencies changes, Rstack automatically restarts the development server and applies the updated configuration.
+The command loads the application configuration registered with [`define.app()`](../configuration#define-app).
 
 ## Options
 

--- a/website/docs/zh/guide/cli/build.mdx
+++ b/website/docs/zh/guide/cli/build.mdx
@@ -1,7 +1,45 @@
 # build
 
-TODO.
+`rs build` 命令使用 [Rsbuild](https://rsbuild.rs/zh/guide/basic/cli#rsbuild-build) 构建应用的生产版本。
+
+## 用法 \{#usage}
+
+```bash
+rs build [options]
+```
+
+该命令会加载通过 [`define.app()`](../configuration#define-app) 注册的应用配置。
+
+## 选项 \{#options}
+
+`rs build` 支持与 Rsbuild 相同的构建选项，具体说明请参见 [Rsbuild CLI 文档](https://rsbuild.rs/zh/guide/basic/cli#rsbuild-build)。
+
+示例：
+
+```bash
+# 将构建产物写入 output 目录
+rs build --dist-path output
+
+# 为构建产物生成 source map
+rs build --source-map
+
+# 在文件变化时重新构建
+rs build --watch
+```
 
 ## 配置 \{#configuration}
 
-参见 [`define.app()`](../configuration#define-app)。
+在 [Rstack 配置文件](/guide/configuration#configuration-file)中通过 [`define.app()`](../configuration#define-app) 配置生产构建。该 API 支持标准的 [Rsbuild 配置](https://rsbuild.rs/zh/config/)：
+
+```ts title="rstack.config.ts"
+import { define } from 'rstack';
+
+define.app({
+  output: {
+    distPath: {
+      root: 'output',
+    },
+    sourceMap: true,
+  },
+});
+```

--- a/website/docs/zh/guide/cli/dev.mdx
+++ b/website/docs/zh/guide/cli/dev.mdx
@@ -8,7 +8,7 @@
 rs dev [options]
 ```
 
-该命令会加载通过 [`define.app()`](../configuration#define-app) 注册的应用配置。当 Rstack 配置文件或其导入的任一依赖发生变化时，Rstack 会自动重启开发服务器并应用更新后的配置。
+该命令会加载通过 [`define.app()`](../configuration#define-app) 注册的应用配置。
 
 ## 选项 \{#options}
 


### PR DESCRIPTION
## Summary

This PR completes the English and Chinese `rs build` guides so users can find command usage, representative examples, and `define.app()` configuration in one place.

It links detailed option behavior to Rsbuild and removes low-level configuration reload details from the `dev` and `build` guides.