### PR TITLE
feat(cli): add format alias for fmt

### DIFF
--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -15,16 +15,16 @@ ${color.cyan('Usage')}:
 ${color.yellow('  $ rs [command] [...options]')}
 
 ${color.cyan('Commands')}:
-  dev      Run the app dev server
-  build    Build the app for production
-  preview  Preview the app production build
-  lib      Build library 
-  doc      Serve or build docs
-  fmt      Format code
-  lint     Lint code
-  test     Run tests
-  staged   Run tasks on staged Git files
-  setup    Install Git hooks
+  dev          Run the app dev server
+  build        Build the app for production
+  preview      Preview the app production build
+  lib          Build library
+  doc          Serve or build docs
+  fmt, format  Format code
+  lint         Lint code
+  test         Run tests
+  staged       Run tasks on staged Git files
+  setup        Install Git hooks
 
 ${color.dim(`For command-specific options, run:
   $ rs <command> -h`)}
@@ -144,7 +144,7 @@ export async function setupCommands(): Promise<void> {
     return;
   }
 
-  if (command === 'fmt') {
+  if (command === 'fmt' || command === 'format') {
     const { runFmtCLI } = await import(
       /* rspackChunkName: 'fmt' */
       '../fmt/cli.ts'

--- a/packages/rstack/tests/cli/fmt/index.test.ts
+++ b/packages/rstack/tests/cli/fmt/index.test.ts
@@ -45,10 +45,21 @@ test('displays fmt help without loading config', () => {
   const fmt = runFmt(['--help']);
 
   expect(topLevel.status).toBe(0);
-  expect(topLevel.stdout).toContain('fmt      Format code');
+  expect(topLevel.stdout).toContain('fmt, format  Format code');
   expect(fmt.status).toBe(0);
   expect(fmt.stdout).toContain('Usage:\n  $ rs fmt [options] [files/globs...]');
   expect(fmt.stderr).toBe('');
+});
+
+test('supports format as an alias for fmt', () => {
+  writeProjectFile('index.ts', 'const message="hello"');
+
+  const result = runCLI(['format', 'index.ts']);
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toBe('index.ts\n');
+  expect(result.stderr).toBe('');
+  expect(readProjectFile('index.ts')).toBe('const message = "hello";\n');
 });
 
 test('returns exit code 1 for invalid arguments', () => {

--- a/packages/rstack/tests/cli/setup/index.test.ts
+++ b/packages/rstack/tests/cli/setup/index.test.ts
@@ -43,7 +43,7 @@ afterEach(() => {
 });
 
 test('displays setup help', ({ execCli, expect }) => {
-  expect(execCli('--help', { cwd })).toContain('setup    Install Git hooks');
+  expect(execCli('--help', { cwd })).toMatch(/setup\s+Install Git hooks/);
 
   const output = execCli('setup --help', { cwd });
 


### PR DESCRIPTION
This PR adds `rs format` as an alias for `rs fmt`, with both names using the same lazily loaded formatter command. The top-level help lists the command as `fmt, format`, while `rs fmt` remains the canonical name in command-specific help and documentation.