### PR TITLE
perf(setup): reduce Git subprocess overhead

### DIFF
--- a/packages/rstack/src/setup/install.ts
+++ b/packages/rstack/src/setup/install.ts
@@ -84,26 +84,34 @@ export const installHooks = ({
   }
 
   // Check Git before touching the filesystem so non-repositories have no side effects.
-  const repository = runGit(cwd, ['rev-parse', '--is-inside-work-tree']);
+  const repository = runGit(cwd, ['rev-parse', '--is-inside-work-tree', '--show-prefix']);
   if (repository.error || repository.status === null) {
     return gitFailure(repository.error, repository.stderr);
   }
-  if (repository.status !== 0 || repository.stdout.trim() !== 'true') {
+
+  const firstLineEnd = repository.stdout.indexOf('\n');
+  const insideWorkTree = (
+    firstLineEnd === -1 ? repository.stdout : repository.stdout.slice(0, firstLineEnd)
+  ).trim();
+
+  if (repository.status !== 0) {
+    if (insideWorkTree === 'true') {
+      return fail(
+        'git-command-failed',
+        `Failed to resolve the Git repository prefix: ${repository.stderr.trim()}`,
+      );
+    }
     return { status: 'skipped', reason: 'not-git-repository' };
   }
 
-  const prefixResult = runGit(cwd, ['rev-parse', '--show-prefix']);
-  if (prefixResult.error || prefixResult.status === null) {
-    return gitFailure(prefixResult.error, prefixResult.stderr);
-  }
-  if (prefixResult.status !== 0) {
-    return fail(
-      'git-command-failed',
-      `Failed to resolve the Git repository prefix: ${prefixResult.stderr.trim()}`,
-    );
+  if (insideWorkTree !== 'true') {
+    return { status: 'skipped', reason: 'not-git-repository' };
   }
 
-  const prefix = removeLineEnding(prefixResult.stdout).replaceAll('\\', '/');
+  const prefix =
+    firstLineEnd === -1
+      ? ''
+      : removeLineEnding(repository.stdout.slice(firstLineEnd + 1)).replaceAll('\\', '/');
   const hooksPath = `${prefix}${resolvedDir}/_`;
 
   const config = runGit(cwd, ['config', '--local', '--get', 'core.hooksPath']);


### PR DESCRIPTION
## Summary

`rs setup` synchronously spawned separate Git processes for repository detection and prefix resolution on every normal run. This PR combines both queries into one `git rev-parse` call, reducing normal-path subprocess startup without changing hook installation behavior.

## Performance

Interleaved `hyperfine` A/B benchmarks on Node.js v24.12.0 and Git 2.50.1:

| Scenario | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Idempotent setup (60 runs) | 65.1 ms | 54.3 ms | 16.6% |
| Install/repair setup (40 runs) | 78.6 ms | 68.8 ms | 12.5% |