### PR TITLE
feat(fmt): add project-root plugin resolver

### DIFF
--- a/packages/rstack/THIRD_PARTY_NOTICES.md
+++ b/packages/rstack/THIRD_PARTY_NOTICES.md
@@ -142,6 +142,78 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+## import-meta-resolve
+
+This package includes bundled code from
+[import-meta-resolve](https://github.com/wooorm/import-meta-resolve).
+
+License: MIT
+
+Copyright (c) Titus Wormer <mailto:tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+This software includes derivative work based on Node.js.
+
+Copyright Node.js contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+Parts of Node.js originate from the Joyent Node repository.
+
+Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
 ## is-binary-path
 
 This package includes bundled code from [is-binary-path](https://github.com/sindresorhus/is-binary-path).

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -70,6 +70,7 @@
     "atomically": "catalog:",
     "fast-ignore": "catalog:",
     "ignore": "catalog:",
+    "import-meta-resolve": "catalog:",
     "is-binary-path": "catalog:",
     "lint-staged": "catalog:",
     "micromatch": "catalog:",

--- a/packages/rstack/src/fmt/plugins.ts
+++ b/packages/rstack/src/fmt/plugins.ts
@@ -1,0 +1,77 @@
+import { isAbsolute, join, resolve as resolvePath } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { moduleResolve } from 'import-meta-resolve';
+import type { Options as PrettierOptions } from 'prettier';
+import type { ResolvedFmtConfig } from './types.ts';
+
+type FmtPlugin = NonNullable<PrettierOptions['plugins']>[number];
+
+const resolveModuleUrl = (specifier: string, parentUrl: URL): string =>
+  moduleResolve(specifier, parentUrl).href;
+
+const resolvePlugin = (plugin: FmtPlugin, rootPath: string, parentUrl: URL): FmtPlugin => {
+  if (plugin instanceof URL) {
+    return resolveModuleUrl(plugin.href, parentUrl);
+  }
+  if (typeof plugin !== 'string') {
+    return plugin;
+  }
+  if (isAbsolute(plugin)) {
+    return resolveModuleUrl(pathToFileURL(plugin).href, parentUrl);
+  }
+  if (URL.canParse(plugin)) {
+    return resolveModuleUrl(plugin, parentUrl);
+  }
+
+  try {
+    return resolveModuleUrl(pathToFileURL(resolvePath(rootPath, plugin)).href, parentUrl);
+  } catch {
+    return resolveModuleUrl(plugin, parentUrl);
+  }
+};
+
+const resolveOptionsPlugins = (
+  options: PrettierOptions,
+  rootPath: string,
+  parentUrl: URL,
+): PrettierOptions => {
+  const { plugins } = options;
+  if (!plugins?.some((plugin) => typeof plugin === 'string' || plugin instanceof URL)) {
+    return options;
+  }
+
+  const resolvedPlugins = plugins.map((plugin) => resolvePlugin(plugin, rootPath, parentUrl));
+
+  return resolvedPlugins.every((plugin, index) => plugin === plugins[index])
+    ? options
+    : { ...options, plugins: resolvedPlugins };
+};
+
+/** Resolves plugin specifiers from the Rstack config root. */
+const resolveFmtConfigPlugins = (config: ResolvedFmtConfig): ResolvedFmtConfig => {
+  const { rootPath } = config;
+  const parentUrl = pathToFileURL(join(rootPath, 'index.js'));
+  const baseOptions = resolveOptionsPlugins(config.baseOptions, rootPath, parentUrl);
+  let overrides = config.overrides;
+
+  for (let index = 0; index < overrides.length; index++) {
+    const override = overrides[index];
+    if (!override.options) {
+      continue;
+    }
+
+    const options = resolveOptionsPlugins(override.options, rootPath, parentUrl);
+    if (options !== override.options) {
+      if (overrides === config.overrides) {
+        overrides = [...overrides];
+      }
+      overrides[index] = { ...override, options };
+    }
+  }
+
+  return baseOptions === config.baseOptions && overrides === config.overrides
+    ? config
+    : { ...config, baseOptions, overrides };
+};
+
+export { resolveFmtConfigPlugins };

--- a/packages/rstack/tests/fmt/plugins.test.ts
+++ b/packages/rstack/tests/fmt/plugins.test.ts
@@ -1,0 +1,86 @@
+import { pathToFileURL } from 'node:url';
+import { expect, test } from 'rstack/test';
+import { normalizeFmtConfig } from '../../src/fmt/config.ts';
+import { resolveFmtConfigPlugins } from '../../src/fmt/plugins.ts';
+import { withTempProject, writeProjectFile } from './helpers.ts';
+
+test('resolves plugin specifiers from the config root', async () => {
+  await withTempProject(async (rootPath) => {
+    const packageEntry = writeProjectFile(
+      rootPath,
+      'node_modules/prettier-plugin-packagejson/import.mjs',
+      'export default {};',
+    );
+    writeProjectFile(
+      rootPath,
+      'node_modules/prettier-plugin-packagejson/package.json',
+      JSON.stringify({
+        name: 'prettier-plugin-packagejson',
+        exports: {
+          import: './import.mjs',
+          require: './require.cjs',
+        },
+      }),
+    );
+    writeProjectFile(
+      rootPath,
+      'node_modules/prettier-plugin-packagejson/require.cjs',
+      'module.exports = {};',
+    );
+
+    const relativePlugin = writeProjectFile(rootPath, 'plugins/relative.mjs');
+    const absolutePlugin = writeProjectFile(rootPath, 'plugins/absolute.mjs');
+    const urlPlugin = writeProjectFile(rootPath, 'plugins/url.mjs');
+    const overridePlugin = writeProjectFile(rootPath, 'plugins/override.mjs');
+    const pluginObject = { languages: [] };
+    const config = normalizeFmtConfig(
+      {
+        plugins: [
+          'prettier-plugin-packagejson',
+          './plugins/relative.mjs',
+          absolutePlugin,
+          pathToFileURL(urlPlugin),
+          'data:text/javascript,export default {}',
+          pluginObject,
+        ],
+        overrides: [
+          {
+            files: '*.json',
+            options: {
+              plugins: ['plugins/override.mjs'],
+            },
+          },
+        ],
+      },
+      rootPath,
+    );
+
+    const resolved = resolveFmtConfigPlugins(config);
+
+    expect(resolved.baseOptions.plugins).toEqual([
+      pathToFileURL(packageEntry).href,
+      pathToFileURL(relativePlugin).href,
+      pathToFileURL(absolutePlugin).href,
+      pathToFileURL(urlPlugin).href,
+      'data:text/javascript,export default {}',
+      pluginObject,
+    ]);
+    expect(resolved.baseOptions.plugins?.at(-1)).toBe(pluginObject);
+    expect(resolved.overrides[0].options?.plugins).toEqual([pathToFileURL(overridePlugin).href]);
+    expect(config.baseOptions.plugins?.[0]).toBe('prettier-plugin-packagejson');
+    expect(config.overrides[0].options?.plugins?.[0]).toBe('plugins/override.mjs');
+  });
+});
+
+test('does not copy config containing only plugin objects', () => {
+  const pluginObject = { languages: [] };
+  const config = normalizeFmtConfig(
+    {
+      plugins: [pluginObject],
+      overrides: [{ files: '*.json', options: { plugins: [pluginObject] } }],
+    },
+    import.meta.dirname,
+  );
+
+  expect(resolveFmtConfigPlugins(config)).toBe(config);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ catalogs:
     ignore:
       specifier: 7.0.6
       version: 7.0.6
+    import-meta-resolve:
+      specifier: 4.2.0
+      version: 4.2.0
     is-binary-path:
       specifier: 3.0.0
       version: 3.0.0
@@ -370,6 +373,9 @@ importers:
       ignore:
         specifier: 'catalog:'
         version: 7.0.6
+      import-meta-resolve:
+        specifier: 'catalog:'
+        version: 4.2.0
       is-binary-path:
         specifier: 'catalog:'
         version: 3.0.0
@@ -1511,6 +1517,9 @@ packages:
 
   immutable@5.1.9:
     resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -3380,6 +3389,8 @@ snapshots:
   immediato@1.1.0: {}
 
   immutable@5.1.9: {}
+
+  import-meta-resolve@4.2.0: {}
 
   indent-string@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,7 @@ catalog:
   'happy-dom': '^20.11.1'
   'heading-case': '^1.1.4'
   ignore: 7.0.6
+  'import-meta-resolve': '4.2.0'
   is-binary-path: 3.0.0
   'lint-staged': '^17.2.0'
   'micromatch': '4.0.8'


### PR DESCRIPTION
This PR establishes project-root-aware Prettier plugin resolution before plugin support is wired into `rs fmt`.

It normalizes package specifiers, file paths, and URLs to absolute module URLs while preserving plugin objects, using the same ESM resolver as `@prettier/cli`. Existing plugin-unsupported behavior remains unchanged.

## Related Links

- https://www.npmjs.com/package/import-meta-resolve/v/4.2.0