### PR TITLE
feat(fmt): establish formatter runtime boundary

### DIFF
--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -60,7 +60,8 @@
     "@rsbuild/core": "catalog:",
     "@rslib/core": "catalog:",
     "@rslint/core": "catalog:",
-    "@rstest/core": "catalog:"
+    "@rstest/core": "catalog:",
+    "prettier": "catalog:"
   },
   "devDependencies": {
     "@rspress/core": "catalog:",

--- a/packages/rstack/rslib.config.ts
+++ b/packages/rstack/rslib.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       lib: './src/lib.ts',
       lint: './src/lint.ts',
       test: './src/test.ts',
+      fmtWorker: './src/fmt/worker.ts',
     },
     define: {
       RSTACK_VERSION: JSON.stringify(pkgJson.version),

--- a/packages/rstack/src/fmt/worker.ts
+++ b/packages/rstack/src/fmt/worker.ts
@@ -1,0 +1,7 @@
+/**
+ * Internal build entry reserved for the fmt worker.
+ *
+ * The worker implementation is intentionally added by a later PR. Keeping a
+ * dedicated entry now establishes a stable published asset boundary.
+ */
+export {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ catalogs:
     oxfmt:
       specifier: ^0.60.0
       version: 0.60.0
+    prettier:
+      specifier: 3.9.6
+      version: 3.9.6
     react:
       specifier: ^19.2.8
       version: 19.2.8
@@ -306,6 +309,9 @@ importers:
       '@rstest/core':
         specifier: 'catalog:'
         version: 0.11.4(happy-dom@20.11.1)
+      prettier:
+        specifier: 'catalog:'
+        version: 3.9.6
     devDependencies:
       '@rspress/core':
         specifier: 'catalog:'
@@ -1776,6 +1782,11 @@ packages:
   postcss@8.5.19:
     resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -3816,6 +3827,8 @@ snapshots:
       nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prettier@3.9.6: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,7 @@ catalog:
   'heading-case': '^1.1.4'
   'lint-staged': '^17.2.0'
   'oxfmt': '^0.60.0'
+  prettier: '3.9.6'
   'react': '^19.2.8'
   'react-dom': '^19.2.8'
   'rsbuild-plugin-open-graph': '^1.1.3'


### PR DESCRIPTION
## Summary

This PR establishes the runtime boundary for the planned `rs fmt` command. It pins Prettier 3.9.6 as an Rstack dependency and adds an internal, separately built worker entry without exposing a formatter API or CLI command yet.
