### PR TITLE
fix(config): isolate concurrent Rstack config loads

### DIFF
--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { loadConfig } from '@rstackjs/load-config';
 import type { RsbuildConfigDefinition } from '@rsbuild/core';
 import type { RslibConfigDefinition } from '@rslib/core';
@@ -33,27 +34,41 @@ type LoadRstackConfigOptions = {
   configFilePath?: string;
 };
 
-type ConfigState = {
+type ConfigSession = {
   configs: Configs;
+  active: boolean;
+};
+
+type ConfigState = {
   configPath?: string;
 };
 
 declare global {
   // rslint-disable-next-line no-var
-  var __rstackConfigState: ConfigState | undefined;
+  var __rstackConfigSessionStorage: AsyncLocalStorage<ConfigSession> | undefined;
+  // rslint-disable-next-line no-var
+  var __rstackCliState: ConfigState | undefined;
 }
 
-export const getConfigState = (): ConfigState => {
+const getConfigSessionStorage = (): AsyncLocalStorage<ConfigSession> => {
   // Rsbuild's fresh import loader can load this module more than once when it
-  // imports the internal rstack config. Keep CLI state on globalThis so the
-  // `--config` path set by the CLI is visible to the fresh-imported instance.
-  if (!globalThis.__rstackConfigState) {
-    globalThis.__rstackConfigState = {
-      configs: {},
-    };
+  // imports the internal Rstack config. Keep the storage on globalThis so
+  // every module instance reads and writes the same active session.
+  if (!globalThis.__rstackConfigSessionStorage) {
+    globalThis.__rstackConfigSessionStorage = new AsyncLocalStorage<ConfigSession>();
   }
 
-  return globalThis.__rstackConfigState;
+  return globalThis.__rstackConfigSessionStorage;
+};
+
+export const getConfigState = (): ConfigState => {
+  // The CLI and its internal tool config can also be loaded as separate module
+  // instances. Keep only the CLI config path in its own global state.
+  if (!globalThis.__rstackCliState) {
+    globalThis.__rstackCliState = {};
+  }
+
+  return globalThis.__rstackCliState;
 };
 
 type Define = {
@@ -100,12 +115,16 @@ type Define = {
 };
 
 const setConfig = <T extends keyof Configs>(type: T, config: Configs[T]): void => {
-  const state = getConfigState();
+  const session = getConfigSessionStorage().getStore();
 
-  if (state.configs[type]) {
+  if (!session?.active) {
+    throw new Error(`The "${type}" config must be defined while loading an Rstack config.`);
+  }
+
+  if (type in session.configs) {
     throw new Error(`The "${type}" config has already been defined.`);
   }
-  state.configs[type] = config;
+  session.configs[type] = config;
 };
 
 export const define: Define = {
@@ -122,31 +141,37 @@ export const loadRstackConfig = async ({
 }: LoadRstackConfigOptions = {}): Promise<LoadedRstackConfig> => {
   const state = getConfigState();
   const configPath = configFilePath ?? state.configPath;
-  state.configs = {};
+  const session: ConfigSession = {
+    configs: {},
+    active: true,
+  };
 
-  try {
-    const { filePath, dependencies } = await loadConfig({
-      loader: 'native',
-      exportName: false,
-      fresh: true,
-      ...(configPath !== undefined
-        ? { path: configPath }
-        : {
-            configFileNames: [
-              'rstack.config.ts',
-              'rstack.config.js',
-              'rstack.config.mts',
-              'rstack.config.mjs',
-            ],
-          }),
-    });
+  return getConfigSessionStorage().run(session, async () => {
+    try {
+      const { filePath, dependencies } = await loadConfig({
+        loader: 'native',
+        exportName: false,
+        fresh: true,
+        ...(configPath !== undefined
+          ? { path: configPath }
+          : {
+              configFileNames: [
+                'rstack.config.ts',
+                'rstack.config.js',
+                'rstack.config.mts',
+                'rstack.config.mjs',
+              ],
+            }),
+      });
 
-    return {
-      configs: state.configs,
-      filePath,
-      dependencies,
-    };
-  } finally {
-    state.configs = {};
-  }
+      return {
+        configs: session.configs,
+        filePath,
+        dependencies,
+      };
+    } finally {
+      session.active = false;
+      session.configs = {};
+    }
+  });
 };

--- a/packages/rstack/tests/config/load-config/duplicate.config.ts
+++ b/packages/rstack/tests/config/load-config/duplicate.config.ts
@@ -1,0 +1,4 @@
+import { define } from 'rstack';
+
+define.app({});
+define.app({});

--- a/packages/rstack/tests/config/load-config/index.test.ts
+++ b/packages/rstack/tests/config/load-config/index.test.ts
@@ -2,27 +2,95 @@ import path from 'node:path';
 import { afterEach, expect, test } from 'rstack/test';
 import { getConfigState, loadRstackConfig } from '../../../src/config.ts';
 
+type Deferred = ReturnType<typeof Promise.withResolvers<void>>;
+
+type ConfigTestHooks = {
+  ready: Deferred;
+  release: Deferred;
+};
+
+declare global {
+  // rslint-disable-next-line no-var
+  var __rstackConfigTestHooks: ConfigTestHooks | undefined;
+}
+
 const state = getConfigState();
+const configPath = (fileName: string): string => path.join(import.meta.dirname, fileName);
+const loadConfigFile = (fileName: string) =>
+  loadRstackConfig({ configFilePath: configPath(fileName) });
+
+const createTestHooks = (): ConfigTestHooks =>
+  (globalThis.__rstackConfigTestHooks = {
+    ready: Promise.withResolvers<void>(),
+    release: Promise.withResolvers<void>(),
+  });
 
 afterEach(() => {
-  state.configs = {};
   delete state.configPath;
+  delete globalThis.__rstackConfigTestHooks;
 });
 
-test('should reset config state before and after loading', async () => {
-  state.configs = { app: {} };
-  state.configPath = path.join(import.meta.dirname, 'rstack.config.ts');
+test('should discard a config session after loading fails', async () => {
+  state.configPath = configPath('rstack.config.ts');
 
   await expect(loadRstackConfig()).rejects.toThrow('test config error');
-  expect(state.configs).toEqual({});
+
+  const { configs } = await loadConfigFile('explicit.config.ts');
+  expect(configs).toEqual({ app: {} });
 });
 
 test('should prefer an explicit config path over the state config path', async () => {
-  const configFilePath = path.join(import.meta.dirname, 'explicit.config.ts');
-  state.configPath = path.join(import.meta.dirname, 'rstack.config.ts');
+  const explicitConfigPath = configPath('explicit.config.ts');
+  state.configPath = configPath('rstack.config.ts');
 
-  const { configs, filePath } = await loadRstackConfig({ configFilePath });
+  const { configs, filePath } = await loadRstackConfig({
+    configFilePath: explicitConfigPath,
+  });
 
   expect(configs.app).toEqual({});
-  expect(filePath).toBe(configFilePath);
+  expect(filePath).toBe(explicitConfigPath);
+});
+
+test('should isolate parallel config sessions across top-level await', async () => {
+  const hooks = createTestHooks();
+  const firstLoad = loadConfigFile('parallel-first.config.ts');
+  await hooks.ready.promise;
+
+  const secondLoad = loadConfigFile('parallel-second.config.ts');
+  const parallelLoads = Promise.all([firstLoad, secondLoad]);
+
+  await secondLoad;
+  hooks.release.resolve();
+  const [firstResult, secondResult] = await parallelLoads;
+
+  expect(firstResult.configs).toEqual({
+    app: { root: 'first' },
+    test: {},
+  });
+  expect(secondResult.configs).toEqual({
+    app: { root: 'second' },
+    lib: {},
+  });
+});
+
+test('should keep a running session intact when another config fails', async () => {
+  const hooks = createTestHooks();
+  const successfulLoad = loadConfigFile('parallel-first.config.ts');
+  await hooks.ready.promise;
+
+  await expect(loadConfigFile('parallel-failing.config.ts')).rejects.toThrow(
+    'parallel config error',
+  );
+  hooks.release.resolve();
+
+  expect((await successfulLoad).configs).toEqual({
+    app: { root: 'first' },
+    test: {},
+  });
+});
+
+test('should reject duplicate definitions within the same session', async () => {
+  await expect(loadConfigFile('duplicate.config.ts')).rejects.toThrow(
+    'The "app" config has already been defined.',
+  );
 });

--- a/packages/rstack/tests/config/load-config/parallel-failing.config.ts
+++ b/packages/rstack/tests/config/load-config/parallel-failing.config.ts
@@ -1,0 +1,4 @@
+import { define } from 'rstack';
+
+define.app({ root: 'failing' });
+throw new Error('parallel config error');

--- a/packages/rstack/tests/config/load-config/parallel-first.config.ts
+++ b/packages/rstack/tests/config/load-config/parallel-first.config.ts
@@ -1,0 +1,10 @@
+import { define } from 'rstack';
+
+const hooks = globalThis.__rstackConfigTestHooks!;
+
+define.app({ root: 'first' });
+hooks.ready.resolve();
+
+await hooks.release.promise;
+
+define.test({});

--- a/packages/rstack/tests/config/load-config/parallel-second.config.ts
+++ b/packages/rstack/tests/config/load-config/parallel-second.config.ts
@@ -1,0 +1,4 @@
+import { define } from 'rstack';
+
+define.app({ root: 'second' });
+define.lib({});


### PR DESCRIPTION
Rstack config loads currently share a process-global registry, allowing concurrent project or nested config loads to overwrite or clear each other.

This PR scopes each load to an AsyncLocalStorage session shared across fresh Rstack module instances, while keeping CLI config path state separate. It adds deterministic coverage for concurrent loads, failure isolation, duplicate definitions, and top-level await.