### PR TITLE
feat(fmt): add define.fmt config registration

### DIFF
--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -5,6 +5,7 @@ import type { RslibConfigDefinition } from '@rslib/core';
 import type { RslintConfig } from '@rslint/core';
 import type { UserConfig, UserConfigAsyncFn } from '@rspress/core';
 import type { RstestConfigExport } from '@rstest/core';
+import type { FmtConfigDefinition } from './fmt/types.ts';
 import type { StagedConfig } from './staged.ts';
 
 export type RslintConfigDefinition = RslintConfig | (() => Promise<RslintConfig>);
@@ -16,6 +17,7 @@ export type Configs = {
   doc?: RspressConfigDefinition;
   test?: RstestConfigExport;
   lint?: RslintConfigDefinition;
+  fmt?: FmtConfigDefinition;
   staged?: StagedConfig;
 };
 
@@ -107,6 +109,12 @@ type Define = {
    */
   lint: (config: RslintConfig | (() => Promise<RslintConfig>)) => void;
   /**
+   * Defines the Prettier config for formatting.
+   *
+   * This config will be used by the `rs fmt` command.
+   */
+  fmt: (config: FmtConfigDefinition) => void;
+  /**
    * Defines the lint-staged config for staged files.
    *
    * This config is used by the `rs staged` command.
@@ -133,6 +141,7 @@ export const define: Define = {
   doc: (config) => setConfig('doc', config),
   test: (config) => setConfig('test', config),
   lint: (config) => setConfig('lint', config),
+  fmt: (config) => setConfig('fmt', config),
   staged: (config) => setConfig('staged', config),
 };
 

--- a/packages/rstack/src/fmt/types.ts
+++ b/packages/rstack/src/fmt/types.ts
@@ -1,0 +1,10 @@
+import type { Config as PrettierConfig } from 'prettier';
+
+interface FmtConfig extends PrettierConfig {
+  /** Gitignore-compatible patterns relative to the Rstack config root. */
+  ignorePatterns?: string[];
+}
+
+type FmtConfigDefinition = FmtConfig | (() => FmtConfig | Promise<FmtConfig>);
+
+export type { FmtConfig, FmtConfigDefinition };


### PR DESCRIPTION
## Summary

This PR establishes the configuration registration boundary for the future `rs fmt` command. It adds a flat, Prettier-compatible fmt config with `ignorePatterns` and lets `define.fmt` retain object, synchronous factory, or asynchronous factory definitions without adding a `rstack/fmt` export or runtime formatting behavior.

Automated coverage is intentionally deferred while the formatter configuration lifecycle is still being built.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/109