### PR TITLE
docs: complete lint command guide

### DIFF
--- a/website/docs/en/guide/cli/lint.mdx
+++ b/website/docs/en/guide/cli/lint.mdx
@@ -1,7 +1,42 @@
 # lint
 
-TODO.
+The `rs lint` command uses [Rslint](https://rslint.rs/guide/) to lint source code.
+
+## Usage
+
+```bash
+rs lint [options] [files...]
+```
+
+The command loads the lint configuration registered with [`define.lint()`](../configuration#define-lint).
+
+## Options
+
+`rs lint` supports the same command-line options as Rslint. See the [Rslint CLI documentation](https://rslint.rs/guide/cli) for details.
+
+Examples:
+
+```bash
+# Lint a specific directory
+rs lint src
+
+# Automatically fix problems
+rs lint --fix
+
+# Lint and run TypeScript type checking
+rs lint --type-check
+```
 
 ## Configuration
 
-See [`define.lint()`](../configuration#define-lint).
+Configure linting through [`define.lint()`](../configuration#define-lint) in the [Rstack configuration file](/guide/configuration#configuration-file). It accepts the standard [Rslint configuration](https://rslint.rs/config/). Presets and plugins can be imported from `rstack/lint` on demand:
+
+```ts title="rstack.config.ts"
+import { define } from 'rstack';
+
+define.lint(async () => {
+  const { js, ts } = await import('rstack/lint');
+
+  return [js.configs.recommended, ts.configs.recommended];
+});
+```

--- a/website/docs/zh/guide/cli/lint.mdx
+++ b/website/docs/zh/guide/cli/lint.mdx
@@ -1,7 +1,42 @@
 # lint
 
-TODO.
+`rs lint` 命令使用 [Rslint](https://rslint.rs/guide/) 检查源代码。
+
+## 用法 \{#usage}
+
+```bash
+rs lint [options] [files...]
+```
+
+该命令会加载通过 [`define.lint()`](../configuration#define-lint) 注册的代码检查配置。
+
+## 选项 \{#options}
+
+`rs lint` 支持与 Rslint 相同的命令行选项，具体说明请参见 [Rslint CLI 文档](https://rslint.rs/guide/cli)。
+
+示例：
+
+```bash
+# 检查指定目录
+rs lint src
+
+# 自动修复问题
+rs lint --fix
+
+# 检查代码并运行 TypeScript 类型检查
+rs lint --type-check
+```
 
 ## 配置 \{#configuration}
 
-参见 [`define.lint()`](../configuration#define-lint)。
+在 [Rstack 配置文件](/guide/configuration#configuration-file)中通过 [`define.lint()`](../configuration#define-lint) 配置代码检查。该 API 支持标准的 [Rslint 配置](https://rslint.rs/config/)。预设和插件可以从 `rstack/lint` 按需导入：
+
+```ts title="rstack.config.ts"
+import { define } from 'rstack';
+
+define.lint(async () => {
+  const { js, ts } = await import('rstack/lint');
+
+  return [js.configs.recommended, ts.configs.recommended];
+});
+```


### PR DESCRIPTION
This PR completes the bilingual `rs lint` command guide so users can understand Rslint workflows through Rstack.

It documents representative directory linting, automatic fixing, and type-checking examples alongside `define.lint()` configuration and `rstack/lint` imports, while keeping the English and Chinese structure and anchors aligned.