### PR TITLE
feat(setup): support Git hook runtime initialization

### DIFF
--- a/packages/rstack/src/setup/hooks.ts
+++ b/packages/rstack/src/setup/hooks.ts
@@ -27,7 +27,20 @@ hook="$dir/$name"
 
 [ -f "$hook" ] || exit 0
 
-exec sh -e "$hook" "$@"
+init="\${XDG_CONFIG_HOME:-$HOME/.config}/rstack/hooks-init.sh"
+[ -f "$init" ] && . "$init"
+
+[ "\${RSTACK_HOOKS-}" = "0" ] && exit 0
+[ "\${RSTACK_HOOKS-}" = "2" ] && set -x
+
+export PATH="node_modules/.bin:$PATH"
+
+code=0
+sh -e "$hook" "$@" || code=$?
+
+[ "$code" = "0" ] || echo "Rstack - $name hook failed (code $code)"
+[ "$code" = "127" ] && echo "Rstack - command not found in PATH=$PATH"
+exit "$code"
 `;
 
 // Every generated Git hook sources the same dispatcher to keep runtime behavior

--- a/packages/rstack/src/setup/index.ts
+++ b/packages/rstack/src/setup/index.ts
@@ -40,7 +40,9 @@ export const runSetupCLI = (args: string[]): void => {
   }
 
   if (result.status === 'skipped') {
-    console.log('Git hooks setup skipped: not a Git repository.');
+    const reason =
+      result.reason === 'disabled' ? 'disabled by RSTACK_HOOKS' : 'not a Git repository';
+    console.log(`Git hooks setup skipped: ${reason}.`);
     return;
   }
 

--- a/packages/rstack/src/setup/install.ts
+++ b/packages/rstack/src/setup/install.ts
@@ -9,7 +9,7 @@ const gitignore = '*\n';
 type InstallResult =
   | { status: 'installed'; hooksPath: string }
   | { status: 'unchanged'; hooksPath: string }
-  | { status: 'skipped'; reason: 'not-git-repository' }
+  | { status: 'skipped'; reason: string }
   | { status: 'failed'; reason: string; message: string };
 
 const fail = (reason: string, message: string): InstallResult => ({
@@ -41,6 +41,10 @@ const isCurrentFile = (filePath: string, content: string, executable = false): b
 };
 
 export const installHooks = (cwd: string = process.cwd()): InstallResult => {
+  if (process.env.RSTACK_HOOKS === '0') {
+    return { status: 'skipped', reason: 'disabled' };
+  }
+
   // Check Git before touching the filesystem so non-repositories have no side effects.
   const repository = runGit(cwd, ['rev-parse', '--is-inside-work-tree']);
   if (repository.error || repository.status === null) {

--- a/packages/rstack/tests/cli/setup/index.test.ts
+++ b/packages/rstack/tests/cli/setup/index.test.ts
@@ -68,6 +68,13 @@ test('skips non-Git directories without creating files', ({ execCli, expect }) =
   expect(existsSync(path.join(cwd, '.rstack'))).toBe(false);
 });
 
+test('skips setup when hooks are disabled', ({ execCli, expect }) => {
+  const output = execCli('setup', { cwd, env: { ...env, RSTACK_HOOKS: '0' } });
+
+  expect(output).toContain('Git hooks setup skipped: disabled by RSTACK_HOOKS.');
+  expect(existsSync(path.join(cwd, '.rstack'))).toBe(false);
+});
+
 test('exits with an error when Git is unavailable', ({ expect }) => {
   const result = spawnSync(process.execPath, [RSTACK_BIN_PATH, 'setup'], {
     cwd,

--- a/packages/rstack/tests/setup/hooks.test.ts
+++ b/packages/rstack/tests/setup/hooks.test.ts
@@ -35,27 +35,31 @@ test.runIf(process.platform !== 'win32')('runs generated hooks', () => {
   const generatedHook = path.join(generatedDirectory, 'pre-commit');
   const userHook = path.join(hooksDirectory, 'pre-commit');
   const files = createHookFiles();
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    XDG_CONFIG_HOME: path.join(directory, 'config'),
+  };
 
   try {
     mkdirSync(generatedDirectory, { recursive: true });
     writeFileSync(path.join(generatedDirectory, 'runner'), files.runner);
     writeFileSync(generatedHook, files['pre-commit']);
 
-    expect(spawnSync('sh', [generatedHook]).status).toBe(0);
+    expect(spawnSync('sh', [generatedHook], { env }).status).toBe(0);
 
     writeFileSync(
       userHook,
       `read -r input
 printf '%s\\n' "$1|$input"
-exit 23
 `,
     );
     const result = spawnSync('sh', [generatedHook, 'argument with spaces'], {
       encoding: 'utf8',
+      env,
       input: 'standard input\n',
     });
 
-    expect(result.status).toBe(23);
+    expect(result.status).toBe(0);
     expect(result.stdout).toBe('argument with spaces|standard input\n');
 
     writeFileSync(
@@ -64,10 +68,10 @@ exit 23
 printf 'unreachable\\n'
 `,
     );
-    const errexitResult = spawnSync('sh', [generatedHook], { encoding: 'utf8' });
+    const errexitResult = spawnSync('sh', [generatedHook], { encoding: 'utf8', env });
 
     expect(errexitResult.status).toBe(1);
-    expect(errexitResult.stdout).toBe('');
+    expect(errexitResult.stdout).toBe('Rstack - pre-commit hook failed (code 1)\n');
   } finally {
     rmSync(directory, { force: true, recursive: true });
   }

--- a/packages/rstack/tests/setup/install.test.ts
+++ b/packages/rstack/tests/setup/install.test.ts
@@ -17,7 +17,8 @@ import { installHooks } from '../../src/setup/install.ts';
 
 const hooksPath = '.rstack/hooks/_';
 
-const git = (cwd: string, args: string[]) => spawnSync('git', args, { cwd, encoding: 'utf8' });
+const git = (cwd: string, args: string[], env: NodeJS.ProcessEnv = process.env) =>
+  spawnSync('git', args, { cwd, encoding: 'utf8', env });
 
 const runGit = (cwd: string, args: string[]): string => {
   const result = git(cwd, args);
@@ -43,6 +44,39 @@ const restoreEnv = (name: string, value: string | undefined): void => {
     process.env[name] = value;
   }
 };
+
+const hookEnv = (cwd: string, value?: string): NodeJS.ProcessEnv => {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    XDG_CONFIG_HOME: path.join(cwd, '.git', 'xdg'),
+  };
+
+  if (value !== undefined) {
+    env.RSTACK_HOOKS = value;
+  }
+
+  return env;
+};
+
+const writeHook = (cwd: string, content: string): void => {
+  const filePath = path.join(cwd, '.rstack', 'hooks', 'pre-commit');
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+};
+
+const writeInit = (cwd: string, content: string): void => {
+  const filePath = path.join(cwd, '.git', 'xdg', 'rstack', 'hooks-init.sh');
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+};
+
+const stage = (cwd: string, name: string): void => {
+  writeFileSync(path.join(cwd, name), 'content\n');
+  runGit(cwd, ['add', name]);
+};
+
+const commit = (cwd: string, value?: string) =>
+  git(cwd, ['commit', '--quiet', '-m', 'test'], hookEnv(cwd, value));
 
 const withRepository = (callback: (cwd: string) => void): void =>
   withDirectory((cwd) => {
@@ -158,23 +192,78 @@ test('reports Git configuration failures without changing hooksPath', () => {
   });
 });
 
-test('blocks commits when a user hook fails', () => {
+test('loads user init and project binaries', () => {
   withRepository((cwd) => {
-    const userDirectory = path.join(cwd, '.rstack', 'hooks');
-    mkdirSync(userDirectory, { recursive: true });
+    const binDirectory = path.join(cwd, 'node_modules', '.bin');
+    mkdirSync(binDirectory, { recursive: true });
+    writeInit(cwd, 'set -u\nexport RSTACK_INIT=loaded\n');
+
+    const command = path.join(binDirectory, 'rstack-hook-command');
     writeFileSync(
-      path.join(userDirectory, 'pre-commit'),
-      `printf 'ran\\n' > hook-ran
-exit 1
+      command,
+      `#!/usr/bin/env sh
+printf 'ran\\n' > project-bin-ran
+`,
+    );
+    chmodSync(command, 0o755);
+
+    writeHook(
+      cwd,
+      `printf '%s\\n' "$RSTACK_INIT" > init-ran
+rstack-hook-command
 `,
     );
 
     expect(installHooks(cwd).status).toBe('installed');
-    writeFileSync(path.join(cwd, 'file.txt'), 'content\n');
-    runGit(cwd, ['add', 'file.txt']);
+    stage(cwd, 'file.txt');
 
-    expect(git(cwd, ['commit', '--quiet', '-m', 'test']).status).not.toBe(0);
-    expect(readFileSync(path.join(cwd, 'hook-ran'), 'utf8')).toBe('ran\n');
+    expect(commit(cwd).status).toBe(0);
+    expect(readFileSync(path.join(cwd, 'init-ran'), 'utf8')).toBe('loaded\n');
+    expect(readFileSync(path.join(cwd, 'project-bin-ran'), 'utf8')).toBe('ran\n');
+  });
+});
+
+test('skips user hooks when disabled by the environment or init', () => {
+  withRepository((cwd) => {
+    writeHook(cwd, 'echo ran >> hook-ran\n');
+    expect(installHooks(cwd).status).toBe('installed');
+
+    stage(cwd, 'first.txt');
+    expect(commit(cwd, '0').status).toBe(0);
+    expect(existsSync(path.join(cwd, 'hook-ran'))).toBe(false);
+
+    writeInit(cwd, 'set -u\nexport RSTACK_HOOKS=0\n');
+
+    stage(cwd, 'second.txt');
+    expect(commit(cwd).status).toBe(0);
+    expect(existsSync(path.join(cwd, 'hook-ran'))).toBe(false);
+  });
+});
+
+test('traces and reports hook failures and command lookup errors', () => {
+  withRepository((cwd) => {
+    writeHook(cwd, 'exit 23\n');
+    expect(installHooks(cwd).status).toBe('installed');
+    stage(cwd, 'file.txt');
+
+    const failed = commit(cwd, '2');
+    expect(failed.stderr).toContain('+ sh -e');
+    expect(`${failed.stdout}${failed.stderr}`).toContain(
+      'Rstack - pre-commit hook failed (code 23)',
+    );
+
+    writeHook(
+      cwd,
+      `printf '%s\\n' "$PATH" > hook-path
+missing-command
+`,
+    );
+    const missing = commit(cwd);
+    const actualPath = readFileSync(path.join(cwd, 'hook-path'), 'utf8').trim();
+    const output = `${missing.stdout}${missing.stderr}`;
+
+    expect(output).toContain('Rstack - pre-commit hook failed (code 127)');
+    expect(output).toContain(`Rstack - command not found in PATH=${actualPath}`);
     expect(git(cwd, ['rev-parse', '--verify', 'HEAD']).status).not.toBe(0);
   });
 });


### PR DESCRIPTION
This PR gives generated Rstack Git hooks a controlled runtime initialization path for GUI clients and Node version managers. It loads `${XDG_CONFIG_HOME:-$HOME/.config}/rstack/hooks-init.sh`, prepends the project `node_modules/.bin`, and supports `RSTACK_HOOKS=0/2` for opt-out and tracing. Hook failures now report the hook name, exit code, and PATH details for missing commands, while `rs setup` also respects the opt-out.