### PR TITLE
chore(ci): add heading case check

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "build": "pnpm --filter './packages/**' build",
     "check:format": "oxfmt . --check",
-    "check:spell": "pnpm dlx cspell",
+    "check:spell": "pnpm dlx cspell && heading-case",
     "doc": "pnpm --dir website dev",
     "doc:build": "node --run build && pnpm --dir website build",
-    "format": "oxfmt .",
+    "format": "oxfmt . && heading-case --write",
     "lint": "rs lint --type-check",
     "prepare": "node scripts/rs.js setup",
     "test": "pnpm --filter './packages/**' test"
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "cspell-ban-words": "catalog:",
+    "heading-case": "catalog:",
     "oxfmt": "catalog:",
     "rstack": "workspace:*",
     "typescript": "catalog:"

--- a/packages/rstack/tests/config/define-doc/docs/index.md
+++ b/packages/rstack/tests/config/define-doc/docs/index.md
@@ -1,3 +1,3 @@
-# Define Doc
+# Define doc
 
 define.doc works

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ catalogs:
     happy-dom:
       specifier: ^20.11.1
       version: 20.11.1
+    heading-case:
+      specifier: ^1.1.4
+      version: 1.1.4
     lint-staged:
       specifier: ^17.2.0
       version: 17.2.0
@@ -108,6 +111,9 @@ importers:
       cspell-ban-words:
         specifier: 'catalog:'
         version: 0.0.4
+      heading-case:
+        specifier: 'catalog:'
+        version: 1.1.4
       oxfmt:
         specifier: 'catalog:'
         version: 0.60.0
@@ -1430,6 +1436,10 @@ packages:
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  heading-case@1.1.4:
+    resolution: {integrity: sha512-UwPg0xcqLrmd6kSW93kxjy4FMqcb0o97IoTUy+TMvjCF8mJvi6X0h733DEaJO/Ch9h9dOyv0I0ckGoSsuUp9KA==}
+    hasBin: true
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
@@ -3193,6 +3203,8 @@ snapshots:
       hast-util-parse-selector: 4.0.0
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
+
+  heading-case@1.1.4: {}
 
   hookable@6.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,7 @@ catalog:
   '@shikijs/transformers': '^4.3.1'
   'cspell-ban-words': '^0.0.4'
   'happy-dom': '^20.11.1'
+  'heading-case': '^1.1.4'
   'lint-staged': '^17.2.0'
   'oxfmt': '^0.60.0'
   'react': '^19.2.8'


### PR DESCRIPTION
Markdown headings currently have no automated sentence-case validation, allowing inconsistent capitalization to enter the documentation. This PR adds `heading-case` 1.1.4 to the spell-check and formatting workflows and fixes the existing noncompliant fixture heading.

## Related Links

- https://github.com/rstackjs/heading-case/releases/tag/v1.1.4