### PR TITLE
perf(fmt): disable fsync for atomic writes

### DIFF
--- a/packages/rstack/src/fmt/worker.ts
+++ b/packages/rstack/src/fmt/worker.ts
@@ -5,6 +5,16 @@ import { format } from 'prettier';
 import { getPrettierPlugins } from './prettierPlugins.ts';
 import type { FmtFileRequest } from './types.ts';
 
+/**
+ * Formatting output can be regenerated, so avoid waiting for a durability sync
+ * after every file, which is especially expensive during parallel formatting.
+ * `atomically` still uses a temporary file and rename for atomic replacement.
+ */
+const atomicWriteOptions = {
+  encoding: 'utf8',
+  fsync: false,
+} as const;
+
 const formatFile = async (
   { path, options }: FmtFileRequest,
   shouldWrite: boolean,
@@ -20,7 +30,7 @@ const formatFile = async (
   }
 
   if (shouldWrite) {
-    await writeFile(path, formatted, 'utf8');
+    await writeFile(path, formatted, atomicWriteOptions);
   }
 
   return true;

--- a/packages/rstack/tests/fmt/worker.test.ts
+++ b/packages/rstack/tests/fmt/worker.test.ts
@@ -1,0 +1,35 @@
+import { expect, rs, test } from 'rstack/test';
+import { formatFile } from '../../src/fmt/worker.ts';
+
+const mocks = rs.hoisted(() => ({
+  writeFileCalls: [] as [string, string, unknown][],
+}));
+
+rs.mock('atomically', () => ({
+  readFile: () => Promise.resolve('const value=1'),
+  writeFile: (path: string, data: string, options: unknown) => {
+    mocks.writeFileCalls.push([path, data, options]);
+    return Promise.resolve();
+  },
+}));
+
+test('disables fsync for atomic writes', async () => {
+  const filePath = '/virtual/example.ts';
+
+  await expect(
+    formatFile(
+      {
+        path: filePath,
+        options: {
+          filepath: filePath,
+          parser: 'typescript',
+        },
+      },
+      true,
+    ),
+  ).resolves.toBe(true);
+
+  expect(mocks.writeFileCalls).toEqual([
+    [filePath, 'const value = 1;\n', { encoding: 'utf8', fsync: false }],
+  ]);
+});


### PR DESCRIPTION
## Summary

Per-file `fsync` dominates `rs fmt` parallel write time for large repositories even though formatter output can be regenerated.

This disables `fsync` for `atomically` writes while preserving temporary-file and rename-based atomic replacement, and adds a regression assertion for the write options.

The tradeoff is weaker durability if the OS crashes or loses power immediately after formatting; on the Outline fixture (2,516 files, 2,374 rewritten), parallel formatting on an M3 Max improved from approximately 12.7s to 2.2s.

## Related Links

- https://github.com/oxc-project/bench-formatter