### PR TITLE
release: v0.2.0

### DIFF
--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rstack",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "repository": "https://github.com/rstackjs/rstack-cli",
   "bin": {


### PR DESCRIPTION
## Summary

- bump the `rstack` package version from 0.1.0 to 0.2.0

## Testing

- not run (version-only metadata change)