### PR TITLE
docs: move skills to quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,26 +33,6 @@ Rstack CLI is currently experimental and mainly used for internal validation. It
 
 Welcome to try it out and share feedback through issues and discussions!
 
-## Skills
-
-### Best practice
-
-Rstack CLI is still new and does not have complete documentation yet.
-
-Installing the Rstack CLI skill so the agent can understand how to use it:
-
-```bash
-npx skills add rstackjs/rstack-cli --skill rstack-cli-best-practices
-```
-
-### Migration
-
-Installing the migration skill so the agent can migrate existing projects to Rstack CLI:
-
-```bash
-npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
-```
-
 ## Usage
 
 1. Install `rstack` in your project:
@@ -94,23 +74,6 @@ pnpm test
 pnpm lint
 pnpm lib
 pnpm doc
-```
-
-## API imports
-
-Rstack re-exports the APIs of its underlying tools through dedicated entry points:
-
-| Tool    | Import path   |
-| ------- | ------------- |
-| Rsbuild | `rstack/app`  |
-| Rslib   | `rstack/lib`  |
-| Rslint  | `rstack/lint` |
-| Rstest  | `rstack/test` |
-
-For example, import Rstest APIs without adding `@rstest/core` as a direct dependency:
-
-```ts
-import { expect, test } from 'rstack/test';
 ```
 
 ## Credits

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -83,3 +83,23 @@ define.lint({
 ```
 
 See [Configuration](./configuration) for all available configuration APIs.
+
+## Skills
+
+### Best practice
+
+Rstack CLI is still new and does not have complete documentation yet.
+
+Install the Rstack CLI skill so the agent can understand how to use it:
+
+```bash
+npx skills add rstackjs/rstack-cli --skill rstack-cli-best-practices
+```
+
+### Migration
+
+Install the migration skill so the agent can migrate existing projects to Rstack CLI:
+
+```bash
+npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
+```

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -88,8 +88,6 @@ See [Configuration](./configuration) for all available configuration APIs.
 
 ### Best practice
 
-Rstack CLI is still new and does not have complete documentation yet.
-
 Install the Rstack CLI skill so the agent can understand how to use it:
 
 ```bash

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -83,3 +83,23 @@ define.lint({
 ```
 
 所有可用的配置 API 请参见[配置](./configuration)。
+
+## Skills \{#skills}
+
+### 最佳实践 \{#best-practice}
+
+Rstack CLI 仍处于早期阶段，目前尚未提供完整文档。
+
+安装 Rstack CLI Skill，使 Agent 能够了解如何使用 Rstack CLI：
+
+```bash
+npx skills add rstackjs/rstack-cli --skill rstack-cli-best-practices
+```
+
+### 迁移 \{#migration}
+
+安装迁移 Skill，使 Agent 能够将现有项目迁移到 Rstack CLI：
+
+```bash
+npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
+```

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -88,8 +88,6 @@ define.lint({
 
 ### 最佳实践 \{#best-practice}
 
-Rstack CLI 仍处于早期阶段，目前尚未提供完整文档。
-
 安装 Rstack CLI Skill，使 Agent 能够了解如何使用 Rstack CLI：
 
 ```bash


### PR DESCRIPTION
The README should stay focused on the core CLI overview and setup flow.

This PR moves the Skills guidance into both English and Chinese quick start guides with matching anchors, and removes the API imports section from the README.