### PR TITLE
chore(deps): move load-config to rstack package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "test": "pnpm --filter './packages/**' test"
   },
   "devDependencies": {
-    "@rstackjs/load-config": "catalog:",
     "@types/node": "catalog:",
     "cspell-ban-words": "catalog:",
     "oxfmt": "catalog:",

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@rspress/core": "catalog:",
+    "@rstackjs/load-config": "catalog:",
     "@rstackjs/test-utils": "catalog:",
     "@rstest/adapter-rsbuild": "catalog:",
     "@rstest/adapter-rslib": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,6 @@ importers:
 
   .:
     devDependencies:
-      '@rstackjs/load-config':
-        specifier: 'catalog:'
-        version: 0.1.2
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -307,6 +304,9 @@ importers:
       '@rspress/core':
         specifier: 'catalog:'
         version: 2.0.18(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
+      '@rstackjs/load-config':
+        specifier: 'catalog:'
+        version: 0.1.2
       '@rstackjs/test-utils':
         specifier: 'catalog:'
         version: 0.2.0


### PR DESCRIPTION
This PR declares `@rstackjs/load-config` in the `rstack` workspace that imports and bundles it. It removes the misplaced root dependency and keeps pnpm's workspace importer metadata aligned with actual ownership.