### PR TITLE
feat(setup): support custom Git hooks directories

### DIFF
--- a/packages/rstack/src/setup/index.ts
+++ b/packages/rstack/src/setup/index.ts
@@ -10,24 +10,33 @@ ${color.yellow('  $ rs setup [options]')}
 Install Git hooks in the current repository.
 
 ${color.cyan('Options')}:
-  -h, --help  Display this help message`;
+  --hooks-dir <path>  Specify hooks directory relative to the current directory
+  -h, --help          Display this help message`;
 
 export const runSetupCLI = (args: string[]): void => {
   const { values } = parseArgs({
     args,
     options: {
       help: { type: 'boolean', short: 'h' },
+      'hooks-dir': { type: 'string', multiple: true },
     },
     allowPositionals: false,
     strict: true,
   });
+
+  const hooksDirs = values['hooks-dir'];
+  if (hooksDirs && hooksDirs.length > 1) {
+    throw new Error('The --hooks-dir option cannot be specified more than once.');
+  }
+
+  const hooksDir = hooksDirs?.[0];
 
   if (values.help) {
     console.log(helpMessage);
     return;
   }
 
-  const result = installHooks();
+  const result = installHooks({ hooksDir });
 
   if (result.status === 'installed' || result.status === 'unchanged') {
     return;

--- a/packages/rstack/src/setup/install.ts
+++ b/packages/rstack/src/setup/install.ts
@@ -3,8 +3,13 @@ import { chmodSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'nod
 import path from 'node:path';
 import { createHookFiles } from './hooks.ts';
 
-const hooksPath = '.rstack/hooks/_';
+const defaultHooksDir = '.rstack/hooks';
 const gitignore = '*\n';
+
+type InstallHooksOptions = {
+  cwd?: string;
+  hooksDir?: string;
+};
 
 type InstallResult =
   | { status: 'installed'; hooksPath: string }
@@ -19,6 +24,8 @@ const fail = (reason: string, message: string): InstallResult => ({
 });
 
 const runGit = (cwd: string, args: string[]) => spawnSync('git', args, { cwd, encoding: 'utf8' });
+
+const removeLineEnding = (value: string): string => value.replace(/\r?\n$/u, '');
 
 const gitFailure = (error: NodeJS.ErrnoException | undefined, stderr: string): InstallResult => {
   if (error?.code === 'ENOENT') {
@@ -40,7 +47,10 @@ const isCurrentFile = (filePath: string, content: string, executable = false): b
   }
 };
 
-export const installHooks = (cwd: string = process.cwd()): InstallResult => {
+export const installHooks = ({
+  cwd = process.cwd(),
+  hooksDir = defaultHooksDir,
+}: InstallHooksOptions = {}): InstallResult => {
   if (process.env.RSTACK_HOOKS === '0') {
     return { status: 'skipped', reason: 'disabled' };
   }
@@ -54,6 +64,21 @@ export const installHooks = (cwd: string = process.cwd()): InstallResult => {
     return { status: 'skipped', reason: 'not-git-repository' };
   }
 
+  const prefixResult = runGit(cwd, ['rev-parse', '--show-prefix']);
+  if (prefixResult.error || prefixResult.status === null) {
+    return gitFailure(prefixResult.error, prefixResult.stderr);
+  }
+  if (prefixResult.status !== 0) {
+    return fail(
+      'git-command-failed',
+      `Failed to resolve the Git repository prefix: ${prefixResult.stderr.trim()}`,
+    );
+  }
+
+  const prefix = removeLineEnding(prefixResult.stdout).replaceAll('\\', '/');
+  const resolvedHooksDir = hooksDir.replaceAll('\\', '/');
+  const hooksPath = `${prefix}${resolvedHooksDir}/_`;
+
   const config = runGit(cwd, ['config', '--local', '--get', 'core.hooksPath']);
   if (config.error || config.status === null) {
     return gitFailure(config.error, config.stderr);
@@ -62,11 +87,11 @@ export const installHooks = (cwd: string = process.cwd()): InstallResult => {
     return fail('git-config-failed', `Failed to read core.hooksPath: ${config.stderr.trim()}`);
   }
 
-  const directory = path.join(cwd, hooksPath);
+  const directory = path.join(cwd, resolvedHooksDir, '_');
   const files = Object.entries(createHookFiles());
   // Skip all writes only when the config, generated content, and executable modes match.
   const unchanged =
-    config.stdout.trim() === hooksPath &&
+    removeLineEnding(config.stdout) === hooksPath &&
     isCurrentFile(path.join(directory, '.gitignore'), gitignore) &&
     files.every(([name, content]) => isCurrentFile(path.join(directory, name), content, true));
 

--- a/packages/rstack/tests/cli/setup/index.test.ts
+++ b/packages/rstack/tests/cli/setup/index.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach } from 'rstack/test';
@@ -24,6 +24,13 @@ const initRepository = (): void => {
   git(['config', '--local', 'user.email', 'test@rstack.dev']);
 };
 
+const runSetup = (args: string[], runCwd: string = cwd) =>
+  spawnSync(process.execPath, [RSTACK_BIN_PATH, 'setup', ...args], {
+    cwd: runCwd,
+    encoding: 'utf8',
+    env,
+  });
+
 beforeEach(() => {
   cwd = mkdtempSync(path.join(tmpdir(), 'rstack setup '));
   env = {
@@ -44,11 +51,22 @@ test('displays setup help', ({ execCli, expect }) => {
 
   expect(execCli('setup -h', { cwd })).toBe(output);
   expect(output).toContain('Usage:\n  $ rs setup [options]');
+  expect(output).toContain('--hooks-dir <path>');
   expect(output).toContain('-h, --help');
 });
 
 test('rejects unknown setup options', ({ execCli, expect }) => {
   expect(() => execCli('setup --unknown', { cwd })).toThrow();
+});
+
+test('reports missing and repeated hooks directory options', ({ expect }) => {
+  const missing = runSetup(['--hooks-dir']);
+  expect(missing.status).toBe(1);
+  expect(missing.stderr).toContain('--hooks-dir');
+
+  const repeated = runSetup(['--hooks-dir', 'first', '--hooks-dir', 'second']);
+  expect(repeated.status).toBe(1);
+  expect(repeated.stderr).toContain('The --hooks-dir option cannot be specified more than once.');
 });
 
 test('installs hooks silently without loading Rstack config', ({ execCli, expect }) => {
@@ -61,6 +79,16 @@ test('installs hooks silently without loading Rstack config', ({ execCli, expect
   expect(existsSync(path.join(cwd, '.rstack', 'hooks', 'pre-commit'))).toBe(false);
 
   expect(execCli('setup', { cwd, env })).toBe('');
+});
+
+test('installs a custom hooks directory from a nested project', ({ execCli, expect }) => {
+  initRepository();
+  const projectDirectory = path.join(cwd, 'frontend');
+  mkdirSync(projectDirectory);
+
+  expect(execCli('setup --hooks-dir "custom hooks"', { cwd: projectDirectory, env })).toBe('');
+  expect(git(['config', '--local', '--get', 'core.hooksPath'])).toBe('frontend/custom hooks/_');
+  expect(existsSync(path.join(projectDirectory, 'custom hooks', '_', 'runner'))).toBe(true);
 });
 
 test('skips non-Git directories without creating files', ({ execCli, expect }) => {

--- a/packages/rstack/tests/setup/install.test.ts
+++ b/packages/rstack/tests/setup/install.test.ts
@@ -15,7 +15,8 @@ import { expect, test } from 'rstack/test';
 import { createHookFiles } from '../../src/setup/hooks.ts';
 import { installHooks } from '../../src/setup/install.ts';
 
-const hooksPath = '.rstack/hooks/_';
+const hooksDir = '.rstack/hooks';
+const hooksPath = `${hooksDir}/_`;
 
 const git = (cwd: string, args: string[], env: NodeJS.ProcessEnv = process.env) =>
   spawnSync('git', args, { cwd, encoding: 'utf8', env });
@@ -58,8 +59,8 @@ const hookEnv = (cwd: string, value?: string): NodeJS.ProcessEnv => {
   return env;
 };
 
-const writeHook = (cwd: string, content: string): void => {
-  const filePath = path.join(cwd, '.rstack', 'hooks', 'pre-commit');
+const writeHook = (cwd: string, content: string, directory = hooksDir): void => {
+  const filePath = path.join(cwd, directory, 'pre-commit');
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, content);
 };
@@ -98,7 +99,7 @@ const withRepository = (callback: (cwd: string) => void): void =>
 
 test('installs generated hooks and configures the repository', () => {
   withRepository((cwd) => {
-    expect(installHooks(cwd)).toEqual({ status: 'installed', hooksPath });
+    expect(installHooks({ cwd })).toEqual({ status: 'installed', hooksPath });
     expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(hooksPath);
 
     const directory = path.join(cwd, hooksPath);
@@ -115,6 +116,68 @@ test('installs generated hooks and configures the repository', () => {
   });
 });
 
+test('installs a custom hooks directory from the Git root and runs its hook', () => {
+  withRepository((cwd) => {
+    const customHooksDir = 'frontend/custom hooks';
+    const customHooksPath = `${customHooksDir}/_`;
+    writeHook(cwd, "printf 'ran\\n' > custom-hook-ran\n", customHooksDir);
+
+    expect(installHooks({ cwd, hooksDir: customHooksDir })).toEqual({
+      status: 'installed',
+      hooksPath: customHooksPath,
+    });
+    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(customHooksPath);
+    expect(existsSync(path.join(cwd, customHooksPath, 'runner'))).toBe(true);
+
+    stage(cwd, 'file.txt');
+    expect(commit(cwd).status).toBe(0);
+    expect(readFileSync(path.join(cwd, 'custom-hook-ran'), 'utf8')).toBe('ran\n');
+  });
+});
+
+test('installs the default hooks directory from a nested project', () => {
+  withRepository((cwd) => {
+    const projectDirectory = path.join(cwd, 'frontend');
+    const nestedHooksPath = `frontend/${hooksPath}`;
+    mkdirSync(projectDirectory);
+    writeHook(
+      projectDirectory,
+      `printf 'root\\n' > nested-hook-cwd
+cd frontend
+printf 'nested\\n' > nested-hook-ran
+`,
+    );
+
+    expect(installHooks({ cwd: projectDirectory })).toEqual({
+      status: 'installed',
+      hooksPath: nestedHooksPath,
+    });
+    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(nestedHooksPath);
+    expect(existsSync(path.join(projectDirectory, hooksPath, 'runner'))).toBe(true);
+
+    stage(cwd, 'file.txt');
+    expect(commit(cwd).status).toBe(0);
+    expect(readFileSync(path.join(cwd, 'nested-hook-cwd'), 'utf8')).toBe('root\n');
+    expect(readFileSync(path.join(projectDirectory, 'nested-hook-ran'), 'utf8')).toBe('nested\n');
+  });
+});
+
+test('installs a custom hooks directory from a nested project', () => {
+  withRepository((cwd) => {
+    const projectDirectory = path.join(cwd, 'frontend app');
+    mkdirSync(projectDirectory);
+
+    expect(installHooks({ cwd: projectDirectory, hooksDir: 'config\\hooks' })).toEqual({
+      status: 'installed',
+      hooksPath: 'frontend app/config/hooks/_',
+    });
+    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(
+      'frontend app/config/hooks/_',
+    );
+    expect(existsSync(path.join(projectDirectory, 'config', 'hooks', '_', 'runner'))).toBe(true);
+  });
+});
+
 test('is idempotent and preserves user hooks', () => {
   withRepository((cwd) => {
     const userDirectory = path.join(cwd, '.rstack', 'hooks');
@@ -122,8 +185,8 @@ test('is idempotent and preserves user hooks', () => {
     mkdirSync(userDirectory, { recursive: true });
     writeFileSync(userHook, 'echo user hook\n');
 
-    expect(installHooks(cwd).status).toBe('installed');
-    expect(installHooks(cwd)).toEqual({ status: 'unchanged', hooksPath });
+    expect(installHooks({ cwd }).status).toBe('installed');
+    expect(installHooks({ cwd })).toEqual({ status: 'unchanged', hooksPath });
 
     expect(readFileSync(userHook, 'utf8')).toBe('echo user hook\n');
     expect(existsSync(path.join(userDirectory, 'commit-msg'))).toBe(false);
@@ -132,18 +195,18 @@ test('is idempotent and preserves user hooks', () => {
 
 test.runIf(process.platform !== 'win32')('restores executable mode on existing shims', () => {
   withRepository((cwd) => {
-    expect(installHooks(cwd).status).toBe('installed');
+    expect(installHooks({ cwd }).status).toBe('installed');
     const shim = path.join(cwd, hooksPath, 'pre-commit');
     chmodSync(shim, 0o644);
 
-    expect(installHooks(cwd).status).toBe('installed');
+    expect(installHooks({ cwd }).status).toBe('installed');
     expect(statSync(shim).mode & 0o777).toBe(0o755);
   });
 });
 
 test('skips non-Git directories without creating files', () => {
   withDirectory((cwd) => {
-    expect(installHooks(cwd)).toEqual({
+    expect(installHooks({ cwd })).toEqual({
       status: 'skipped',
       reason: 'not-git-repository',
     });
@@ -156,7 +219,7 @@ test('reports when Git is unavailable', () => {
     const originalPath = process.env.PATH;
     process.env.PATH = '';
     try {
-      expect(installHooks(cwd)).toEqual({
+      expect(installHooks({ cwd })).toEqual({
         status: 'failed',
         reason: 'git-not-found',
         message: 'Git command not found.',
@@ -171,7 +234,7 @@ test('does not configure Git when writing generated files fails', () => {
   withRepository((cwd) => {
     writeFileSync(path.join(cwd, '.rstack'), 'not a directory');
 
-    expect(installHooks(cwd)).toMatchObject({
+    expect(installHooks({ cwd })).toMatchObject({
       status: 'failed',
       reason: 'write-failed',
     });
@@ -183,7 +246,7 @@ test('reports Git configuration failures without changing hooksPath', () => {
   withRepository((cwd) => {
     writeFileSync(path.join(cwd, '.git', 'config.lock'), 'locked');
 
-    expect(installHooks(cwd)).toMatchObject({
+    expect(installHooks({ cwd })).toMatchObject({
       status: 'failed',
       reason: 'git-config-failed',
     });
@@ -214,7 +277,7 @@ rstack-hook-command
 `,
     );
 
-    expect(installHooks(cwd).status).toBe('installed');
+    expect(installHooks({ cwd }).status).toBe('installed');
     stage(cwd, 'file.txt');
 
     expect(commit(cwd).status).toBe(0);
@@ -226,7 +289,7 @@ rstack-hook-command
 test('skips user hooks when disabled by the environment or init', () => {
   withRepository((cwd) => {
     writeHook(cwd, 'echo ran >> hook-ran\n');
-    expect(installHooks(cwd).status).toBe('installed');
+    expect(installHooks({ cwd }).status).toBe('installed');
 
     stage(cwd, 'first.txt');
     expect(commit(cwd, '0').status).toBe(0);
@@ -243,7 +306,7 @@ test('skips user hooks when disabled by the environment or init', () => {
 test('traces and reports hook failures and command lookup errors', () => {
   withRepository((cwd) => {
     writeHook(cwd, 'exit 23\n');
-    expect(installHooks(cwd).status).toBe('installed');
+    expect(installHooks({ cwd }).status).toBe('installed');
     stage(cwd, 'file.txt');
 
     const failed = commit(cwd, '2');


### PR DESCRIPTION
## Summary

This PR lets `rs setup` install Git hooks in a custom cwd-relative directory and from nested projects. It adds `--hooks-dir`, derives the repository-relative `core.hooksPath` from Git's current prefix, and normalizes Windows path separators. Integration coverage verifies root and nested installation, paths with spaces, and real hook execution.