### PR TITLE
docs: complete lib command guide

### DIFF
--- a/website/docs/en/guide/cli/lib.mdx
+++ b/website/docs/en/guide/cli/lib.mdx
@@ -1,7 +1,63 @@
 # lib
 
-TODO.
+The `rs lib` command uses [Rslib](https://rslib.rs/guide/basic/cli#rslib) to build library outputs.
+
+## Usage
+
+```bash
+rs lib [command] [options]
+```
+
+The command loads the library configuration registered with [`define.lib()`](../configuration#define-lib). When no subcommand is provided, it builds the library.
+
+## Options
+
+`rs lib` supports the same library build options as Rslib. See the [Rslib CLI documentation](https://rslib.rs/guide/basic/cli#rslib) for details.
+
+Examples:
+
+```bash
+# Build ESM output and generate declaration files
+rs lib --format esm --dts
+
+# Build CommonJS output without bundling modules
+rs lib --format cjs --no-bundle
+
+# Rebuild when files change
+rs lib --watch
+```
+
+## Subcommands
+
+### inspect
+
+[`rs lib inspect`](https://rslib.rs/guide/basic/cli#rslib-inspect) generates the normalized Rslib configuration and the corresponding Rsbuild and Rspack configurations for inspection.
+
+```bash
+rs lib inspect
+```
+
+### mf-dev
+
+[`rs lib mf-dev`](https://rslib.rs/guide/basic/cli#rslib-mf-dev) starts an Rsbuild development server for a library output that uses the Module Federation (`mf`) format. Use it to develop and debug the module in a host application.
+
+```bash
+rs lib mf-dev
+```
 
 ## Configuration
 
-See [`define.lib()`](../configuration#define-lib).
+Configure library builds through [`define.lib()`](../configuration#define-lib) in the [Rstack configuration file](/guide/configuration#configuration-file). It accepts the standard [Rslib configuration](https://rslib.rs/config/):
+
+```ts title="rstack.config.ts"
+import { define } from 'rstack';
+
+define.lib({
+  lib: [
+    {
+      dts: true,
+      format: 'esm',
+    },
+  ],
+});
+```

--- a/website/docs/en/guide/cli/lib.mdx
+++ b/website/docs/en/guide/cli/lib.mdx
@@ -17,11 +17,8 @@ The command loads the library configuration registered with [`define.lib()`](../
 Examples:
 
 ```bash
-# Build ESM output and generate declaration files
-rs lib --format esm --dts
-
-# Build CommonJS output without bundling modules
-rs lib --format cjs --no-bundle
+# Build and generate declaration files
+rs lib --dts
 
 # Rebuild when files change
 rs lib --watch

--- a/website/docs/zh/guide/cli/lib.mdx
+++ b/website/docs/zh/guide/cli/lib.mdx
@@ -1,7 +1,63 @@
 # lib
 
-TODO.
+`rs lib` 命令使用 [Rslib](https://rslib.rs/zh/guide/basic/cli#rslib) 构建库产物。
+
+## 用法 \{#usage}
+
+```bash
+rs lib [command] [options]
+```
+
+该命令会加载通过 [`define.lib()`](../configuration#define-lib) 注册的库配置。未指定子命令时，默认执行库构建。
+
+## 选项 \{#options}
+
+`rs lib` 支持与 Rslib 相同的库构建选项，具体说明请参见 [Rslib CLI 文档](https://rslib.rs/zh/guide/basic/cli#rslib)。
+
+示例：
+
+```bash
+# 构建 ESM 产物并生成声明文件
+rs lib --format esm --dts
+
+# 构建不打包模块的 CommonJS 产物
+rs lib --format cjs --no-bundle
+
+# 在文件变化时重新构建
+rs lib --watch
+```
+
+## 子命令 \{#subcommands}
+
+### inspect
+
+[`rs lib inspect`](https://rslib.rs/zh/guide/basic/cli#rslib-inspect) 用于生成归一化后的 Rslib 配置及对应的 Rsbuild 和 Rspack 配置，以便检查最终生效的配置。
+
+```bash
+rs lib inspect
+```
+
+### mf-dev
+
+[`rs lib mf-dev`](https://rslib.rs/zh/guide/basic/cli#rslib-mf-dev) 为使用模块联邦（`mf`）格式的库产物启动 Rsbuild 开发服务器，用于在宿主应用中开发和调试模块。
+
+```bash
+rs lib mf-dev
+```
 
 ## 配置 \{#configuration}
 
-参见 [`define.lib()`](../configuration#define-lib)。
+在 [Rstack 配置文件](/guide/configuration#configuration-file)中通过 [`define.lib()`](../configuration#define-lib) 配置库构建。该 API 支持标准的 [Rslib 配置](https://rslib.rs/zh/config/)：
+
+```ts title="rstack.config.ts"
+import { define } from 'rstack';
+
+define.lib({
+  lib: [
+    {
+      dts: true,
+      format: 'esm',
+    },
+  ],
+});
+```

--- a/website/docs/zh/guide/cli/lib.mdx
+++ b/website/docs/zh/guide/cli/lib.mdx
@@ -17,11 +17,8 @@ rs lib [command] [options]
 示例：
 
 ```bash
-# 构建 ESM 产物并生成声明文件
-rs lib --format esm --dts
-
-# 构建不打包模块的 CommonJS 产物
-rs lib --format cjs --no-bundle
+# 构建产物并生成声明文件
+rs lib --dts
 
 # 在文件变化时重新构建
 rs lib --watch


### PR DESCRIPTION
## Summary

This PR completes the English and Chinese `rs lib` guides so users can configure and build library outputs with Rslib.

It documents representative build options, `define.lib()` configuration, and the `inspect` and `mf-dev` subcommands with links and examples.