### PR TITLE
refactor(fmt): replace WorkTank with Tinypool

### DIFF
--- a/packages/rstack/THIRD_PARTY_NOTICES.md
+++ b/packages/rstack/THIRD_PARTY_NOTICES.md
@@ -273,63 +273,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-## isoconcurrency
-
-This package includes bundled code from
-[isoconcurrency](https://github.com/fabiospampinato/isoconcurrency).
-
-License: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2025-present Fabio Spampinato
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-## isotimer
-
-This package includes bundled code from [isotimer](https://github.com/fabiospampinato/isotimer).
-
-License: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2025-present Fabio Spampinato
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
 ## micromatch
 
 This package includes bundled code from [micromatch](https://github.com/micromatch/micromatch).
@@ -559,63 +502,6 @@ License: MIT
 The MIT License (MIT)
 
 Copyright (c) 2020-present Fabio Spampinato
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-## webworker-shim
-
-This package includes bundled code from
-[webworker-shim](https://github.com/fabiospampinato/webworker-shim).
-
-License: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2022-present Fabio Spampinato
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-## worktank
-
-This package includes bundled code from [worktank](https://github.com/fabiospampinato/worktank).
-
-License: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2021-present Fabio Spampinato
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -58,6 +58,7 @@
     "@rslint/core": "catalog:",
     "@rstest/core": "catalog:",
     "prettier": "catalog:",
+    "tinypool": "catalog:",
     "yuku-parser": "catalog:"
   },
   "devDependencies": {
@@ -78,8 +79,7 @@
     "rslog": "catalog:",
     "sort-package-json": "catalog:",
     "tiny-readdir": "catalog:",
-    "typescript": "catalog:",
-    "worktank": "catalog:"
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "@rspress/core": "^2.0.17"

--- a/packages/rstack/src/fmt/runner.ts
+++ b/packages/rstack/src/fmt/runner.ts
@@ -54,7 +54,7 @@ const runFmtFilesInWorkerPool = async (
     );
     return results.filter((result): result is FmtFileResult => result !== undefined);
   } finally {
-    workerPool.terminate();
+    await workerPool.terminate();
   }
 };
 

--- a/packages/rstack/src/fmt/worker.ts
+++ b/packages/rstack/src/fmt/worker.ts
@@ -13,6 +13,11 @@ import type { FmtFileRequest } from './types.ts';
 type PrettierPlugins = NonNullable<PrettierOptions['plugins']>;
 type FormatFileResult = 'changed' | 'unchanged' | 'unsupported';
 
+interface FormatFileTask {
+  file: FmtFileRequest;
+  shouldWrite: boolean;
+}
+
 const fileInfoOptions = {
   ignorePath: [],
   resolveConfig: false,
@@ -37,10 +42,10 @@ const resolveFmtParser = async (
  * Use synchronous direct I/O inside the dedicated worker to avoid libuv
  * scheduling overhead. This prioritizes throughput over crash-safe replacement.
  */
-const formatFile = async (
-  { path, options }: FmtFileRequest,
-  shouldWrite: boolean,
-): Promise<FormatFileResult> => {
+const formatFile = async ({
+  file: { path, options },
+  shouldWrite,
+}: FormatFileTask): Promise<FormatFileResult> => {
   const plugins = await getPrettierPlugins(options);
   const parser = await resolveFmtParser(path, options, plugins);
   if (!parser) {

--- a/packages/rstack/src/fmt/workerPool.ts
+++ b/packages/rstack/src/fmt/workerPool.ts
@@ -1,13 +1,17 @@
 // Derived from @prettier/cli, see THIRD_PARTY_NOTICES.md
 
 import { availableParallelism } from 'node:os';
-import WorkTank from 'worktank';
+import Tinypool from 'tinypool';
+import type { FmtFileRequest } from './types.ts';
 
 type FmtWorkerMethods = typeof import('./worker.ts');
 
 interface FmtWorkerPool {
-  formatFile: FmtWorkerMethods['formatFile'];
-  terminate: () => void;
+  formatFile: (
+    file: FmtFileRequest,
+    shouldWrite: boolean,
+  ) => ReturnType<FmtWorkerMethods['formatFile']>;
+  terminate: () => Promise<void>;
 }
 
 const getFmtWorkerCount = (fileCount: number, maxWorkers?: number): number =>
@@ -27,30 +31,27 @@ const createFmtWorkerPool = async (
   maxWorkers?: number,
 ): Promise<FmtWorkerPool> => {
   const workerCount = getFmtWorkerCount(fileCount, maxWorkers);
-  const pool = new WorkTank<FmtWorkerMethods>({
-    pool: {
-      name: 'rstack-fmt',
-      size: workerCount,
-    },
-    worker: {
-      autoInstantiate: true,
-      methods: getFmtWorkerUrl(),
-    },
+  const pool = new Tinypool({
+    filename: getFmtWorkerUrl().href,
+    name: 'initializeFmtWorker',
+    minThreads: workerCount,
+    maxThreads: workerCount,
   });
 
   try {
-    // Concurrent handshakes make WorkTank assign one task to every worker.
     await Promise.all(
-      Array.from({ length: workerCount }, () => pool.exec('initializeFmtWorker', [])),
+      Array.from({ length: workerCount }, () =>
+        pool.run(undefined, { name: 'initializeFmtWorker' }),
+      ),
     );
   } catch (error) {
-    pool.terminate();
+    await pool.destroy();
     throw error;
   }
 
   return {
-    formatFile: (file, shouldWrite) => pool.exec('formatFile', [file, shouldWrite]),
-    terminate: pool.terminate,
+    formatFile: (file, shouldWrite) => pool.run({ file, shouldWrite }, { name: 'formatFile' }),
+    terminate: () => pool.destroy(),
   };
 };
 

--- a/packages/rstack/tests/fmt/runnerWriteFailure.test.ts
+++ b/packages/rstack/tests/fmt/runnerWriteFailure.test.ts
@@ -11,6 +11,7 @@ rs.mock('../../src/fmt/workerPool.ts', () => ({
       formatFile: () => Promise.reject(new Error('file write failed')),
       terminate: () => {
         mocks.terminateCalls++;
+        return Promise.resolve();
       },
     }),
 }));

--- a/packages/rstack/tests/fmt/worker.test.ts
+++ b/packages/rstack/tests/fmt/worker.test.ts
@@ -9,16 +9,16 @@ test('writes formatted files', async () => {
     const filePath = writeProjectFile(rootPath, 'example.ts', 'const value=1');
 
     await expect(
-      formatFile(
-        {
+      formatFile({
+        file: {
           path: filePath,
           options: {
             filepath: filePath,
             parser: 'typescript',
           },
         },
-        true,
-      ),
+        shouldWrite: true,
+      }),
     ).resolves.toBe('changed');
 
     expect(readFileSync(filePath, 'utf8')).toBe('const value = 1;\n');
@@ -31,13 +31,13 @@ test('infers the parser for an explicitly provided node_modules file', async () 
     const filePath = writeProjectFile(rootPath, 'node_modules/example/index.ts', source);
 
     await expect(
-      formatFile(
-        {
+      formatFile({
+        file: {
           path: filePath,
           options: { filepath: filePath },
         },
-        false,
-      ),
+        shouldWrite: false,
+      }),
     ).resolves.toBe('changed');
 
     expect(readFileSync(filePath, 'utf8')).toBe(source);
@@ -49,13 +49,13 @@ test('skips unsupported files before reading them', async () => {
     const filePath = path.join(rootPath, 'missing.unknown');
 
     await expect(
-      formatFile(
-        {
+      formatFile({
+        file: {
           path: filePath,
           options: { filepath: filePath },
         },
-        true,
-      ),
+        shouldWrite: true,
+      }),
     ).resolves.toBe('unsupported');
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,12 +127,12 @@ catalogs:
     tiny-readdir:
       specifier: 3.1.1
       version: 3.1.1
+    tinypool:
+      specifier: 2.1.0
+      version: 2.1.0
     typescript:
       specifier: ^7.0.2
       version: 7.0.2
-    worktank:
-      specifier: 3.0.2
-      version: 3.0.2
     yuku-parser:
       specifier: 0.8.3
       version: 0.8.3
@@ -348,6 +348,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
+      tinypool:
+        specifier: 'catalog:'
+        version: 2.1.0
       yuku-parser:
         specifier: 'catalog:'
         version: 0.8.3
@@ -406,9 +409,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
-      worktank:
-        specifier: 'catalog:'
-        version: 3.0.2
 
   website:
     devDependencies:
@@ -1603,9 +1603,6 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
-  immediato@1.1.0:
-    resolution: {integrity: sha512-6DTWQWiM3SyxAbNRDmMvFgZVwVP6wT8ciQv7GivxXejtXZFIcemC0Wlzfd/jEouJ2JroCIp4qZVloKW4BviUpQ==}
-
   immutable@5.1.9:
     resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
 
@@ -1654,12 +1651,6 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
-
-  isoconcurrency@1.0.0:
-    resolution: {integrity: sha512-YhuPf5V6uOtQQHt9gIkOTbq75ceXqraDvxtZZeS/XbNsre6fmM+WpJgNTSkGX5jB3+gnbwoTVqW1c3qdfyVpOA==}
-
-  isotimer@1.0.0:
-    resolution: {integrity: sha512-1p1wborMl9fFbulXx9YBpIqFnfUn/2tN8Ne9g3GLMaiQAPmN/wLlpNOKCNT822div3Sq7LKkApZJ+6JipDUusQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2326,6 +2317,10 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2392,15 +2387,9 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
-  webworker-shim@1.1.4:
-    resolution: {integrity: sha512-W/40L5W6ZQyGhYr3hJ7N/2SjdK5OdFtnYm94j6xlRyjckegXnIGwz0EdxdkQx6VGTglJjK8mqBhMz3fd3AY4bg==}
-
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
-
-  worktank@3.0.2:
-    resolution: {integrity: sha512-ry5gPtWnakOnUBAAa2aiyWZwAFJuBtd/MwZH6o9DXnQHD4AZvidtl2uTLrb2d3Zjy9D04n84lHJNnIETQl7tuA==}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -3507,8 +3496,6 @@ snapshots:
 
   ignore@7.0.6: {}
 
-  immediato@1.1.0: {}
-
   immutable@5.1.9: {}
 
   import-meta-resolve@4.2.0: {}
@@ -3545,12 +3532,6 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
-
-  isoconcurrency@1.0.0: {}
-
-  isotimer@1.0.0:
-    dependencies:
-      immediato: 1.1.0
 
   js-tokens@4.0.0: {}
 
@@ -4500,6 +4481,8 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
+  tinypool@2.1.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -4601,16 +4584,7 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  webworker-shim@1.1.4: {}
-
   whatwg-mimetype@3.0.0: {}
-
-  worktank@3.0.2:
-    dependencies:
-      isoconcurrency: 1.0.0
-      isotimer: 1.0.0
-      promise-make-naked: 3.0.2
-      webworker-shim: 1.1.4
 
   ws@8.21.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,9 +51,9 @@ catalog:
   rslog: ^2.3.0
   'rspress-plugin-font-open-sans': '^1.0.4'
   'sort-package-json': '4.0.0'
+  tinypool: '2.1.0'
   tiny-readdir: 3.1.1
   'typescript': '^7.0.2'
-  worktank: '3.0.2'
   yuku-parser: '0.8.3'
 
 overrides:


### PR DESCRIPTION
## Summary

This PR replaces WorkTank with Tinypool for formatter worker execution while preserving the existing formatter behavior. Tinypool remains a runtime dependency and relies on Rslib's default dependency externalization. Worker tasks now use object payloads, and pool shutdown is awaited to ensure cleanup completes.