### PR TITLE
feat(fmt): resolve formatter config

### DIFF
--- a/packages/rstack/src/fmt/config.ts
+++ b/packages/rstack/src/fmt/config.ts
@@ -1,4 +1,11 @@
-import type { FmtConfig, ResolvedFmtConfig } from './types.ts';
+import { dirname } from 'node:path';
+import type { FmtConfig, FmtConfigDefinition, ResolvedFmtConfig } from './types.ts';
+
+type ResolveFmtConfigOptions = {
+  definition: FmtConfigDefinition | undefined;
+  configFilePath: string | null;
+  cwd: string;
+};
 
 /** Splits a flat config into project-level formatting options and rules. */
 const normalizeFmtConfig = (config: FmtConfig | undefined, rootPath: string): ResolvedFmtConfig => {
@@ -12,4 +19,16 @@ const normalizeFmtConfig = (config: FmtConfig | undefined, rootPath: string): Re
   };
 };
 
-export { normalizeFmtConfig };
+/** Resolves a formatter config definition and its project root. */
+const resolveFmtConfig = async ({
+  definition,
+  configFilePath,
+  cwd,
+}: ResolveFmtConfigOptions): Promise<ResolvedFmtConfig> => {
+  const config = typeof definition === 'function' ? await definition() : definition;
+  const rootPath = configFilePath ? dirname(configFilePath) : cwd;
+
+  return normalizeFmtConfig(config, rootPath);
+};
+
+export { normalizeFmtConfig, resolveFmtConfig };


### PR DESCRIPTION
## Summary

This PR resolves lazy `define.fmt` definitions into the internal normalized formatter model while keeping evaluation separate from Rstack config loading.

The formatter root uses the Rstack config file directory and falls back to the caller-provided cwd when no config file is present. It does not add CLI behavior or a public export.