### PR TITLE
perf: fully minify bundled lint-staged code

### DIFF
--- a/packages/rstack/rslib.config.ts
+++ b/packages/rstack/rslib.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from '@rslib/core';
 import pkgJson from './package.json' with { type: 'json' };
 
+const fullyMinifiedChunks = /lintStaged\.js$/;
+
 export default defineConfig({
   lib: [{ syntax: 'es2023', dts: true }],
   source: {
@@ -24,5 +26,26 @@ export default defineConfig({
     // Rstack always passes an explicit config object to lint-staged, so its
     // optional YAML config loader is not used.
     externals: ['jiti', 'yaml'],
+    minify: {
+      js: true,
+      css: false,
+      jsOptions: [
+        {
+          // Fully minify the bundled lint-staged code to reduce package size.
+          include: fullyMinifiedChunks,
+        },
+        {
+          exclude: fullyMinifiedChunks,
+          minimizerOptions: {
+            // Preserve variable names and disable minification for easier debugging.
+            mangle: false,
+            minify: false,
+            compress: {
+              keep_fnames: true,
+            },
+          },
+        },
+      ],
+    },
   },
 });

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,4 +1,5 @@
 # Custom Dictionary Words
+fnames
 llms
 oxfmt
 rsbuild


### PR DESCRIPTION
## Summary

This PR uses multiple JS minimizer configurations to fully minify the bundled `lint-staged` chunk, while other chunks keep the debug-friendly minification settings used by Rsbuild. The mutually exclusive rules preserve existing debuggability and allow more fully minified chunks to be added later.

## Performance

| Output | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `lintStaged.js` | 150,131 B | 61,556 B | 59.0% |
| All JavaScript | 211,229 B | 117,746 B | 44.3% |

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8154