### PR TITLE
fix(types): avoid leaking load-config types

### DIFF
--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -1,4 +1,4 @@
-import { loadConfig, type LoadConfigResult } from '@rstackjs/load-config';
+import { loadConfig } from '@rstackjs/load-config';
 import type { RsbuildConfigDefinition } from '@rsbuild/core';
 import type { RslibConfigDefinition } from '@rslib/core';
 import type { RslintConfig } from '@rslint/core';
@@ -18,8 +18,10 @@ export type Configs = {
   staged?: StagedConfig;
 };
 
-type LoadedRstackConfig = Pick<LoadConfigResult, 'filePath' | 'dependencies'> & {
+type LoadedRstackConfig = {
   configs: Configs;
+  filePath: string | null;
+  dependencies: string[];
 };
 
 type ConfigState = {


### PR DESCRIPTION
## Summary

The published `rstack` declarations currently reference `@rstackjs/load-config`, even though its runtime implementation is bundled and consumers should not need to install it.

This PR defines the config loader result shape within Rstack so the emitted declarations remain self-contained without adding a production dependency.