### PR TITLE
docs: add rs fmt to monorepo guide

### DIFF
--- a/website/docs/en/guide/monorepo.mdx
+++ b/website/docs/en/guide/monorepo.mdx
@@ -2,13 +2,13 @@
 
 This guide explains how to use Rstack CLI in a monorepo, including how it works with task orchestrators such as [Turborepo](https://turborepo.com/docs) and [Nx](https://nx.dev/docs/getting-started/intro).
 
-It covers managing Rstack dependencies, configuring lint and staged-file tasks at the root, and defining separate configurations for web applications and libraries.
+It covers managing Rstack dependencies, configuring lint, formatting, and staged-file tasks at the root, and defining separate configurations for web applications and libraries.
 
 ## Project structure
 
 The recommended setup has two levels:
 
-- The root manages the shared Rstack version, lint rules, and staged-file tasks.
+- The root manages the shared Rstack version, lint and formatting rules, and staged-file tasks.
 - Each application or library has its own [Rstack configuration](./configuration) for build, test, or documentation configuration.
 
 ```text
@@ -37,7 +37,7 @@ Project-specific dependencies, such as Rsbuild plugins and testing libraries, sh
 
 ## Root configuration
 
-Use [`define.lint()`](./configuration#define-lint) and [`define.staged()`](./configuration#define-staged) in the root `rstack.config.ts` for checks that apply to the entire repository:
+Use [`define.lint()`](./configuration#define-lint), [`define.fmt()`](./configuration#define-fmt), and [`define.staged()`](./configuration#define-staged) in the root `rstack.config.ts` for checks and formatting that apply to the entire repository:
 
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
@@ -48,8 +48,14 @@ define.lint(async () => {
   return [js.configs.recommended, ts.configs.recommended];
 });
 
+define.fmt({
+  singleQuote: true,
+  ignorePatterns: ['**/dist/**'],
+});
+
 define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs}': 'rs lint',
+  '*.{js,jsx,ts,tsx,mjs,cjs}': ['rs lint', 'rs fmt'],
+  '*.{json,md,mdx,css,html,yml,yaml}': 'rs fmt',
 });
 ```
 
@@ -60,6 +66,8 @@ Expose these tasks through scripts in the root `package.json`:
   "private": true,
   "scripts": {
     "lint": "rs lint",
+    "format": "rs fmt",
+    "check:format": "rs fmt --check",
     "staged": "rs staged"
   }
 }

--- a/website/docs/zh/guide/monorepo.mdx
+++ b/website/docs/zh/guide/monorepo.mdx
@@ -2,13 +2,13 @@
 
 本指南介绍如何在 Monorepo 中使用 Rstack CLI，以及如何让它与 [Turborepo](https://turborepo.com/docs)、[Nx](https://nx.dev/docs/getting-started/intro) 等任务编排工具协同工作。
 
-主要内容包括管理 Rstack 依赖、在根目录统一配置代码检查和暂存文件任务，以及为 Web 应用和库项目定义独立配置。
+主要内容包括管理 Rstack 依赖、在根目录统一配置代码检查、格式化和暂存文件任务，以及为 Web 应用和库项目定义独立配置。
 
 ## 目录结构 \{#project-structure}
 
 推荐使用两层配置：
 
-- 根目录统一管理 Rstack 版本、lint 规则和暂存文件任务。
+- 根目录统一管理 Rstack 版本、lint 和格式化规则，以及暂存文件任务。
 - 每个应用或库使用自己的 [Rstack 配置](./configuration)，定义构建、测试或文档配置。
 
 ```text
@@ -37,7 +37,7 @@ Rsbuild 插件、测试库等项目专属依赖，建议定义在实际使用它
 
 ## 根配置 \{#root-configuration}
 
-在根目录的 `rstack.config.ts` 中使用 [`define.lint()`](./configuration#define-lint) 和 [`define.staged()`](./configuration#define-staged) 配置适用于整个仓库的检查：
+在根目录的 `rstack.config.ts` 中使用 [`define.lint()`](./configuration#define-lint)、[`define.fmt()`](./configuration#define-fmt) 和 [`define.staged()`](./configuration#define-staged)，配置适用于整个仓库的检查和格式化：
 
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
@@ -48,8 +48,14 @@ define.lint(async () => {
   return [js.configs.recommended, ts.configs.recommended];
 });
 
+define.fmt({
+  singleQuote: true,
+  ignorePatterns: ['**/dist/**'],
+});
+
 define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs}': 'rs lint',
+  '*.{js,jsx,ts,tsx,mjs,cjs}': ['rs lint', 'rs fmt'],
+  '*.{json,md,mdx,css,html,yml,yaml}': 'rs fmt',
 });
 ```
 
@@ -60,6 +66,8 @@ define.staged({
   "private": true,
   "scripts": {
     "lint": "rs lint",
+    "format": "rs fmt",
+    "check:format": "rs fmt --check",
     "staged": "rs staged"
   }
 }


### PR DESCRIPTION
This PR extends the monorepo guide so repository-wide formatting can be configured alongside linting and staged-file tasks. It adds aligned English and Chinese examples for `define.fmt()`, `rs fmt`, format-check scripts, and staged formatting.