### PR TITLE
feat: add Rstack configuration guide link

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/SKILL.md
+++ b/.agents/skills/migrate-to-rstack-cli/SKILL.md
@@ -40,6 +40,7 @@ Use one of the default names: `rstack.config.ts`, `.js`, `.mts`, or `.mjs`.
 Use `rs -c <path>` or `rs --config <path>` only for a custom path.
 
 ```ts
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/examples/app-react/rstack.config.ts
+++ b/examples/app-react/rstack.config.ts
@@ -1,3 +1,4 @@
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/examples/app-vanilla/rstack.config.ts
+++ b/examples/app-vanilla/rstack.config.ts
@@ -1,3 +1,4 @@
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.test({

--- a/examples/documentation/rstack.config.ts
+++ b/examples/documentation/rstack.config.ts
@@ -1,3 +1,4 @@
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 import path from 'node:path';
 

--- a/examples/lib-node/rstack.config.ts
+++ b/examples/lib-node/rstack.config.ts
@@ -1,3 +1,4 @@
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib({

--- a/examples/lib-react/rstack.config.ts
+++ b/examples/lib-react/rstack.config.ts
@@ -1,3 +1,4 @@
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib(async () => {

--- a/examples/rstest-inline-projects/rstack.config.ts
+++ b/examples/rstest-inline-projects/rstack.config.ts
@@ -1,3 +1,4 @@
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 import { defineInlineProject } from 'rstack/test';
 

--- a/packages/rstack/rstack.config.ts
+++ b/packages/rstack/rstack.config.ts
@@ -1,3 +1,4 @@
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.test(async () => {

--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -78,18 +78,24 @@ type Define = {
    * Defines the Rsbuild config for the app.
    *
    * This config is used by the `rs dev`, `rs build`, and `rs preview` commands.
+   *
+   * @see {@link https://rstack.rs/config | Rstack configuration guide}
    */
   app: (config: RsbuildConfigDefinition) => void;
   /**
    * Defines the Rslib config for libraries.
    *
    * This config is used by the `rs lib` command.
+   *
+   * @see {@link https://rstack.rs/config | Rstack configuration guide}
    */
   lib: (config: RslibConfigDefinition) => void;
   /**
    * Defines the Rspress config for documentation.
    *
    * This config is used by the `rs doc` command.
+   *
+   * @see {@link https://rstack.rs/config | Rstack configuration guide}
    */
   doc: (config: RspressConfigDefinition) => void;
   /**
@@ -100,24 +106,32 @@ type Define = {
    * Unless `extends` is set explicitly, Rstest automatically extends `define.app` or
    * falls back to `define.lib`. For multi-project configs, this applies to every inline
    * project without an explicit `extends`. The app config takes precedence when both are defined.
+   *
+   * @see {@link https://rstack.rs/config | Rstack configuration guide}
    */
   test: (config: RstestConfigExport) => void;
   /**
    * Defines the Rslint config for linting.
    *
    * This config is used by the `rs lint` command.
+   *
+   * @see {@link https://rstack.rs/config | Rstack configuration guide}
    */
   lint: (config: RslintConfig | (() => Promise<RslintConfig>)) => void;
   /**
    * Defines the Prettier config for formatting.
    *
    * This config will be used by the `rs fmt` command.
+   *
+   * @see {@link https://rstack.rs/config | Rstack configuration guide}
    */
   fmt: (config: FmtConfigDefinition) => void;
   /**
    * Defines the lint-staged config for staged files.
    *
    * This config is used by the `rs staged` command.
+   *
+   * @see {@link https://rstack.rs/config | Rstack configuration guide}
    */
   staged: (config: StagedConfig) => void;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ catalogs:
     '@rspress/core':
       specifier: ^2.0.19
       version: 2.0.19
+    '@rspress/plugin-client-redirects':
+      specifier: ^2.0.19
+      version: 2.0.19
     '@rspress/plugin-sitemap':
       specifier: ^2.0.19
       version: 2.0.19
@@ -406,6 +409,9 @@ importers:
       '@rspress/core':
         specifier: 'catalog:'
         version: 2.0.19(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
+      '@rspress/plugin-client-redirects':
+        specifier: 'catalog:'
+        version: 2.0.19(@rspress/core@2.0.19)
       '@rspress/plugin-sitemap':
         specifier: 'catalog:'
         version: 2.0.19(@rspress/core@2.0.19)
@@ -912,6 +918,12 @@ packages:
     resolution: {integrity: sha512-m0KfQNNXxjP975652nIOwUTqrvbJapRp4NpnoQMc5heawGhkC4+F7zTHvxY+huvzGYnKtL2fMMTrgWhEjKkrug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  '@rspress/plugin-client-redirects@2.0.19':
+    resolution: {integrity: sha512-BUwgEyj8vCkU58cV3Gp97aTSnfGJm7aXh40K0Dot1BqsCQ8ekdsMuaLXrICROdP9/ctd4oALtLBkOE+PKTa4Sg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rspress/core': ^2.0.10
 
   '@rspress/plugin-sitemap@2.0.19':
     resolution: {integrity: sha512-9ydrpj9hmmXWKWKIXUqJ1UrfxSvfxhHZRBZLb5OkTlOuQBNAg6BpsrW1WHoJqJr7p+3zqlz7S/9HTzSA3+EYcA==}
@@ -2787,6 +2799,10 @@ snapshots:
       - micromark
       - micromark-util-types
       - supports-color
+
+  '@rspress/plugin-client-redirects@2.0.19(@rspress/core@2.0.19)':
+    dependencies:
+      '@rspress/core': 2.0.19(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
   '@rspress/plugin-sitemap@2.0.19(@rspress/core@2.0.19)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ catalog:
   '@rslib/core': '~1.0.0-beta.1'
   '@rslint/core': '~0.7.2'
   '@rspress/core': '^2.0.19'
+  '@rspress/plugin-client-redirects': '^2.0.19'
   '@rspress/plugin-sitemap': '^2.0.19'
   '@rstack-dev/doc-ui': '1.14.7'
   '@rstackjs/load-config': ^0.1.2

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -1,3 +1,4 @@
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lint(async () => {

--- a/website/docs/en/guide/configuration.mdx
+++ b/website/docs/en/guide/configuration.mdx
@@ -7,6 +7,7 @@ Rstack centralizes the configuration for your project's tools in a single file. 
 Create `rstack.config.ts` in the project root and call the relevant `define.*()` APIs:
 
 ```ts title="rstack.config.ts"
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -68,6 +68,7 @@ The following commands are available:
 Create `rstack.config.ts` in the project root and register the configurations your project needs. The following is a minimal example for an application with testing and linting:
 
 ```ts title="rstack.config.ts"
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/website/docs/zh/guide/configuration.mdx
+++ b/website/docs/zh/guide/configuration.mdx
@@ -7,6 +7,7 @@ Rstack 将项目所用工具的配置集中到一份文件中。通过 `define.*
 在项目根目录创建 `rstack.config.ts`，并调用对应的 `define.*()` API：
 
 ```ts title="rstack.config.ts"
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -68,6 +68,7 @@ Rstack 提供以下命令：
 在项目根目录创建 `rstack.config.ts`，并注册项目所需的配置。以下是一个包含应用、测试和代码检查的最小示例：
 
 ```ts title="rstack.config.ts"
+// Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/website/package.json
+++ b/website/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@rsbuild/plugin-sass": "catalog:",
     "@rspress/core": "catalog:",
+    "@rspress/plugin-client-redirects": "catalog:",
     "@rspress/plugin-sitemap": "catalog:",
     "@rstack-dev/doc-ui": "catalog:",
     "@shikijs/transformers": "catalog:",

--- a/website/rstack.config.ts
+++ b/website/rstack.config.ts
@@ -1,3 +1,4 @@
+// Rstack configuration guide: https://rstack.rs/config
 import path from 'node:path';
 import { define } from 'rstack';
 
@@ -10,6 +11,7 @@ define.doc(async () => {
   const { pluginSass } = await import('@rsbuild/plugin-sass');
   const { transformerNotationDiff, transformerNotationFocus, transformerNotationHighlight } =
     await import('@shikijs/transformers');
+  const { pluginClientRedirects } = await import('@rspress/plugin-client-redirects');
   const { pluginSitemap } = await import('@rspress/plugin-sitemap');
   const { pluginOpenGraph } = await import('rsbuild-plugin-open-graph');
   const { pluginFontOpenSans } = await import('rspress-plugin-font-open-sans');
@@ -42,7 +44,18 @@ define.doc(async () => {
     route: {
       cleanUrls: true,
     },
-    plugins: [pluginFontOpenSans(), pluginSitemap({ siteUrl })],
+    plugins: [
+      pluginClientRedirects({
+        redirects: [
+          {
+            from: '^/config/?$',
+            to: '/guide/configuration',
+          },
+        ],
+      }),
+      pluginFontOpenSans(),
+      pluginSitemap({ siteUrl }),
+    ],
     themeConfig: {
       socialLinks: [
         {


### PR DESCRIPTION
This PR makes the Rstack configuration guide easier to discover from configuration files and editor hovers.

It adds a stable `/config` redirect, links the guide from `define.*` JSDoc and user-facing configuration examples, and updates the migration skill to preserve the comment.

## Related Links

- https://rspress.rs/plugin/official-plugins/client-redirects