### PR TITLE
chore(deps): update @rslib/core to 1.0.0-beta.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ catalogs:
       specifier: ^2.0.1
       version: 2.0.1
     '@rslib/core':
-      specifier: ~1.0.0-beta.0
-      version: 1.0.0-beta.0
+      specifier: ~1.0.0-beta.1
+      version: 1.0.0-beta.1
     '@rslint/core':
       specifier: ~0.7.0
       version: 0.7.0
@@ -302,7 +302,7 @@ importers:
         version: 2.1.7
       '@rslib/core':
         specifier: 'catalog:'
-        version: 1.0.0-beta.0(typescript@7.0.2)
+        version: 1.0.0-beta.1(typescript@7.0.2)
       '@rslint/core':
         specifier: 'catalog:'
         version: 0.7.0
@@ -321,7 +321,7 @@ importers:
         version: 0.11.3(@rsbuild/core@2.1.7)(@rstest/core@0.11.3)
       '@rstest/adapter-rslib':
         specifier: 'catalog:'
-        version: 0.11.3(@rslib/core@1.0.0-beta.0)(@rstest/core@0.11.3)(typescript@7.0.2)
+        version: 0.11.3(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.3)(typescript@7.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -732,8 +732,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rslib/core@1.0.0-beta.0':
-    resolution: {integrity: sha512-l+NKLyVBnNPZ2WQoyVM8KoKhi4/mwo96A2fYqcPBXWg0nBJUdaIyJ5sJKAMxa39LR2a15ItShDHKYrQ48aUTbw==}
+  '@rslib/core@1.0.0-beta.1':
+    resolution: {integrity: sha512-HHPZ+wTUKT/3bEhw2y0JB0O62wMuljkSHVZelLbSGhBflCaUt+D3LohBcIxYW6bhzPbUp4gkJXo1pdTpxiuNLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1978,8 +1978,8 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  rsbuild-plugin-dts@1.0.0-beta.0:
-    resolution: {integrity: sha512-+WOBPjcADvQPdjQuIiNI6LLQgDFnwSDo7tl1Yn/sXmUH8YISp5PveSEU08B7ABPeiTgBUdevUnVrb8f/deYaxw==}
+  rsbuild-plugin-dts@1.0.0-beta.1:
+    resolution: {integrity: sha512-hAEjOXhfIHR4erqjsqjRvA9Yqzc6Thry06tHheXDJUVwmR3VbN8BSMDC8kBZzyKdypDF0IJ98FmLQRiC194sMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -2557,10 +2557,10 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.7
 
-  '@rslib/core@1.0.0-beta.0(typescript@7.0.2)':
+  '@rslib/core@1.0.0-beta.1(typescript@7.0.2)':
     dependencies:
       '@rsbuild/core': 2.1.7
-      rsbuild-plugin-dts: 1.0.0-beta.0(@rsbuild/core@2.1.7)(typescript@7.0.2)
+      rsbuild-plugin-dts: 1.0.0-beta.1(@rsbuild/core@2.1.7)(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
@@ -2788,7 +2788,7 @@ snapshots:
 
   '@rspress/shared@2.0.18':
     dependencies:
-      '@rsbuild/core': 2.1.6
+      '@rsbuild/core': 2.1.7
       '@shikijs/rehype': 4.3.1
       unified: 11.0.5
     transitivePeerDependencies:
@@ -2808,9 +2808,9 @@ snapshots:
       '@rsbuild/core': 2.1.7
       '@rstest/core': 0.11.3(happy-dom@20.11.0)
 
-  '@rstest/adapter-rslib@0.11.3(@rslib/core@1.0.0-beta.0)(@rstest/core@0.11.3)(typescript@7.0.2)':
+  '@rstest/adapter-rslib@0.11.3(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.3)(typescript@7.0.2)':
     dependencies:
-      '@rslib/core': 1.0.0-beta.0(typescript@7.0.2)
+      '@rslib/core': 1.0.0-beta.1(typescript@7.0.2)
       '@rstest/core': 0.11.3(happy-dom@20.11.0)
     optionalDependencies:
       typescript: 7.0.2
@@ -4120,7 +4120,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  rsbuild-plugin-dts@1.0.0-beta.0(@rsbuild/core@2.1.7)(typescript@7.0.2):
+  rsbuild-plugin-dts@1.0.0-beta.1(@rsbuild/core@2.1.7)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.1.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalog:
   '@rsbuild/core': '~2.1.7'
   '@rsbuild/plugin-react': '^2.1.0'
   '@rsbuild/plugin-sass': '^2.0.1'
-  '@rslib/core': '~1.0.0-beta.0'
+  '@rslib/core': '~1.0.0-beta.1'
   '@rslint/core': '~0.7.0'
   '@rspress/core': '^2.0.18'
   '@rspress/plugin-sitemap': '^2.0.18'


### PR DESCRIPTION
## Summary

Bump the `@rslib/core` catalog entry from `~1.0.0-beta.0` to `~1.0.0-beta.1`. beta.1 has breaking changes, but after careful inspection they do not affect the correctness of the build output.
