### PR TITLE
chore: disallow JavaScript extensions in source imports

### DIFF
--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -6,6 +6,22 @@ define.lint(async () => {
     js.configs.recommended,
     ts.configs.recommended,
     {
+      files: ['packages/rstack/src/**/*.ts'],
+      rules: {
+        '@typescript-eslint/no-restricted-imports': [
+          'error',
+          {
+            patterns: [
+              {
+                regex: String.raw`^\.{1,2}/.*\.js$`,
+                message: 'Use the .ts extension for relative imports.',
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
       languageOptions: {
         parserOptions: {
           project: [

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -5,6 +5,7 @@ define.lint(async () => {
   return [
     js.configs.recommended,
     ts.configs.recommended,
+    // Source imports use .ts for Node.js native TypeScript execution; builds rewrite them to .js.
     {
       files: ['packages/rstack/src/**/*.ts'],
       rules: {


### PR DESCRIPTION
Source imports could regress to `.js` extensions, preventing the Rstack package from running directly through Node.js native TypeScript support. This PR adds a scoped Rslint restriction for relative `.js` import and export specifiers under `packages/rstack/src`, while leaving runtime paths to emitted JavaScript files unaffected.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/88