### PR TITLE
perf(setup): speed up repeated setup

### DIFF
--- a/packages/rstack/src/setup/install.ts
+++ b/packages/rstack/src/setup/install.ts
@@ -84,49 +84,47 @@ export const installHooks = ({
   }
 
   // Check Git before touching the filesystem so non-repositories have no side effects.
-  const repository = runGit(cwd, ['rev-parse', '--is-inside-work-tree', '--show-prefix']);
+  const repository = runGit(cwd, [
+    'rev-parse',
+    '--is-inside-work-tree',
+    '--show-prefix',
+    '--git-path',
+    'hooks',
+  ]);
   if (repository.error || repository.status === null) {
     return gitFailure(repository.error, repository.stderr);
   }
 
-  const firstLineEnd = repository.stdout.indexOf('\n');
-  const insideWorkTree = (
-    firstLineEnd === -1 ? repository.stdout : repository.stdout.slice(0, firstLineEnd)
-  ).trim();
+  const [insideWorkTree = '', repositoryPrefix, configuredHooksPath] = removeLineEnding(
+    repository.stdout,
+  ).split(/\r?\n/u);
 
   if (repository.status !== 0) {
-    if (insideWorkTree === 'true') {
+    if (insideWorkTree.trim() === 'true') {
       return fail(
         'git-command-failed',
-        `Failed to resolve the Git repository prefix: ${repository.stderr.trim()}`,
+        `Failed to resolve the Git repository paths: ${repository.stderr.trim()}`,
       );
     }
     return { status: 'skipped', reason: 'not-git-repository' };
   }
 
-  if (insideWorkTree !== 'true') {
+  if (insideWorkTree.trim() !== 'true') {
     return { status: 'skipped', reason: 'not-git-repository' };
   }
 
-  const prefix =
-    firstLineEnd === -1
-      ? ''
-      : removeLineEnding(repository.stdout.slice(firstLineEnd + 1)).replaceAll('\\', '/');
-  const hooksPath = `${prefix}${resolvedDir}/_`;
+  if (repositoryPrefix === undefined || configuredHooksPath === undefined) {
+    return fail('git-command-failed', 'Failed to resolve the Git repository paths.');
+  }
 
-  const config = runGit(cwd, ['config', '--local', '--get', 'core.hooksPath']);
-  if (config.error || config.status === null) {
-    return gitFailure(config.error, config.stderr);
-  }
-  if (config.status !== 0 && config.status !== 1) {
-    return fail('git-config-failed', `Failed to read core.hooksPath: ${config.stderr.trim()}`);
-  }
+  const prefix = repositoryPrefix.replaceAll('\\', '/');
+  const hooksPath = `${prefix}${resolvedDir}/_`;
 
   const directory = path.join(cwd, resolvedDir, '_');
   const files = Object.entries(createHookFiles());
   // Skip all writes only when the config, generated content, and executable modes match.
   const unchanged =
-    removeLineEnding(config.stdout) === hooksPath &&
+    path.resolve(cwd, configuredHooksPath) === path.resolve(directory) &&
     isCurrentFile(path.join(directory, '.gitignore'), gitignore) &&
     files.every(([name, content]) => isCurrentFile(path.join(directory, name), content, true));
 

--- a/packages/rstack/src/setup/install.ts
+++ b/packages/rstack/src/setup/install.ts
@@ -124,7 +124,7 @@ export const installHooks = ({
   const files = Object.entries(createHookFiles());
   // Skip all writes only when the config, generated content, and executable modes match.
   const unchanged =
-    path.resolve(cwd, configuredHooksPath) === path.resolve(directory) &&
+    path.resolve(cwd, configuredHooksPath) === directory &&
     isCurrentFile(path.join(directory, '.gitignore'), gitignore) &&
     files.every(([name, content]) => isCurrentFile(path.join(directory, name), content, true));
 

--- a/packages/rstack/tests/setup/directories.test.ts
+++ b/packages/rstack/tests/setup/directories.test.ts
@@ -39,6 +39,10 @@ printf 'nested\\n' > nested-hook-ran
       status: 'installed',
       hooksPath: nestedHooksPath,
     });
+    expect(installHooks({ cwd: projectDirectory })).toEqual({
+      status: 'unchanged',
+      hooksPath: nestedHooksPath,
+    });
     expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(nestedHooksPath);
     expect(existsSync(path.join(projectDirectory, hooksPath, 'runner'))).toBe(true);
 
@@ -55,6 +59,10 @@ test('installs a custom hooks directory from a nested project', () => {
 
     expect(installHooks({ cwd: projectDirectory, hooksDir: 'config\\hooks' })).toEqual({
       status: 'installed',
+      hooksPath: 'frontend app/config/hooks/_',
+    });
+    expect(installHooks({ cwd: projectDirectory, hooksDir: 'config\\hooks' })).toEqual({
+      status: 'unchanged',
       hooksPath: 'frontend app/config/hooks/_',
     });
     expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(


### PR DESCRIPTION
## Summary

This PR speeds up repeated `rs setup` runs by resolving the repository prefix and effective hooks path in one `git rev-parse` invocation, removing an extra Git subprocess while preserving nested and custom hooks directory behavior.

On macOS with Node.js v24.12.0, `hyperfine --warmup 10 --runs 50 'node packages/rstack/bin/rs.js setup'` measured mean latency decreasing from **56.59 ms** to **43.24 ms**, a **23.6% reduction**.

It also adds idempotency coverage for repeated setup from nested projects using default and custom hooks directories.