### PR TITLE
docs: add API reference

### DIFF
--- a/website/docs/en/guide/_meta.json
+++ b/website/docs/en/guide/_meta.json
@@ -14,6 +14,11 @@
     "label": "Configuration"
   },
   {
+    "type": "file",
+    "name": "api-reference",
+    "label": "API reference"
+  },
+  {
     "type": "dir-section-header",
     "name": "cli",
     "label": "CLI"

--- a/website/docs/en/guide/api-reference.mdx
+++ b/website/docs/en/guide/api-reference.mdx
@@ -1,0 +1,106 @@
+# API reference
+
+Rstack provides a unified configuration API and re-exports the public APIs of Rsbuild, Rslib, Rstest, and Rslint through dedicated subpaths. Prefer these subpaths to direct imports from each tool's core package so that dependency entry points and tool versions remain aligned with Rstack.
+
+## Import paths
+
+| Import path              | Contents                                          | Use case                                |
+| ------------------------ | ------------------------------------------------- | --------------------------------------- |
+| `rstack`                 | Rstack configuration API                          | Register tool configurations            |
+| `rstack/app`             | Public APIs from `@rsbuild/core`                  | Build applications and extend Rsbuild   |
+| `rstack/lib`             | Public APIs from `@rslib/core`                    | Build libraries and extend Rslib        |
+| `rstack/test`            | Public APIs from `@rstest/core`                   | Write tests and configure test projects |
+| `rstack/lint`            | Public APIs from `@rslint/core`                   | Use Rslint presets and plugins          |
+| `rstack/types`           | Project types shared by Rsbuild and Rslib         | Type application and library sources    |
+| `rstack/test/globals`    | Global Rstest API declarations                    | Enable global test API types            |
+| `rstack/test/importMeta` | `ImportMeta` declaration for `import.meta.rstest` | Type in-source tests                    |
+
+## Main entry point
+
+### `define`
+
+Import `define` from `rstack` to register tool configurations in `rstack.config.ts`; see [Configuration APIs](./configuration#configuration-apis) for details.
+
+## Re-exports
+
+The tool-specific subpaths below re-export the public APIs from their corresponding core packages. Using these Rstack entry points keeps dependency entry points and tool versions aligned with the toolchain integrated by Rstack.
+
+### `rstack/app`
+
+`rstack/app` re-exports all public APIs from `@rsbuild/core`, including APIs for creating and controlling Rsbuild instances.
+
+```ts
+import { createRsbuild, mergeRsbuildConfig } from 'rstack/app';
+```
+
+For details, see the [Rsbuild core APIs](https://rsbuild.rs/api/javascript-api/core).
+
+### `rstack/lib`
+
+`rstack/lib` re-exports all public APIs from `@rslib/core`, including APIs for creating Rslib instances and merging Rslib configurations.
+
+```ts
+import { createRslib, mergeRslibConfig } from 'rstack/lib';
+```
+
+For details, see the [Rslib core APIs](https://rslib.rs/api/javascript-api/core).
+
+### `rstack/test`
+
+`rstack/test` re-exports all public APIs from `@rstest/core`, including APIs for defining tests, writing assertions, mocking modules, and merging test configurations.
+
+```ts
+import { describe, expect, test } from 'rstack/test';
+```
+
+See the [Rstest runtime API](https://rstest.rs/api/runtime-api/) for test APIs and the [Rstest core APIs](https://rstest.rs/api/javascript-api/rstest-core) for configuration helpers.
+
+### `rstack/lint`
+
+`rstack/lint` re-exports all public APIs from `@rslint/core`, including JavaScript and TypeScript presets and framework plugins.
+
+```ts
+import { js, reactPlugin, ts } from 'rstack/lint';
+```
+
+For details about the available presets and plugins, see [Rslint rules and presets](https://rslint.rs/config/rules-and-presets).
+
+## TypeScript types
+
+These type-only entry points add ambient declarations to a TypeScript project. Add only the entries your project needs to [`compilerOptions.types`](https://www.typescriptlang.org/tsconfig/#types) in `tsconfig.json`.
+
+### `rstack/types`
+
+`rstack/types` provides project-level declarations shared by Rsbuild and Rslib, including types for `import.meta.env` and static asset imports. Use it in place of `@rsbuild/core/types` or `@rslib/core/types`.
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["rstack/types", "node"]
+  }
+}
+```
+
+### `rstack/test/globals`
+
+`rstack/test/globals` declares Rstest APIs such as `test`, `expect`, and lifecycle hooks as globals. Add it when tests use these APIs without explicit imports.
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["rstack/test/globals", "node"]
+  }
+}
+```
+
+### `rstack/test/importMeta`
+
+`rstack/test/importMeta` augments `ImportMeta` with the optional `rstest` property, enabling `import.meta.rstest` in in-source tests.
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["rstack/test/importMeta", "node"]
+  }
+}
+```

--- a/website/docs/zh/guide/_meta.json
+++ b/website/docs/zh/guide/_meta.json
@@ -14,6 +14,11 @@
     "label": "配置"
   },
   {
+    "type": "file",
+    "name": "api-reference",
+    "label": "API 参考"
+  },
+  {
     "type": "dir-section-header",
     "name": "cli",
     "label": "CLI"

--- a/website/docs/zh/guide/api-reference.mdx
+++ b/website/docs/zh/guide/api-reference.mdx
@@ -1,0 +1,106 @@
+# API 参考 \{#api-reference}
+
+Rstack 提供统一的配置 API，并通过专用子路径重导出 Rsbuild、Rslib、Rstest 和 Rslint 的公开 API。建议优先从这些子路径导入，以统一依赖入口，并确保 API 与 Rstack 集成的工具版本保持一致。
+
+## 导入路径 \{#import-paths}
+
+| 导入路径                 | 内容                                      | 使用场景                 |
+| ------------------------ | ----------------------------------------- | ------------------------ |
+| `rstack`                 | Rstack 配置 API                           | 注册各项工具配置         |
+| `rstack/app`             | `@rsbuild/core` 的公开 API                | 构建应用及扩展 Rsbuild   |
+| `rstack/lib`             | `@rslib/core` 的公开 API                  | 构建库及扩展 Rslib       |
+| `rstack/test`            | `@rstest/core` 的公开 API                 | 编写测试及配置测试项目   |
+| `rstack/lint`            | `@rslint/core` 的公开 API                 | 使用 Rslint 预设和插件   |
+| `rstack/types`           | Rsbuild 与 Rslib 共用的项目类型           | 为应用和库的源码提供类型 |
+| `rstack/test/globals`    | Rstest 全局 API 声明                      | 启用全局测试 API 类型    |
+| `rstack/test/importMeta` | `import.meta.rstest` 的 `ImportMeta` 声明 | 为源码内测试提供类型     |
+
+## 主入口 \{#main-entry-point}
+
+### `define`
+
+从 `rstack` 导入 `define`，用于在 `rstack.config.ts` 中注册各项工具配置；详细用法请参阅[配置 API](./configuration#configuration-apis)。
+
+## 重导出 \{#re-exports}
+
+以下工具子路径均会重导出对应 core 包的公开 API。通过这些 Rstack 入口导入，可以让依赖入口和工具版本与 Rstack 集成的工具链保持一致。
+
+### `rstack/app`
+
+`rstack/app` 重导出 `@rsbuild/core` 的全部公开 API，包括用于创建和控制 Rsbuild 实例的 API。
+
+```ts
+import { createRsbuild, mergeRsbuildConfig } from 'rstack/app';
+```
+
+具体用法请参阅 [Rsbuild 核心 API](https://rsbuild.rs/zh/api/javascript-api/core)。
+
+### `rstack/lib`
+
+`rstack/lib` 重导出 `@rslib/core` 的全部公开 API，包括用于创建 Rslib 实例和合并 Rslib 配置的 API。
+
+```ts
+import { createRslib, mergeRslibConfig } from 'rstack/lib';
+```
+
+具体用法请参阅 [Rslib 核心 API](https://rslib.rs/zh/api/javascript-api/core)。
+
+### `rstack/test`
+
+`rstack/test` 重导出 `@rstest/core` 的全部公开 API，包括用于定义测试、编写断言、模拟模块和合并测试配置的 API。
+
+```ts
+import { describe, expect, test } from 'rstack/test';
+```
+
+测试 API 请参阅 [Rstest 运行时 API](https://rstest.rs/zh/api/runtime-api/)，配置辅助 API 请参阅 [Rstest 核心 API](https://rstest.rs/zh/api/javascript-api/rstest-core)。
+
+### `rstack/lint`
+
+`rstack/lint` 重导出 `@rslint/core` 的全部公开 API，包括 JavaScript 和 TypeScript 预设以及框架插件。
+
+```ts
+import { js, reactPlugin, ts } from 'rstack/lint';
+```
+
+可用的预设和插件请参阅 [Rslint 规则和预设](https://rslint.rs/config/rules-and-presets)。
+
+## TypeScript 类型 \{#typescript-types}
+
+以下纯类型入口用于为 TypeScript 项目补充环境类型声明。请仅将项目需要的入口添加到 `tsconfig.json` 的 [`compilerOptions.types`](https://www.typescriptlang.org/tsconfig/#types) 中。
+
+### `rstack/types`
+
+`rstack/types` 提供 Rsbuild 与 Rslib 共用的项目级类型声明，包括 `import.meta.env` 和静态资源导入的类型。请使用该入口替代 `@rsbuild/core/types` 或 `@rslib/core/types`。
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["rstack/types", "node"]
+  }
+}
+```
+
+### `rstack/test/globals`
+
+`rstack/test/globals` 提供 `test`、`expect` 和生命周期钩子等 Rstest API 的全局声明。测试代码无需显式导入这些 API 时，请添加该入口。
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["rstack/test/globals", "node"]
+  }
+}
+```
+
+### `rstack/test/importMeta`
+
+`rstack/test/importMeta` 为 `ImportMeta` 增加可选的 `rstest` 属性，使源码内测试可以使用 `import.meta.rstest`。
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["rstack/test/importMeta", "node"]
+  }
+}
+```


### PR DESCRIPTION
This PR adds a centralized API reference so users can discover Rstack's main entry point, re-exported tool APIs, and TypeScript type entry points in one place.

It documents the recommended `rstack/*` import paths with aligned English and Chinese examples and adds the page to both sidebars.