### PR TITLE
perf(fmt): streamline worker boundaries

### DIFF
--- a/packages/rstack/src/fmt/discovery.ts
+++ b/packages/rstack/src/fmt/discovery.ts
@@ -8,17 +8,10 @@ const createFileRequest = (
   filePath: string,
   config: ResolvedFmtConfig,
   resolvePlugins: FmtPluginResolver,
-): FmtFileRequest => {
-  const options = resolvePlugins(resolveFmtOptions(filePath, config));
-
-  return {
-    path: filePath,
-    options: {
-      ...options,
-      filepath: filePath,
-    },
-  };
-};
+): FmtFileRequest => ({
+  path: filePath,
+  options: resolvePlugins(resolveFmtOptions(filePath, config)),
+});
 
 /** Discovers worker-ready files without reading Prettier config files or `.prettierignore`. */
 const discoverFmtFiles = async ({

--- a/packages/rstack/src/fmt/prettierPlugins.ts
+++ b/packages/rstack/src/fmt/prettierPlugins.ts
@@ -18,9 +18,12 @@ const fmtOptionsPlugin = {
 const defaultFmtPlugins: PrettierPlugins = [yukuPlugin, fmtOptionsPlugin];
 
 /** Prepends bundled plugins so project plugins can override their parsers. */
-const getPrettierPlugins = async (options: ResolvedFmtOptions): Promise<PrettierPlugins> => {
+const getPrettierPlugins = async (
+  options: ResolvedFmtOptions,
+  filePath: string,
+): Promise<PrettierPlugins> => {
   const plugins =
-    options.sortPackageJson === true && /(^|[/\\])package\.json$/.test(options.filepath ?? '')
+    options.sortPackageJson === true && /(^|[/\\])package\.json$/.test(filePath)
       ? [...defaultFmtPlugins, (await import('./sortPackageJsonPlugin.ts')).sortPackageJsonPlugin]
       : defaultFmtPlugins;
 

--- a/packages/rstack/src/fmt/runner.ts
+++ b/packages/rstack/src/fmt/runner.ts
@@ -16,25 +16,21 @@ const runFmtFile = async (
   shouldWrite: boolean,
   formatFile: FormatFile,
 ): Promise<FmtFileResult | undefined> => {
-  const startTime = performance.now();
-
   try {
     const result = await formatFile(file, shouldWrite);
-    if (result === 'unsupported') {
+    if (result !== 'changed') {
       return;
     }
 
     return {
       path: file.path,
-      status: result === 'changed' ? (shouldWrite ? 'written' : 'different') : 'unchanged',
-      durationMs: performance.now() - startTime,
+      status: shouldWrite ? 'written' : 'different',
     };
   } catch (error) {
     return {
       path: file.path,
       status: 'error',
       error,
-      durationMs: performance.now() - startTime,
     };
   }
 };
@@ -80,7 +76,6 @@ const runFmtFiles = async ({
   mode,
   maxWorkers,
 }: RunFmtFilesOptions): Promise<FmtRunResult> => {
-  const startTime = performance.now();
   const shouldWrite = mode === 'write';
   const results =
     files.length === 0 ? [] : await runFmtFilesInWorkerPool(files, shouldWrite, maxWorkers);
@@ -88,7 +83,6 @@ const runFmtFiles = async ({
   return {
     files: results,
     exitCode: getFmtExitCode(results),
-    durationMs: performance.now() - startTime,
   };
 };
 

--- a/packages/rstack/src/fmt/types.ts
+++ b/packages/rstack/src/fmt/types.ts
@@ -57,8 +57,8 @@ interface DiscoverFmtFilesOptions {
 interface FmtFileRequest {
   /** Absolute path to the file. */
   path: string;
-  /** Final per-file options with project plugins and the file path resolved. */
-  options: ResolvedFmtOptions & Required<Pick<PrettierOptions, 'filepath'>>;
+  /** Final per-file options with project plugins resolved. */
+  options: ResolvedFmtOptions;
 }
 
 type FmtMode = 'write' | 'check' | 'list-different';
@@ -75,15 +75,13 @@ interface RunFmtFilesOptions {
 
 interface SuccessfulFmtFileResult {
   path: string;
-  status: 'unchanged' | 'written' | 'different';
-  durationMs: number;
+  status: 'written' | 'different';
 }
 
 interface FailedFmtFileResult {
   path: string;
   status: 'error';
   error: unknown;
-  durationMs: number;
 }
 
 type FmtFileResult = SuccessfulFmtFileResult | FailedFmtFileResult;
@@ -92,7 +90,6 @@ interface FmtRunResult {
   files: FmtFileResult[];
   /** Recommended CLI exit code. */
   exitCode: FmtExitCode;
-  durationMs: number;
 }
 
 export type {

--- a/packages/rstack/src/fmt/worker.ts
+++ b/packages/rstack/src/fmt/worker.ts
@@ -41,7 +41,7 @@ const formatFile = async (
   { path, options }: FmtFileRequest,
   shouldWrite: boolean,
 ): Promise<FormatFileResult> => {
-  const plugins = await getPrettierPlugins(options);
+  const plugins = await getPrettierPlugins(options, path);
   const parser = await resolveFmtParser(path, options, plugins);
   if (!parser) {
     return 'unsupported';
@@ -50,6 +50,7 @@ const formatFile = async (
   const source = readFileSync(path, 'utf8');
   const formatted = await format(source, {
     ...options,
+    filepath: path,
     parser,
     plugins,
   });

--- a/packages/rstack/tests/fmt/discovery.test.ts
+++ b/packages/rstack/tests/fmt/discovery.test.ts
@@ -64,9 +64,9 @@ test('defers parser inference to workers and preserves an explicit parser', asyn
       'unknown.extension',
     ]);
     expect(inferredFiles.every((file) => file.options.parser === undefined)).toBe(true);
-    expect(configuredFiles[0].options).toMatchObject({
-      filepath: path.join(rootPath, 'source.custom'),
-      parser: 'babel',
+    expect(configuredFiles[0]).toEqual({
+      path: path.join(rootPath, 'source.custom'),
+      options: { parser: 'babel' },
     });
   });
 });

--- a/packages/rstack/tests/fmt/runner.test.ts
+++ b/packages/rstack/tests/fmt/runner.test.ts
@@ -8,7 +8,6 @@ import { withTempProject } from './helpers.ts';
 const createRequest = (filePath: string): FmtFileRequest => ({
   path: filePath,
   options: {
-    filepath: filePath,
     parser: 'typescript',
   },
 });
@@ -31,11 +30,9 @@ test('does not rewrite unchanged files', async () => {
 
     expect(result).toMatchObject({
       exitCode: 0,
-      files: [{ path: filePath, status: 'unchanged' }],
+      files: [],
     });
     expect(statSync(filePath).mtimeMs).toBe(mtimeMs);
-    expect(result.durationMs).toBeGreaterThanOrEqual(0);
-    expect(result.files[0].durationMs).toBeGreaterThanOrEqual(0);
   });
 });
 
@@ -112,7 +109,7 @@ test('omits unsupported files from the result', async () => {
     const result = await run([
       {
         path: filePath,
-        options: { filepath: filePath },
+        options: {},
       },
     ]);
 

--- a/packages/rstack/tests/fmt/runnerWorkerPreflight.test.ts
+++ b/packages/rstack/tests/fmt/runnerWorkerPreflight.test.ts
@@ -22,7 +22,6 @@ beforeEach(() => {
 const createRequest = (filePath: string): FmtFileRequest => ({
   path: filePath,
   options: {
-    filepath: filePath,
     parser: 'typescript',
   },
 });

--- a/packages/rstack/tests/fmt/runnerWriteFailure.test.ts
+++ b/packages/rstack/tests/fmt/runnerWriteFailure.test.ts
@@ -23,7 +23,6 @@ test('returns an error when a file write fails', async () => {
       {
         path: filePath,
         options: {
-          filepath: filePath,
           parser: 'typescript',
         },
       },

--- a/packages/rstack/tests/fmt/worker.test.ts
+++ b/packages/rstack/tests/fmt/worker.test.ts
@@ -13,7 +13,6 @@ test('writes formatted files', async () => {
         {
           path: filePath,
           options: {
-            filepath: filePath,
             parser: 'typescript',
           },
         },
@@ -34,7 +33,7 @@ test('infers the parser for an explicitly provided node_modules file', async () 
       formatFile(
         {
           path: filePath,
-          options: { filepath: filePath },
+          options: {},
         },
         false,
       ),
@@ -52,7 +51,7 @@ test('skips unsupported files before reading them', async () => {
       formatFile(
         {
           path: filePath,
-          options: { filepath: filePath },
+          options: {},
         },
         true,
       ),


### PR DESCRIPTION
This PR trims the internal fmt worker boundary to avoid copying options and sending the file path twice for every file. Workers now set Prettier's `filepath` from the request path, while the runner omits unused timing metadata and unchanged-file result objects. CLI formatting behavior remains unchanged.