### PR TITLE
feat(setup): expose the rs setup command

### DIFF
--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import { color } from 'rslog';
 import { getConfigState } from '../config.js';
+import { runSetupCLI } from '../setup/index.js';
 import { runStagedCLI } from '../staged.js';
 import { insertConfigArg, parseCliArgs } from './args.js';
 
@@ -22,6 +23,7 @@ ${color.cyan('Commands')}:
   lint     Lint code
   test     Run tests
   staged   Run tasks on staged Git files
+  setup    Install Git hooks
 
 ${color.dim(`For command-specific options, run:
   $ rs <command> -h`)}
@@ -143,6 +145,11 @@ export async function setupCommands(): Promise<void> {
 
   if (command === 'staged') {
     await runStagedCLI(args.slice(1));
+    return;
+  }
+
+  if (command === 'setup') {
+    runSetupCLI(args.slice(1));
     return;
   }
 

--- a/packages/rstack/src/setup/index.ts
+++ b/packages/rstack/src/setup/index.ts
@@ -1,0 +1,48 @@
+import { parseArgs } from 'node:util';
+import { color } from 'rslog';
+import { installHooks } from './install.js';
+
+const helpMessage = `Rstack v${RSTACK_VERSION}
+
+${color.cyan('Usage')}:
+${color.yellow('  $ rs setup [options]')}
+
+Install Git hooks in the current repository.
+
+${color.cyan('Options')}:
+  -h, --help  Display this help message`;
+
+export const runSetupCLI = (args: string[]): void => {
+  const { values } = parseArgs({
+    args,
+    options: {
+      help: { type: 'boolean', short: 'h' },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  if (values.help) {
+    console.log(helpMessage);
+    return;
+  }
+
+  const result = installHooks();
+
+  if (result.status === 'installed') {
+    console.log('Git hooks installed.');
+    return;
+  }
+
+  if (result.status === 'unchanged') {
+    console.log('Git hooks are already installed.');
+    return;
+  }
+
+  if (result.status === 'skipped') {
+    console.log('Git hooks setup skipped: not a Git repository.');
+    return;
+  }
+
+  throw new Error(result.message);
+};

--- a/packages/rstack/tests/cli/setup/index.test.ts
+++ b/packages/rstack/tests/cli/setup/index.test.ts
@@ -1,0 +1,80 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach } from 'rstack/test';
+import { RSTACK_BIN_PATH, test } from '#test-helpers';
+
+const hooksPath = '.rstack/hooks/_';
+
+let cwd: string;
+let env: NodeJS.ProcessEnv;
+
+const git = (args: string[]): string => {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8', env });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `Git exited with status ${result.status}`);
+  }
+  return result.stdout.trim();
+};
+
+const initRepository = (): void => {
+  git(['init', '--quiet']);
+  git(['config', '--local', 'user.name', 'Rstack Test']);
+  git(['config', '--local', 'user.email', 'test@rstack.dev']);
+};
+
+beforeEach(() => {
+  cwd = mkdtempSync(path.join(tmpdir(), 'rstack setup '));
+  env = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: path.join(cwd, 'global.gitconfig'),
+    GIT_CONFIG_NOSYSTEM: '1',
+  };
+});
+
+afterEach(() => {
+  rmSync(cwd, { force: true, recursive: true });
+});
+
+test('displays setup help', ({ execCli, expect }) => {
+  expect(execCli('--help', { cwd })).toContain('setup    Install Git hooks');
+
+  const output = execCli('setup --help', { cwd });
+
+  expect(execCli('setup -h', { cwd })).toBe(output);
+  expect(output).toContain('Usage:\n  $ rs setup [options]');
+  expect(output).toContain('-h, --help');
+});
+
+test('rejects unknown setup options', ({ execCli, expect }) => {
+  expect(() => execCli('setup --unknown', { cwd })).toThrow();
+});
+
+test('installs hooks without loading Rstack config', ({ execCli, expect }) => {
+  initRepository();
+  writeFileSync(path.join(cwd, 'rstack.config.ts'), 'throw new Error("must not load");\n');
+
+  expect(execCli('setup', { cwd, env })).toContain('Git hooks installed.');
+  expect(git(['config', '--local', '--get', 'core.hooksPath'])).toBe(hooksPath);
+  expect(existsSync(path.join(cwd, hooksPath, 'runner'))).toBe(true);
+  expect(existsSync(path.join(cwd, '.rstack', 'hooks', 'pre-commit'))).toBe(false);
+
+  expect(execCli('setup', { cwd, env })).toContain('Git hooks are already installed.');
+});
+
+test('skips non-Git directories without creating files', ({ execCli, expect }) => {
+  expect(execCli('setup', { cwd })).toContain('Git hooks setup skipped: not a Git repository.');
+  expect(existsSync(path.join(cwd, '.rstack'))).toBe(false);
+});
+
+test('exits with an error when Git is unavailable', ({ expect }) => {
+  const result = spawnSync(process.execPath, [RSTACK_BIN_PATH, 'setup'], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...env, PATH: '', Path: '' },
+  });
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain('Git command not found.');
+});


### PR DESCRIPTION
This PR exposes the default Git hook installer through `rs setup`, making the installer available from the CLI without loading Rstack config or creating user hooks. It adds command-specific help, strict option validation, and concise output and exit-code handling for installed, unchanged, skipped, and failed results. The command remains non-interactive and introduces no runtime dependencies.