### PR TITLE
feat(fmt): normalize formatter config

### DIFF
--- a/packages/rstack/src/fmt/config.ts
+++ b/packages/rstack/src/fmt/config.ts
@@ -1,0 +1,15 @@
+import type { FmtConfig, ResolvedFmtConfig } from './types.ts';
+
+/** Splits a flat config into project-level formatting options and rules. */
+const normalizeFmtConfig = (config: FmtConfig | undefined, rootPath: string): ResolvedFmtConfig => {
+  const { ignorePatterns = [], overrides = [], ...baseOptions } = config ?? {};
+
+  return {
+    rootPath,
+    baseOptions,
+    overrides,
+    ignorePatterns,
+  };
+};
+
+export { normalizeFmtConfig };

--- a/packages/rstack/src/fmt/types.ts
+++ b/packages/rstack/src/fmt/types.ts
@@ -1,4 +1,4 @@
-import type { Config as PrettierConfig } from 'prettier';
+import type { Config as PrettierConfig, Options as PrettierOptions } from 'prettier';
 
 interface FmtConfig extends PrettierConfig {
   /** Gitignore-compatible patterns relative to the Rstack config root. */
@@ -7,4 +7,16 @@ interface FmtConfig extends PrettierConfig {
 
 type FmtConfigDefinition = FmtConfig | (() => FmtConfig | Promise<FmtConfig>);
 
-export type { FmtConfig, FmtConfigDefinition };
+/** Internal project config before per-file rules are applied. */
+interface ResolvedFmtConfig {
+  /** Root for relative patterns and plugin paths. */
+  rootPath: string;
+  /** Shared Prettier options before per-file overrides. */
+  baseOptions: PrettierOptions;
+  /** Per-file override rules. */
+  overrides: NonNullable<PrettierConfig['overrides']>;
+  /** Root-relative ignore patterns. */
+  ignorePatterns: string[];
+}
+
+export type { FmtConfig, FmtConfigDefinition, ResolvedFmtConfig };


### PR DESCRIPTION
## Summary

This PR introduces an internal normalized formatter config model so later `rs fmt` stages can consume project context, shared Prettier options, per-file overrides, and ignore patterns separately.

It adds a pure config transformation without I/O, config factory execution, or public exports.