### PR TITLE
chore(fmt): enable packagejson plugin

### DIFF
--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -40,8 +40,7 @@ define.lint(async () => {
 
 define.fmt({
   ignorePatterns: ['**/dist/**', 'pnpm-lock.yaml'],
-  // TODO: Enable after rs fmt supports resolving Prettier plugins from the project root.
-  // plugins: ['prettier-plugin-packagejson'],
+  plugins: ['prettier-plugin-packagejson'],
   printWidth: 100,
   singleQuote: true,
 });


### PR DESCRIPTION
Now that `rs fmt` resolves Prettier plugins from the project root, the repository can use `prettier-plugin-packagejson` through `define.fmt`. This enables the existing plugin in the repository configuration and removes the obsolete TODO.