### PR TITLE
docs: link staged and setup guides

### DIFF
--- a/website/docs/en/guide/cli/staged.mdx
+++ b/website/docs/en/guide/cli/staged.mdx
@@ -2,7 +2,9 @@
 
 The `rs staged` command uses [lint-staged](https://github.com/lint-staged/lint-staged) to run tasks against files staged in Git.
 
-A common use case is to run linters, formatters, or other checks on staged files before committing code.
+`rs staged` can run linters, formatters, or other checks on staged files before committing code.
+
+A common pattern is to pair `rs staged` with [`rs setup`](./setup) and run staged-file tasks from a `pre-commit` hook.
 
 ## Usage
 

--- a/website/docs/zh/guide/cli/staged.mdx
+++ b/website/docs/zh/guide/cli/staged.mdx
@@ -2,7 +2,9 @@
 
 `rs staged` 命令使用 [lint-staged](https://github.com/lint-staged/lint-staged) 对 Git 暂存文件运行任务。
 
-常见的使用场景是在提交代码前，对暂存文件运行 linter、格式化工具或其他检查。
+`rs staged` 可用于在提交代码前，对暂存文件运行 linter、格式化工具或其他检查。
+
+常见做法是将 `rs staged` 与 [`rs setup`](./setup) 配合使用，通过 `pre-commit` hook 运行暂存文件任务。
 
 ## 用法 \{#usage}
 


### PR DESCRIPTION
`rs staged` and `rs setup` are commonly used together to run staged-file tasks from a `pre-commit` hook.

This PR updates the English and Chinese staged command guides to describe that workflow and link to the setup guide.