### PR TITLE
fix: silence successful hook setup

### DIFF
--- a/packages/rstack/src/setup/index.ts
+++ b/packages/rstack/src/setup/index.ts
@@ -29,13 +29,7 @@ export const runSetupCLI = (args: string[]): void => {
 
   const result = installHooks();
 
-  if (result.status === 'installed') {
-    console.log('Git hooks installed.');
-    return;
-  }
-
-  if (result.status === 'unchanged') {
-    console.log('Git hooks are already installed.');
+  if (result.status === 'installed' || result.status === 'unchanged') {
     return;
   }
 

--- a/packages/rstack/tests/cli/setup/index.test.ts
+++ b/packages/rstack/tests/cli/setup/index.test.ts
@@ -51,16 +51,16 @@ test('rejects unknown setup options', ({ execCli, expect }) => {
   expect(() => execCli('setup --unknown', { cwd })).toThrow();
 });
 
-test('installs hooks without loading Rstack config', ({ execCli, expect }) => {
+test('installs hooks silently without loading Rstack config', ({ execCli, expect }) => {
   initRepository();
   writeFileSync(path.join(cwd, 'rstack.config.ts'), 'throw new Error("must not load");\n');
 
-  expect(execCli('setup', { cwd, env })).toContain('Git hooks installed.');
+  expect(execCli('setup', { cwd, env })).toBe('');
   expect(git(['config', '--local', '--get', 'core.hooksPath'])).toBe(hooksPath);
   expect(existsSync(path.join(cwd, hooksPath, 'runner'))).toBe(true);
   expect(existsSync(path.join(cwd, '.rstack', 'hooks', 'pre-commit'))).toBe(false);
 
-  expect(execCli('setup', { cwd, env })).toContain('Git hooks are already installed.');
+  expect(execCli('setup', { cwd, env })).toBe('');
 });
 
 test('skips non-Git directories without creating files', ({ execCli, expect }) => {


### PR DESCRIPTION
## Summary

`rs setup` currently logs on both the first successful installation and subsequent no-op runs, unlike Husky's silent success behavior. This PR makes both successful states silent while retaining skip and failure diagnostics.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/90