### PR TITLE
docs: add Prettier to credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ pnpm doc
 
 Rstack CLI is inspired by:
 
+- [Bun](https://github.com/oven-sh/bun)
 - [Cargo](https://github.com/rust-lang/cargo)
 - [Deno](https://github.com/denoland/deno)
-- [Bun](https://github.com/oven-sh/bun)
 - [Husky](https://github.com/typicode/husky)
+- [Prettier](https://github.com/prettier/prettier)
 - [Vite Plus](https://github.com/voidzero-dev/vite-plus)
 
 ## License


### PR DESCRIPTION
Prettier provides the formatting foundation for the upcoming `rs fmt` workflow and should be acknowledged alongside the projects that inspired Rstack CLI. This PR adds Prettier to the README credits and sorts all entries alphabetically.