### PR TITLE
chore: add Husky third-party notice

### DIFF
--- a/packages/rstack/THIRD_PARTY_NOTICES.md
+++ b/packages/rstack/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,31 @@
+# Third-Party Notices
+
+This package includes software developed by third parties.
+
+## Husky
+
+Portions of the Git hook installer and runtime are derived from [Husky](https://github.com/typicode/husky).
+
+License: MIT
+
+MIT License
+
+Copyright (c) 2021 typicode
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -10,7 +10,8 @@
   "files": [
     "bin",
     "dist",
-    "types"
+    "types",
+    "THIRD_PARTY_NOTICES.md"
   ],
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -18,3 +18,4 @@ rstest
 shiki
 shikijs
 turborepo
+typicode


### PR DESCRIPTION
## Summary

The Git hook installer and runtime derive behavior from Husky, so the published package needs to preserve Husky's MIT notice. This PR adds the full license text to a third-party notices file and includes it in the `rstack` package tarball.

## Related Links

- https://github.com/typicode/husky/blob/main/LICENSE