### PR TITLE
docs: update homepage copy and footer links

### DIFF
--- a/website/i18n.json
+++ b/website/i18n.json
@@ -4,12 +4,12 @@
     "zh": "快速上手"
   },
   "subtitle": {
-    "en": "The Unified Rstack Toolchain",
-    "zh": "统一的 Rstack 工具链"
+    "en": "The Unified JavaScript Toolchain",
+    "zh": "统一的 JavaScript 工具链"
   },
   "slogan": {
     "en": "One CLI, one configuration, one consistent workflow",
-    "zh": "一个命令行、一份配置、一致的研发体验"
+    "zh": "一个命令行、一份配置、一致的工作流"
   },
   "unifiedCli": {
     "en": "One CLI",

--- a/website/theme/components/HomeFooter.tsx
+++ b/website/theme/components/HomeFooter.tsx
@@ -26,16 +26,24 @@ function useFooterData() {
       title: t('commands'),
       items: [
         {
-          title: 'rs dev',
-          link: getLink('/guide/cli/dev'),
-        },
-        {
           title: 'rs build',
           link: getLink('/guide/cli/build'),
         },
         {
+          title: 'rs lib',
+          link: getLink('/guide/cli/lib'),
+        },
+        {
           title: 'rs test',
           link: getLink('/guide/cli/test'),
+        },
+        {
+          title: 'rs lint',
+          link: getLink('/guide/cli/lint'),
+        },
+        {
+          title: 'rs doc',
+          link: getLink('/guide/cli/doc'),
         },
       ],
     },


### PR DESCRIPTION
## Summary

This PR updates the homepage positioning to describe Rstack as a unified JavaScript toolchain with a consistent workflow.

It also refines the footer command links around the primary build, library, test, lint, and documentation workflows.