### PR TITLE
chore: migrate repository formatting to rs fmt

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-**/dist/**
-pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "type": "module",
   "scripts": {
     "build": "pnpm --filter './packages/**' build",
-    "check:format": "prettier . --check --experimental-cli",
+    "check:format": "rs fmt --check",
     "check:spell": "pnpm dlx cspell && heading-case",
     "doc": "pnpm --dir website dev",
     "doc:build": "node --run build && pnpm --dir website build",
-    "format": "prettier . --write --experimental-cli && heading-case --write",
+    "format": "rs fmt && heading-case --write",
     "lint": "rs lint --type-check",
     "prepare": "node scripts/rs.js setup",
     "test": "pnpm --filter './packages/**' test"

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,6 +1,0 @@
-/** @type {import('prettier').Config} */
-export default {
-  plugins: ['prettier-plugin-packagejson'],
-  printWidth: 100,
-  singleQuote: true,
-};

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -38,11 +38,15 @@ define.lint(async () => {
   ];
 });
 
+define.fmt({
+  ignorePatterns: ['**/dist/**', 'pnpm-lock.yaml'],
+  // TODO: Enable after rs fmt supports resolving Prettier plugins from the project root.
+  // plugins: ['prettier-plugin-packagejson'],
+  printWidth: 100,
+  singleQuote: true,
+});
+
 define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': [
-    'rs lint --fix',
-    'prettier --write --experimental-cli --no-error-on-unmatched-pattern',
-  ],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}':
-    'prettier --write --experimental-cli --no-error-on-unmatched-pattern',
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
 });


### PR DESCRIPTION
This PR migrates the repository's formatting scripts and staged-file tasks from the standalone Prettier CLI to `rs fmt`. Prettier options and ignore patterns now live under `define.fmt`, removing the separate configuration and ignore files. `prettier-plugin-packagejson` remains disabled with a TODO until `rs fmt` supports project-root plugin resolution.