### PR TITLE
refactor: use TypeScript extensions in source imports

### DIFF
--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -1,9 +1,9 @@
 import { join } from 'node:path';
 import { color } from 'rslog';
-import { getConfigState } from '../config.js';
-import { runSetupCLI } from '../setup/index.js';
-import { runStagedCLI } from '../staged.js';
-import { insertConfigArg, parseCliArgs } from './args.js';
+import { getConfigState } from '../config.ts';
+import { runSetupCLI } from '../setup/index.ts';
+import { runStagedCLI } from '../staged.ts';
+import { insertConfigArg, parseCliArgs } from './args.ts';
 
 declare global {
   const RSTACK_VERSION: string;

--- a/packages/rstack/src/cli/index.ts
+++ b/packages/rstack/src/cli/index.ts
@@ -1,4 +1,4 @@
-import { setupCommands } from './commands.js';
+import { setupCommands } from './commands.ts';
 import { logger } from 'rslog';
 
 export async function runCLI(): Promise<void> {

--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -5,7 +5,7 @@ import type { RslibConfigDefinition } from '@rslib/core';
 import type { RslintConfig } from '@rslint/core';
 import type { UserConfig, UserConfigAsyncFn } from '@rspress/core';
 import type { RstestConfigExport } from '@rstest/core';
-import type { StagedConfig } from './staged.js';
+import type { StagedConfig } from './staged.ts';
 
 export type RslintConfigDefinition = RslintConfig | (() => Promise<RslintConfig>);
 export type RspressConfigDefinition = UserConfig | UserConfigAsyncFn;

--- a/packages/rstack/src/index.ts
+++ b/packages/rstack/src/index.ts
@@ -1,2 +1,2 @@
-export { define } from './config.js';
-export { runCLI } from './cli/index.js';
+export { define } from './config.ts';
+export { runCLI } from './cli/index.ts';

--- a/packages/rstack/src/rsbuildConfig.ts
+++ b/packages/rstack/src/rsbuildConfig.ts
@@ -1,5 +1,5 @@
 import type { ConfigParams, RsbuildConfigDefinition, WatchFiles } from '@rsbuild/core';
-import { loadRstackConfig, type Configs } from './config.js';
+import { loadRstackConfig, type Configs } from './config.ts';
 
 const resolveRsbuildConfig = async (configs: Configs, params: ConfigParams) => {
   const appConfig = configs.app;

--- a/packages/rstack/src/rslibConfig.ts
+++ b/packages/rstack/src/rslibConfig.ts
@@ -1,5 +1,5 @@
 import type { ConfigParams, RslibConfig, RslibConfigDefinition } from '@rslib/core';
-import { loadRstackConfig, type Configs } from './config.js';
+import { loadRstackConfig, type Configs } from './config.ts';
 
 const resolveRslibConfig = async (configs: Configs, params: ConfigParams): Promise<RslibConfig> => {
   const libConfig = configs.lib;

--- a/packages/rstack/src/rslintConfig.ts
+++ b/packages/rstack/src/rslintConfig.ts
@@ -1,4 +1,4 @@
-import { loadRstackConfig } from './config.js';
+import { loadRstackConfig } from './config.ts';
 import type { RslintConfig } from '@rslint/core';
 
 const { configs } = await loadRstackConfig();

--- a/packages/rstack/src/rspressConfig.ts
+++ b/packages/rstack/src/rspressConfig.ts
@@ -1,5 +1,5 @@
 import type { UserConfig } from '@rspress/core';
-import { loadRstackConfig, type Configs } from './config.js';
+import { loadRstackConfig, type Configs } from './config.ts';
 
 const resolveRspressConfig = async (configs: Configs): Promise<UserConfig> => {
   const docConfig = configs.doc;

--- a/packages/rstack/src/rstestConfig.ts
+++ b/packages/rstack/src/rstestConfig.ts
@@ -1,6 +1,6 @@
 import type { ConfigParams } from '@rsbuild/core';
 import type { RstestConfig, RstestConfigExport } from '@rstest/core';
-import { loadRstackConfig, type Configs } from './config.js';
+import { loadRstackConfig, type Configs } from './config.ts';
 
 const resolveAutomaticExtends = async (
   configs: Configs,

--- a/packages/rstack/src/setup/index.ts
+++ b/packages/rstack/src/setup/index.ts
@@ -1,6 +1,6 @@
 import { parseArgs } from 'node:util';
 import { color } from 'rslog';
-import { installHooks } from './install.js';
+import { installHooks } from './install.ts';
 
 const helpMessage = `Rstack v${RSTACK_VERSION}
 

--- a/packages/rstack/src/setup/install.ts
+++ b/packages/rstack/src/setup/install.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { chmodSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { createHookFiles } from './hooks.js';
+import { createHookFiles } from './hooks.ts';
 
 const hooksPath = '.rstack/hooks/_';
 const gitignore = '*\n';

--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -1,6 +1,6 @@
 import { parseArgs } from 'node:util';
 import { color } from 'rslog';
-import { loadRstackConfig } from './config.js';
+import { loadRstackConfig } from './config.ts';
 
 export type StagedSyncTaskGenerator = (stagedFileNames: readonly string[]) => string | string[];
 

--- a/packages/rstack/tsconfig.json
+++ b/packages/rstack/tsconfig.json
@@ -9,7 +9,8 @@
     "isolatedDeclarations": true,
     "skipLibCheck": true,
     "module": "nodenext",
-    "moduleResolution": "nodenext"
+    "moduleResolution": "nodenext",
+    "rewriteRelativeImportExtensions": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This change makes the Rstack package source compatible with Node.js native TypeScript execution by using explicit `.ts` extensions for internal relative imports. The package TypeScript config now enables `rewriteRelativeImportExtensions`, so emitted JavaScript continues to reference `.js` files without changing the published package interface.