### PR TITLE
chore: expand third-party notices

### DIFF
--- a/cspell.config.js
+++ b/cspell.config.js
@@ -13,7 +13,15 @@ export default {
     // ignore release note author mentions such as "by @chenjiahan"
     'by\\s+@[A-Za-z0-9_-]+',
   ],
-  ignorePaths: ['dist', 'dist-*', 'coverage', 'doc_build', 'node_modules', 'pnpm-lock.yaml'],
+  ignorePaths: [
+    'dist',
+    'dist-*',
+    'coverage',
+    'doc_build',
+    'node_modules',
+    'packages/rstack/THIRD_PARTY_NOTICES.md',
+    'pnpm-lock.yaml',
+  ],
   flagWords: banWords,
   dictionaries: ['dictionary'],
   dictionaryDefinitions: [

--- a/packages/rstack/THIRD_PARTY_NOTICES.md
+++ b/packages/rstack/THIRD_PARTY_NOTICES.md
@@ -29,3 +29,115 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+## fresh-import
+
+This package includes bundled code from [fresh-import](https://github.com/sapphi-red/fresh-import), version 0.2.1.
+
+License: MIT
+
+MIT License
+
+Copyright (c) 2026 sapphi-red
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## lint-staged
+
+This package includes bundled code from [lint-staged](https://github.com/lint-staged/lint-staged), version 17.2.0.
+
+License: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Andrey Okonetchnikov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## picomatch
+
+This package includes bundled code from [picomatch](https://github.com/micromatch/picomatch), version 4.0.5.
+
+License: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2017-present, Jon Schlinkert.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+## tinyexec
+
+This package includes bundled code from [tinyexec](https://github.com/tinylibs/tinyexec), version 1.2.4.
+
+License: MIT
+
+MIT License
+
+Copyright (c) 2024 Tinylibs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/rstack/THIRD_PARTY_NOTICES.md
+++ b/packages/rstack/THIRD_PARTY_NOTICES.md
@@ -32,7 +32,7 @@ SOFTWARE.
 
 ## fresh-import
 
-This package includes bundled code from [fresh-import](https://github.com/sapphi-red/fresh-import), version 0.2.1.
+This package includes bundled code from [fresh-import](https://github.com/sapphi-red/fresh-import).
 
 License: MIT
 
@@ -60,7 +60,7 @@ SOFTWARE.
 
 ## lint-staged
 
-This package includes bundled code from [lint-staged](https://github.com/lint-staged/lint-staged), version 17.2.0.
+This package includes bundled code from [lint-staged](https://github.com/lint-staged/lint-staged).
 
 License: MIT
 
@@ -88,7 +88,7 @@ SOFTWARE.
 
 ## picomatch
 
-This package includes bundled code from [picomatch](https://github.com/micromatch/picomatch), version 4.0.5.
+This package includes bundled code from [picomatch](https://github.com/micromatch/picomatch).
 
 License: MIT
 
@@ -116,7 +116,7 @@ THE SOFTWARE.
 
 ## tinyexec
 
-This package includes bundled code from [tinyexec](https://github.com/tinylibs/tinyexec), version 1.2.4.
+This package includes bundled code from [tinyexec](https://github.com/tinylibs/tinyexec).
 
 License: MIT
 

--- a/packages/rstack/THIRD_PARTY_NOTICES.md
+++ b/packages/rstack/THIRD_PARTY_NOTICES.md
@@ -2,15 +2,15 @@
 
 This package includes software developed by third parties.
 
-## Husky
+## fresh-import
 
-Portions of the Git hook installer and runtime are derived from [Husky](https://github.com/typicode/husky).
+This package includes bundled code from [fresh-import](https://github.com/sapphi-red/fresh-import).
 
 License: MIT
 
 MIT License
 
-Copyright (c) 2021 typicode
+Copyright (c) 2026 sapphi-red
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -30,15 +30,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-## fresh-import
+## Husky
 
-This package includes bundled code from [fresh-import](https://github.com/sapphi-red/fresh-import).
+Portions of the Git hook installer and runtime are derived from [Husky](https://github.com/typicode/husky).
 
 License: MIT
 
 MIT License
 
-Copyright (c) 2026 sapphi-red
+Copyright (c) 2021 typicode
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,10 +1,12 @@
 # Custom Dictionary Words
+andrey
 applypatch
 errexit
 fnames
 huskyrc
 llms
 nosystem
+okonetchnikov
 oxfmt
 rsbuild
 rslib
@@ -15,7 +17,11 @@ rspress
 rstack
 rstackjs
 rstest
+sapphi
+schlinkert
 shiki
 shikijs
+tinyexec
+tinylibs
 turborepo
 typicode

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,12 +1,10 @@
 # Custom Dictionary Words
-andrey
 applypatch
 errexit
 fnames
 huskyrc
 llms
 nosystem
-okonetchnikov
 oxfmt
 rsbuild
 rslib
@@ -17,11 +15,7 @@ rspress
 rstack
 rstackjs
 rstest
-sapphi
-schlinkert
 shiki
 shikijs
-tinyexec
-tinylibs
 turborepo
 typicode


### PR DESCRIPTION
## Summary

The `rstack` package bundles `fresh-import`, `lint-staged`, `picomatch`, and `tinyexec`, so their MIT notices need to ship with the published tarball. This PR adds their notices and copyright texts to `THIRD_PARTY_NOTICES.md`, then excludes that file from cspell so upstream names do not need to be maintained in the custom dictionary.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/101