### PR TITLE
chore: run rs setup from source

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "doc:build": "node --run build && pnpm --dir website build",
     "format": "oxfmt .",
     "lint": "rs lint --type-check",
-    "prepare": "pnpm --filter rstack build && rs setup",
+    "prepare": "node scripts/rs.js setup",
     "test": "pnpm --filter './packages/**' test"
   },
   "devDependencies": {

--- a/scripts/rs.js
+++ b/scripts/rs.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// Repository-only CLI entry for running Rstack from source without requiring dist.
+import pkg from '../packages/rstack/package.json' with { type: 'json' };
+
+// The published CLI receives this version at build time, so provide it before loading the source.
+globalThis.RSTACK_VERSION = pkg.version;
+
+const { runCLI } = await import('../packages/rstack/src/index.ts');
+
+await runCLI();


### PR DESCRIPTION
The repository currently builds the Rstack package during `prepare` solely so it can run `rs setup`. This PR adds a repository-only source CLI entry and uses it for setup, removing the bootstrap build while leaving the published bin unchanged. The runner remains command-agnostic so it can support further self-hosting work.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/88
- https://github.com/rstackjs/rstack-cli/pull/89