### PR TITLE
feat(fmt): enable Yuku by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ Rstack CLI brings the Rstack toolchain together for JavaScript development, with
 
 It also covers local development needs outside Rstack's scope, with Prettier formatting and lint-staged commands.
 
-| Command      | Description                      | Powered by                                                |
-| ------------ | -------------------------------- | --------------------------------------------------------- |
-| `rs dev`     | Run the app dev server           | [Rsbuild](https://github.com/web-infra-dev/rsbuild)       |
-| `rs build`   | Build the app for production     | [Rsbuild](https://github.com/web-infra-dev/rsbuild)       |
-| `rs preview` | Preview the app production build | [Rsbuild](https://github.com/web-infra-dev/rsbuild)       |
-| `rs test`    | Run tests                        | [Rstest](https://github.com/web-infra-dev/rstest)         |
-| `rs lint`    | Lint code                        | [Rslint](https://github.com/web-infra-dev/rslint)         |
-| `rs lib`     | Build library                    | [Rslib](https://github.com/web-infra-dev/rslib)           |
-| `rs doc`     | Serve or build docs              | [Rspress](https://github.com/web-infra-dev/rspress)       |
-| `rs fmt`     | Format code                      | [Prettier](https://github.com/prettier/prettier)          |
-| `rs setup`   | Install Git hooks                | -                                                         |
-| `rs staged`  | Run tasks on staged Git files    | [lint-staged](https://github.com/lint-staged/lint-staged) |
+| Command      | Description                      | Powered by                                                                                        |
+| ------------ | -------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `rs dev`     | Run the app dev server           | [Rsbuild](https://github.com/web-infra-dev/rsbuild)                                               |
+| `rs build`   | Build the app for production     | [Rsbuild](https://github.com/web-infra-dev/rsbuild)                                               |
+| `rs preview` | Preview the app production build | [Rsbuild](https://github.com/web-infra-dev/rsbuild)                                               |
+| `rs test`    | Run tests                        | [Rstest](https://github.com/web-infra-dev/rstest)                                                 |
+| `rs lint`    | Lint code                        | [Rslint](https://github.com/web-infra-dev/rslint)                                                 |
+| `rs lib`     | Build library                    | [Rslib](https://github.com/web-infra-dev/rslib)                                                   |
+| `rs doc`     | Serve or build docs              | [Rspress](https://github.com/web-infra-dev/rspress)                                               |
+| `rs fmt`     | Format code                      | [Prettier](https://github.com/prettier/prettier) + [Yuku](https://github.com/yuku-toolchain/yuku) |
+| `rs setup`   | Install Git hooks                | -                                                                                                 |
+| `rs staged`  | Run tasks on staged Git files    | [lint-staged](https://github.com/lint-staged/lint-staged)                                         |
 
 Rstack CLI fits into your existing project workflow. It does not replace your runtime, package manager, or task runner, such as [pnpm](https://github.com/pnpm/pnpm), [Bun](https://github.com/oven-sh/bun), [Turborepo](https://github.com/vercel/turborepo), [Nx](https://github.com/nrwl/nx), and [Nub](https://github.com/nubjs/nub).
 

--- a/packages/rstack/THIRD_PARTY_NOTICES.md
+++ b/packages/rstack/THIRD_PARTY_NOTICES.md
@@ -29,6 +29,65 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+## @prettier/plugin-yuku
+
+This package includes bundled code from
+[@prettier/plugin-yuku](https://github.com/prettier/prettier/tree/main/packages/plugin-yuku).
+
+License: MIT
+
+Copyright © James Long and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+The bundled plugin also contains MIT-licensed code from:
+
+- emoji-regex 10.6.0, copyright Mathias Bynens
+- escape-string-regexp 5.0.0, copyright Sindre Sorhus
+- get-east-asian-width 1.6.0, copyright Sindre Sorhus
+- index-to-position 1.2.0, copyright Sindre Sorhus
+- is-es5-identifier-name 1.0.1, copyright fisker Cheung
+- jest-docblock 30.4.0, copyright Meta Platforms, Inc. and Jest contributors
+- narrow-emojis 0.0.3, copyright fisker Cheung
+- Prettier 3.10.0-dev, copyright James Long and contributors
+- to-fast-properties 4.0.0, copyright Petka Antonov, Benjamin Gruenbaum,
+  John-David Dalton, and Sindre Sorhus
+- trim-newlines 5.0.0, copyright Sindre Sorhus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notices and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 ## atomically
 
 This package includes bundled code from

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -57,9 +57,11 @@
     "@rslib/core": "catalog:",
     "@rslint/core": "catalog:",
     "@rstest/core": "catalog:",
-    "prettier": "catalog:"
+    "prettier": "catalog:",
+    "yuku-parser": "catalog:"
   },
   "devDependencies": {
+    "@prettier/plugin-yuku": "catalog:",
     "@rspress/core": "catalog:",
     "@rstackjs/load-config": "catalog:",
     "@rstackjs/test-utils": "catalog:",

--- a/packages/rstack/src/fmt/format.ts
+++ b/packages/rstack/src/fmt/format.ts
@@ -2,6 +2,7 @@ import { format, formatWithCursor } from 'prettier';
 import { resolveFmtOptions } from './config.ts';
 import { resolveFmtParser } from './parser.ts';
 import { createFmtPluginResolver } from './plugins.ts';
+import { getRuntimeFmtPlugins } from './runtimePlugins.ts';
 import type { FormatTextOptions, FormatTextResult } from './types.ts';
 
 /** Formats source text without reading formatter config or ignore files. */
@@ -23,6 +24,7 @@ const formatText = async (
     ...options,
     filepath: filePath,
     parser,
+    plugins: getRuntimeFmtPlugins(options.plugins),
   };
 
   if (cursorOffset === undefined) {

--- a/packages/rstack/src/fmt/format.ts
+++ b/packages/rstack/src/fmt/format.ts
@@ -2,7 +2,7 @@ import { format, formatWithCursor } from 'prettier';
 import { resolveFmtOptions } from './config.ts';
 import { resolveFmtParser } from './parser.ts';
 import { createFmtPluginResolver } from './plugins.ts';
-import { getRuntimeFmtPlugins } from './runtimePlugins.ts';
+import { getPrettierPlugins } from './prettierPlugins.ts';
 import type { FormatTextOptions, FormatTextResult } from './types.ts';
 
 /** Formats source text without reading formatter config or ignore files. */
@@ -24,7 +24,7 @@ const formatText = async (
     ...options,
     filepath: filePath,
     parser,
-    plugins: getRuntimeFmtPlugins(options.plugins),
+    plugins: getPrettierPlugins(options.plugins),
   };
 
   if (cursorOffset === undefined) {

--- a/packages/rstack/src/fmt/parser.ts
+++ b/packages/rstack/src/fmt/parser.ts
@@ -1,4 +1,5 @@
 import { getFileInfo, type FileInfoOptions, type Options as PrettierOptions } from 'prettier';
+import { getRuntimeFmtPlugins } from './runtimePlugins.ts';
 
 const fileInfoOptions = {
   ignorePath: [],
@@ -15,7 +16,7 @@ const resolveFmtParser = async (
   (
     await getFileInfo(filePath, {
       ...fileInfoOptions,
-      plugins: options.plugins,
+      plugins: getRuntimeFmtPlugins(options.plugins),
     })
   ).inferredParser;
 

--- a/packages/rstack/src/fmt/parser.ts
+++ b/packages/rstack/src/fmt/parser.ts
@@ -1,5 +1,5 @@
 import { getFileInfo, type FileInfoOptions, type Options as PrettierOptions } from 'prettier';
-import { getRuntimeFmtPlugins } from './runtimePlugins.ts';
+import { getPrettierPlugins } from './prettierPlugins.ts';
 
 const fileInfoOptions = {
   ignorePath: [],
@@ -16,7 +16,7 @@ const resolveFmtParser = async (
   (
     await getFileInfo(filePath, {
       ...fileInfoOptions,
-      plugins: getRuntimeFmtPlugins(options.plugins),
+      plugins: getPrettierPlugins(options.plugins),
     })
   ).inferredParser;
 

--- a/packages/rstack/src/fmt/prettierPlugins.ts
+++ b/packages/rstack/src/fmt/prettierPlugins.ts
@@ -6,7 +6,7 @@ type PrettierPlugins = NonNullable<PrettierOptions['plugins']>;
 const defaultFmtPlugins: PrettierPlugins = [yukuPlugin];
 
 /** Prepends Yuku so project plugins can override the default parser. */
-const getRuntimeFmtPlugins = (plugins: PrettierOptions['plugins']): PrettierPlugins =>
+const getPrettierPlugins = (plugins: PrettierOptions['plugins']): PrettierPlugins =>
   plugins?.length ? [...defaultFmtPlugins, ...plugins] : defaultFmtPlugins;
 
-export { getRuntimeFmtPlugins };
+export { getPrettierPlugins };

--- a/packages/rstack/src/fmt/runtimePlugins.ts
+++ b/packages/rstack/src/fmt/runtimePlugins.ts
@@ -1,0 +1,12 @@
+import * as yukuPlugin from '@prettier/plugin-yuku';
+import type { Options as PrettierOptions } from 'prettier';
+
+type PrettierPlugins = NonNullable<PrettierOptions['plugins']>;
+
+const defaultFmtPlugins: PrettierPlugins = [yukuPlugin];
+
+/** Prepends Yuku so project plugins can override the default parser. */
+const getRuntimeFmtPlugins = (plugins: PrettierOptions['plugins']): PrettierPlugins =>
+  plugins?.length ? [...defaultFmtPlugins, ...plugins] : defaultFmtPlugins;
+
+export { getRuntimeFmtPlugins };

--- a/packages/rstack/src/fmt/serial.ts
+++ b/packages/rstack/src/fmt/serial.ts
@@ -2,7 +2,7 @@
 
 import { readFile, writeFile } from 'atomically';
 import { format } from 'prettier';
-import { getRuntimeFmtPlugins } from './runtimePlugins.ts';
+import { getPrettierPlugins } from './prettierPlugins.ts';
 import type { FmtFileRequest } from './types.ts';
 
 const formatFileSerial = async (
@@ -12,7 +12,7 @@ const formatFileSerial = async (
   const source = await readFile(path, 'utf8');
   const formatted = await format(source, {
     ...options,
-    plugins: getRuntimeFmtPlugins(options.plugins),
+    plugins: getPrettierPlugins(options.plugins),
   });
 
   if (source === formatted) {

--- a/packages/rstack/src/fmt/serial.ts
+++ b/packages/rstack/src/fmt/serial.ts
@@ -2,6 +2,7 @@
 
 import { readFile, writeFile } from 'atomically';
 import { format } from 'prettier';
+import { getRuntimeFmtPlugins } from './runtimePlugins.ts';
 import type { FmtFileRequest } from './types.ts';
 
 const formatFileSerial = async (
@@ -9,7 +10,10 @@ const formatFileSerial = async (
   shouldWrite: boolean,
 ): Promise<boolean> => {
   const source = await readFile(path, 'utf8');
-  const formatted = await format(source, options);
+  const formatted = await format(source, {
+    ...options,
+    plugins: getRuntimeFmtPlugins(options.plugins),
+  });
 
   if (source === formatted) {
     return false;

--- a/packages/rstack/tests/cli/fmt/index.test.ts
+++ b/packages/rstack/tests/cli/fmt/index.test.ts
@@ -312,7 +312,7 @@ test('returns exit code 2 for formatting errors', () => {
 
   expect(result.status).toBe(2);
   expect(result.stdout).toBe('');
-  expect(result.stderr).toContain('error   index.ts: SyntaxError: Expression expected.');
+  expect(result.stderr).toContain('error   index.ts: SyntaxError:');
 });
 
 test('succeeds when no files can be formatted', () => {

--- a/packages/rstack/tests/fmt/discovery.test.ts
+++ b/packages/rstack/tests/fmt/discovery.test.ts
@@ -47,8 +47,9 @@ test('applies config ignore patterns outside the config root', async () => {
   });
 });
 
-test('resolves parsers and accepts unknown extensions with an explicit parser', async () => {
+test('uses Yuku parsers by default and accepts an explicit parser', async () => {
   await withTempProject(async (rootPath) => {
+    writeProjectFile(rootPath, 'index.js');
     writeProjectFile(rootPath, 'index.ts');
     writeProjectFile(rootPath, 'source.custom');
     writeProjectFile(rootPath, 'unknown.extension');
@@ -56,8 +57,8 @@ test('resolves parsers and accepts unknown extensions with an explicit parser', 
     const inferredFiles = await discover(rootPath);
     const configuredFiles = await discover(rootPath, ['source.custom'], { parser: 'babel' });
 
-    expect(relativePaths(rootPath, inferredFiles)).toEqual(['index.ts']);
-    expect(inferredFiles[0].options.parser).toBe('typescript');
+    expect(relativePaths(rootPath, inferredFiles)).toEqual(['index.js', 'index.ts']);
+    expect(inferredFiles.map((file) => file.options.parser)).toEqual(['yuku', 'yuku-ts']);
     expect(configuredFiles[0].options).toMatchObject({
       filepath: path.join(rootPath, 'source.custom'),
       parser: 'babel',
@@ -71,7 +72,10 @@ test('resolves plugins after applying matching overrides', async () => {
       rootPath,
       'node_modules/prettier-plugin-fixture/index.mjs',
       `export default {
-  languages: [{ name: 'Fixture JSON', parsers: ['json'], extensions: ['.fixture'] }],
+  languages: [
+    { name: 'Fixture JSON', parsers: ['json'], extensions: ['.fixture'] },
+    { name: 'Fixture TypeScript', parsers: ['babel'], extensions: ['.ts'] },
+  ],
 };
 `,
     );
@@ -89,6 +93,10 @@ test('resolves plugins after applying matching overrides', async () => {
           options: { plugins: ['prettier-plugin-fixture'] },
         },
         {
+          files: '*.ts',
+          options: { plugins: ['prettier-plugin-fixture'] },
+        },
+        {
           files: '*.md',
           options: { plugins: ['missing-plugin'] },
         },
@@ -101,6 +109,12 @@ test('resolves plugins after applying matching overrides', async () => {
     expect(files[0]).toMatchObject({
       options: {
         parser: 'json',
+        plugins: [pathToFileURL(pluginEntry).href],
+      },
+    });
+    expect(files[1]).toMatchObject({
+      options: {
+        parser: 'babel',
         plugins: [pathToFileURL(pluginEntry).href],
       },
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 
 catalogs:
   default:
+    '@prettier/plugin-yuku':
+      specifier: 0.0.1
+      version: 0.0.1
     '@rsbuild/core':
       specifier: ~2.1.9
       version: 2.1.9
@@ -133,6 +136,12 @@ catalogs:
     worktank:
       specifier: 3.0.2
       version: 3.0.2
+    yuku-parser:
+      specifier: 0.8.3
+      version: 0.8.3
+
+overrides:
+  '@prettier/plugin-yuku>yuku-parser': 0.8.3
 
 importers:
 
@@ -345,7 +354,13 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
+      yuku-parser:
+        specifier: 'catalog:'
+        version: 0.8.3
     devDependencies:
+      '@prettier/plugin-yuku':
+        specifier: 'catalog:'
+        version: 0.0.1
       '@rspress/core':
         specifier: 'catalog:'
         version: 2.0.19(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
@@ -642,6 +657,10 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@prettier/plugin-yuku@0.0.1':
+    resolution: {integrity: sha512-6Z3XcE5afL5pdBcG5KSl2eZ6HvNR0erXJn7FjR5OWeSoajrQPAIOpVCSZ+CXnJJSwUKi/UcqvUMcuYjRDd2IKQ==}
+    engines: {node: '>=14'}
 
   '@rsbuild/core@2.1.8':
     resolution: {integrity: sha512-Y70LMcCZspVoQ7Oip1W2Agu5wVhWZ2x3cYl4s9GLQG4VYphBud53DY/jkrqkyQF8ASYZDDDrW2KWNFj0kNLLuA==}
@@ -1241,6 +1260,75 @@ packages:
     resolution: {integrity: sha512-FhKVVHAsHbiD24yNAklQIAbjGmcVLTJjKFx1YEhOzGmiZaH2q6CzbwxboJYK6oasepio8Qap9UqHhudJ98wTbA==}
     peerDependencies:
       react: '>=18.3.1'
+
+  '@yuku-parser/binding-android-arm64@0.8.3':
+    resolution: {integrity: sha512-vySYRsMeul9ssvxeHdxgS9ZUIcq7gqljWNqgokjJE0uQWvVvOprihJ6hOsiifVqWsla0BMc3vAFBvNS9QqCw7g==}
+    cpu: [arm64]
+    os: [android]
+
+  '@yuku-parser/binding-darwin-arm64@0.8.3':
+    resolution: {integrity: sha512-+wpB/wqhiZ685Y77I+lj6v9pHSAJ3Y+QMHJmvch0Q0ahIMbNwtKk3s54MhtjCMKO1qpjPbyN/PjuHDg2hbKaVQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@yuku-parser/binding-darwin-x64@0.8.3':
+    resolution: {integrity: sha512-jKqiWejj4zVy7pPtEGu4/Ty+pG1h7ooQOXIkm7shKZTSwTU9X8X+eoH11uIeKHZi2SQWV0GhNz0J56eerseysQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@yuku-parser/binding-freebsd-x64@0.8.3':
+    resolution: {integrity: sha512-FC7zSwzFzd4z9bsId07CiHLR+Iw6yW/LzIQhL5AUtPUuVXLgEyx0rilgbRUYkl1CT3GJcLpkh63WuPZUSgCDzw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@yuku-parser/binding-linux-arm-gnu@0.8.3':
+    resolution: {integrity: sha512-So61j88b9/ygDnUPlWCm1EUPw4HSxAyDjrNHKgud5N3aRDQ3kw94nW7TriXbo7GBXID9oBHCMNm1r1Fof/Df5Q==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm-musl@0.8.3':
+    resolution: {integrity: sha512-Nmnn20yJvSSKL8ZdtqReBRSGCDkSMqR5jEk/Sk/cdIdZmqVD49Z6M7w2GbMjdrxMI1MBPbsWFMMWxa93cd5t5g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.8.3':
+    resolution: {integrity: sha512-Lfgw7AXJ0rxu6BMPGgfc8HLJWEIr8BHhCzcQp/75k+NM90uCLkHlBNqIg/K42KlSvBgAvu9euOvjdswib+4qJA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm64-musl@0.8.3':
+    resolution: {integrity: sha512-cfRyu87xsJ0tFkHNsnMC4Rq6+xsFJ6i2dc4VAH52d2qLvykEJU/Mdi3ul1O2PyOApX/LoLT3uQZ0fWs3D5XE4w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-linux-x64-gnu@0.8.3':
+    resolution: {integrity: sha512-GcQQCUuYxbm6P1n+io/A50rvWKDeWHutIp6rW0ycDOZuEQjOb8hDVgS88+NDyOnd9FfS0/Z6GXopcRFDyKpzOg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-x64-musl@0.8.3':
+    resolution: {integrity: sha512-rMkImBGZzg7GZlj8krYtdiezyjYI4igjKWMut5T65jHyNWFigMQrEpn9mDIBflloW9FKhGE3mN6yTZ/N+4HRwg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-win32-arm64@0.8.3':
+    resolution: {integrity: sha512-/2Pl2cAzCXWxah8FqJapEj/ikpt9cEutEZFCa0hnbfrshkn5+C+aBM3ZDq62d1jsgQjBMmqr5HVhJUA4OAG/Tg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@yuku-parser/binding-win32-x64@0.8.3':
+    resolution: {integrity: sha512-Ntnvjoan9jnfLhn7Kn3h8j/bhsbVdQSVmKUqFULKtmwImLCJVHOJbLL4qbEJyrOQ7r/FBL1/c/dRvx/AQWzzXg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@yuku-toolchain/types@0.8.3':
+    resolution: {integrity: sha512-9LN3HYs3A9qSPVFunsxlbfwBcUgexti3TmhOzIxB/UH8zFuaHQJXTRDcN17DW6cp1GsyZtiZA7f18uIra36Jag==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2357,6 +2445,12 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yuku-ast@0.8.3:
+    resolution: {integrity: sha512-8x34yU5uhHUnJXzy2Qvjvec/vE9BzS0/2khVT1MsLmSLO/P8Q1Wp8IxHv+IhD+HMYETk6kherOSvP4JPWw2joQ==}
+
+  yuku-parser@0.8.3:
+    resolution: {integrity: sha512-KPQcpF9aj77ywlJBIkQWCQ9DObdxnCA8AJdUOmA5CZZx042Xt4+dvbQmPJfWxF3E+KG5dVAZ2fBKuDJ8VsKWgA==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -2534,6 +2628,10 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
+
+  '@prettier/plugin-yuku@0.0.1':
+    dependencies:
+      yuku-parser: 0.8.3
 
   '@rsbuild/core@2.1.8':
     dependencies:
@@ -3073,6 +3171,44 @@ snapshots:
     dependencies:
       react: 19.2.8
       unhead: 2.1.16
+
+  '@yuku-parser/binding-android-arm64@0.8.3':
+    optional: true
+
+  '@yuku-parser/binding-darwin-arm64@0.8.3':
+    optional: true
+
+  '@yuku-parser/binding-darwin-x64@0.8.3':
+    optional: true
+
+  '@yuku-parser/binding-freebsd-x64@0.8.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-gnu@0.8.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-musl@0.8.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.8.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-musl@0.8.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-gnu@0.8.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-musl@0.8.3':
+    optional: true
+
+  '@yuku-parser/binding-win32-arm64@0.8.3':
+    optional: true
+
+  '@yuku-parser/binding-win32-x64@0.8.3':
+    optional: true
+
+  '@yuku-toolchain/types@0.8.3': {}
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -4525,5 +4661,27 @@ snapshots:
 
   yaml@2.9.0:
     optional: true
+
+  yuku-ast@0.8.3:
+    dependencies:
+      '@yuku-toolchain/types': 0.8.3
+
+  yuku-parser@0.8.3:
+    dependencies:
+      '@yuku-toolchain/types': 0.8.3
+      yuku-ast: 0.8.3
+    optionalDependencies:
+      '@yuku-parser/binding-android-arm64': 0.8.3
+      '@yuku-parser/binding-darwin-arm64': 0.8.3
+      '@yuku-parser/binding-darwin-x64': 0.8.3
+      '@yuku-parser/binding-freebsd-x64': 0.8.3
+      '@yuku-parser/binding-linux-arm-gnu': 0.8.3
+      '@yuku-parser/binding-linux-arm-musl': 0.8.3
+      '@yuku-parser/binding-linux-arm64-gnu': 0.8.3
+      '@yuku-parser/binding-linux-arm64-musl': 0.8.3
+      '@yuku-parser/binding-linux-x64-gnu': 0.8.3
+      '@yuku-parser/binding-linux-x64-musl': 0.8.3
+      '@yuku-parser/binding-win32-arm64': 0.8.3
+      '@yuku-parser/binding-win32-x64': 0.8.3
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ catalogMode: prefer
 cleanupUnusedCatalogs: true
 
 catalog:
+  '@prettier/plugin-yuku': '0.0.1'
   '@rsbuild/core': '~2.1.9'
   '@rsbuild/plugin-react': '^2.1.0'
   '@rsbuild/plugin-sass': '^2.0.1'
@@ -54,6 +55,10 @@ catalog:
   tiny-readdir: 3.1.1
   'typescript': '^7.0.2'
   worktank: '3.0.2'
+  yuku-parser: '0.8.3'
+
+overrides:
+  '@prettier/plugin-yuku>yuku-parser': 'catalog:'
 
 dedupePeers: true
 
@@ -66,6 +71,21 @@ hoistPattern: []
 # Reduce the risk of installing compromised packages
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
+  - '@yuku-parser/binding-android-arm64@0.8.3'
+  - '@yuku-parser/binding-darwin-arm64@0.8.3'
+  - '@yuku-parser/binding-darwin-x64@0.8.3'
+  - '@yuku-parser/binding-freebsd-x64@0.8.3'
+  - '@yuku-parser/binding-linux-arm-gnu@0.8.3'
+  - '@yuku-parser/binding-linux-arm-musl@0.8.3'
+  - '@yuku-parser/binding-linux-arm64-gnu@0.8.3'
+  - '@yuku-parser/binding-linux-arm64-musl@0.8.3'
+  - '@yuku-parser/binding-linux-x64-gnu@0.8.3'
+  - '@yuku-parser/binding-linux-x64-musl@0.8.3'
+  - '@yuku-parser/binding-win32-arm64@0.8.3'
+  - '@yuku-parser/binding-win32-x64@0.8.3'
+  - '@yuku-toolchain/types@0.8.3'
+  - 'yuku-ast@0.8.3'
+  - 'yuku-parser@0.8.3'
   - '@rspack/*'
   - '@rsbuild/*'
   - '@rslib/*'

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -21,3 +21,4 @@ shikijs
 turborepo
 typicode
 worktank
+yuku


### PR DESCRIPTION
## Summary

`rs fmt` currently uses Prettier's standard JavaScript and TypeScript parsers. This PR bundles `@prettier/plugin-yuku` and enables it for parser inference and formatting in both serial and worker paths, while keeping project plugins able to override the default. It installs `yuku-parser@0.8.3` as a runtime dependency and updates the bundled-code notices and README credit.

## Related Links

- https://www.npmjs.com/package/yuku-parser/v/0.8.3
- https://github.com/prettier/prettier/tree/main/packages/plugin-yuku