### PR TITLE
perf(fmt): cap default worker count at eight

### DIFF
--- a/packages/rstack/src/fmt/workerPool.ts
+++ b/packages/rstack/src/fmt/workerPool.ts
@@ -14,8 +14,13 @@ interface FmtWorkerPool {
   terminate: () => Promise<void>;
 }
 
+/**
+ * Caps the default worker count at 8 because formatter throughput can
+ * plateau before all CPU cores are occupied, while additional workers increase
+ * scheduling and memory pressure.
+ */
 const getFmtWorkerCount = (fileCount: number, maxWorkers?: number): number =>
-  Math.min(fileCount, maxWorkers ?? Math.max(1, availableParallelism() - 1));
+  Math.min(fileCount, maxWorkers ?? Math.min(8, Math.max(1, availableParallelism() - 1)));
 
 const getFmtWorkerUrl = (): URL => {
   // Source tests run after build and exercise the same worker artifact as the CLI.

--- a/packages/rstack/tests/fmt/workerPool.test.ts
+++ b/packages/rstack/tests/fmt/workerPool.test.ts
@@ -1,17 +1,11 @@
-import { availableParallelism } from 'node:os';
 import { expect, test } from 'rstack/test';
 import { getFmtWorkerCount } from '../../src/fmt/workerPool.ts';
-
-test('uses one fewer worker than the available parallelism by default', () => {
-  const defaultWorkerCount = Math.max(1, availableParallelism() - 1);
-
-  expect(getFmtWorkerCount(defaultWorkerCount + 1)).toBe(defaultWorkerCount);
-});
 
 test.each([
   [4, 1, 1],
   [4, 2, 2],
   [2, 4, 2],
+  [12, 10, 10],
 ])('uses %s files and %s configured workers as %s workers', (files, workers, expected) => {
   expect(getFmtWorkerCount(files, workers)).toBe(expected);
 });


### PR DESCRIPTION
Formatter throughput can plateau before all CPU cores are occupied, while additional workers increase scheduling and memory pressure. This caps the default `rs fmt` worker count at 8 while preserving explicit `maxWorkers` overrides.