### PR TITLE
docs: add Git hook migration guide

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/SKILL.md
+++ b/.agents/skills/migrate-to-rstack-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migrate-to-rstack-cli
-description: Use when migrating projects from standalone Rsbuild, Rslib, Rstest, Rslint, Rspress, or lint-staged tooling to the unified `rstack` package, `rs` commands, and `rstack.config.*`.
+description: Use when migrating projects from standalone Rsbuild, Rslib, Rstest, Rslint, Rspress, lint-staged, husky or simple-git-hooks tooling to the unified `rstack` package, `rs` commands, and `rstack.config.*`.
 ---
 
 # Migrate to Rstack CLI
@@ -17,13 +17,14 @@ Read every matching reference before editing. Load only the tools present in the
 - `@rslint/core`, `rslint.config.*`, `rslint` commands, or lint imports: [rslint.mdx](references/rslint.mdx)
 - `@rspress/core`, `rspress.config.*`, `rspress` commands, themes, or plugins: [rspress.mdx](references/rspress.mdx)
 - `lint-staged`, `nano-staged`, their configs: [lint-staged.mdx](references/lint-staged.mdx)
+- `husky`, `.husky/`, `package.json#husky`, `simple-git-hooks`, `.simple-git-hooks.*`, or Git hook installer scripts: [git-hooks.mdx](references/git-hooks.mdx)
 
 ## Workflow
 
 1. Inspect manifests, workspace catalogs, lock files, scripts, standalone configs, Git hooks, TypeScript `types`, and source imports.
 2. Read the matching references and inventory behavior that must survive: config functions, CLI arguments, plugins, presets, adapters, custom config paths, and chained commands.
 3. Check the latest `rstack` version and inspect its Node.js engine and underlying tool versions. Resolve plugin and adapter peer ranges first; upgrade incompatible extensions or stop when no compatible version exists. Add `rstack` using the repository's existing package manager and version convention, usually as a development dependency.
-4. Create `rstack.config.ts`. Move each standalone config into its corresponding `define.*` registration.
+4. If a matching reference uses a `define.*` registration, create `rstack.config.ts` and move the standalone configuration into it.
 5. Rewrite commands and imports as directed by the references.
 6. Search again for old direct imports, binaries, config paths, manifest entries, and type references. Remove only entries with no remaining direct or runtime use and no unresolved peer compatibility requirement.
 7. Delete a standalone config only after its behavior is represented in `rstack.config.*`.

--- a/.agents/skills/migrate-to-rstack-cli/references/git-hooks.mdx
+++ b/.agents/skills/migrate-to-rstack-cli/references/git-hooks.mdx
@@ -1,0 +1,75 @@
+# Git Hook Migration
+
+Migrate [Husky](https://typicode.github.io/husky/) or [simple-git-hooks](https://github.com/toplenboren/simple-git-hooks#readme) to [`rs setup`](https://rstack.rs/guide/cli/setup). If a hook calls lint-staged or nano-staged, also read [lint-staged.mdx](lint-staged.mdx).
+
+## Shared Steps
+
+1. Inspect the hook manager configuration, hook scripts, lifecycle scripts, custom paths, environment overrides, and `git config --local --get core.hooksPath`.
+2. Inventory every active hook before editing. Confirm each hook is [supported by `rs setup`](https://rstack.rs/guide/cli/setup#supported-hooks); stop or design an explicit alternative for unsupported hooks.
+3. Create each migrated hook in the selected hooks directory, `.rstack/hooks` by default, before running `rs setup`, because the command changes the repository's `core.hooksPath`. Preserve commands and any explicit directory changes.
+4. Ensure the `prepare` script in the root `package.json` runs `rs setup`, adding it if necessary. Remove the old installer invocation from any lifecycle script while preserving other commands. Use `--hooks-dir` consistently when choosing a custom directory.
+5. Run the updated lifecycle script, exercise the migrated hooks, and remove the old dependency and configuration only after behavior matches.
+
+## Husky
+
+1. Locate the source hooks:
+   - Husky v5 and newer: files such as `.husky/pre-commit`; exclude the generated `.husky/_` directory.
+   - Husky v4: `package.json#husky.hooks` or `.huskyrc*` configuration.
+2. Move each hook body to the corresponding file in the selected hooks directory. Remove lines that source `.husky/_/husky.sh`; keep the reusable POSIX shell commands.
+3. Replace Husky lifecycle invocations such as `husky`, `husky install`, or a custom Husky directory command with `rs setup` or `rs setup --hooks-dir <path>`.
+4. Replace `HUSKY=0`, `HUSKY_SKIP_HOOKS`, and `HUSKY_SKIP_INSTALL` usage with `RSTACK_HOOKS=0`. Replace `HUSKY_GIT_PARAMS` with Git's positional hook arguments such as `$1`.
+5. Tell users who rely on `$XDG_CONFIG_HOME/husky/init.sh`, `~/.config/husky/init.sh`, or the deprecated `~/.huskyrc` to move the required shell setup to `$XDG_CONFIG_HOME/rstack/hooks-init.sh` or `~/.config/rstack/hooks-init.sh`. Do not edit user-level files without permission.
+6. After validation, remove the Husky dependency and old hook directory.
+
+For example, migrate:
+
+```sh title=".husky/pre-commit"
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+pnpm test
+```
+
+to:
+
+```sh title=".rstack/hooks/pre-commit"
+pnpm test
+```
+
+## simple-git-hooks
+
+1. Load the active configuration from `package.json#simple-git-hooks`, a `.simple-git-hooks.{js,cjs,mjs,json}` or `simple-git-hooks.{js,cjs,mjs,json}` file, or the custom path passed to its CLI. Use the configuration values instead of copying generated files from the Git hooks directory.
+2. Create one file in the selected hooks directory for each configured command, using the hook name as the file name. Ignore `preserveUnused` as a command, but inspect and migrate any existing hooks that it preserves.
+3. Replace the simple-git-hooks lifecycle command with `rs setup`, preserving other chained commands.
+4. Replace `SKIP_INSTALL_SIMPLE_GIT_HOOKS=1` and `SKIP_SIMPLE_GIT_HOOKS=1` usage with `RSTACK_HOOKS=0`. Move required commands from the file referenced by `SIMPLE_GIT_HOOKS_RC` to the Rstack user initialization file, with user permission.
+5. Do not run the simple-git-hooks uninstall script after `rs setup`; it follows the current `core.hooksPath` and can delete Rstack's generated hook shims.
+6. After validation, remove the simple-git-hooks dependency, configuration, and installer command. Remove old generated hook files only after confirming their ownership and exact paths.
+
+For example, migrate:
+
+```json title="package.json"
+{
+  "scripts": {
+    "prepare": "existing-command && simple-git-hooks"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "pnpm lint",
+    "pre-push": "pnpm test"
+  }
+}
+```
+
+to `"prepare": "existing-command && rs setup"` and these hook files:
+
+```sh title=".rstack/hooks/pre-commit"
+pnpm lint
+```
+
+```sh title=".rstack/hooks/pre-push"
+pnpm test
+```
+
+## Validate
+
+- Confirm `git config --local --get core.hooksPath` points to the expected Rstack-generated directory.
+- Test each migrated hook and confirm that its commands run as expected.
+- Search for old manager commands, configuration, environment variables, and user instructions before removing dependencies.

--- a/.agents/skills/migrate-to-rstack-cli/references/git-hooks.mdx
+++ b/.agents/skills/migrate-to-rstack-cli/references/git-hooks.mdx
@@ -17,7 +17,7 @@ Migrate [Husky](https://typicode.github.io/husky/) or [simple-git-hooks](https:/
    - Husky v4: `package.json#husky.hooks` or `.huskyrc*` configuration.
 2. Move each hook body to the corresponding file in the selected hooks directory. Remove lines that source `.husky/_/husky.sh`; keep the reusable POSIX shell commands.
 3. Replace Husky lifecycle invocations such as `husky`, `husky install`, or a custom Husky directory command with `rs setup` or `rs setup --hooks-dir <path>`.
-4. Replace `HUSKY=0`, `HUSKY_SKIP_HOOKS`, and `HUSKY_SKIP_INSTALL` usage with `RSTACK_HOOKS=0`. Replace `HUSKY_GIT_PARAMS` with Git's positional hook arguments such as `$1`.
+4. Replace `HUSKY=0`, `HUSKY_SKIP_HOOKS`, and `HUSKY_SKIP_INSTALL` usage with `RSTACK_HOOKS=0`. Replace `HUSKY_GIT_PARAMS` with the positional arguments expected by each hook. For example, change `commitlint -E HUSKY_GIT_PARAMS` to `commitlint --edit "$1"`.
 5. Tell users who rely on `$XDG_CONFIG_HOME/husky/init.sh`, `~/.config/husky/init.sh`, or the deprecated `~/.huskyrc` to move the required shell setup to `$XDG_CONFIG_HOME/rstack/hooks-init.sh` or `~/.config/rstack/hooks-init.sh`. Do not edit user-level files without permission.
 6. After validation, remove the Husky dependency and old hook directory.
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -2,6 +2,7 @@
 applypatch
 errexit
 fnames
+huskyrc
 llms
 nosystem
 oxfmt


### PR DESCRIPTION
## Summary

Projects using Husky or simple-git-hooks need explicit migration guidance when adopting `rs setup`. This PR adds a focused reference covering lifecycle scripts, custom hook directories, environment compatibility, cleanup, and staged-file integration.

## Related Links

- https://rstack.rs/guide/cli/setup