### PR TITLE
perf: externalize unused YAML parser

### DIFF
--- a/packages/rstack/rslib.config.ts
+++ b/packages/rstack/rslib.config.ts
@@ -21,6 +21,8 @@ export default defineConfig({
     },
   },
   output: {
-    externals: ['jiti'],
+    // Rstack always passes an explicit config object to lint-staged, so its
+    // optional YAML config loader is not used.
+    externals: ['jiti', 'yaml'],
   },
 });


### PR DESCRIPTION
## Summary

`lint-staged` is always invoked with an explicit config object, so its optional YAML config loader is unreachable in Rstack. This PR externalizes `yaml`, removing the generated YAML chunk and the related `buffer`/`process` CommonJS bridges without changing supported behavior.

## Performance

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Top-level JS output | 708,081 B | 387,889 B | -320,192 B (-45.2%) |
| Bundled `yaml.js` | 317,427 B (49,983 B gzip) | 0 B | Removed |

Measured from `packages/rstack/dist` after `pnpm --filter rstack build`.