### PR TITLE
feat(setup): improve skipped setup log

### DIFF
--- a/packages/rstack/src/setup/index.ts
+++ b/packages/rstack/src/setup/index.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from 'node:util';
-import { color } from 'rslog';
+import { color, logger } from 'rslog';
 import { installHooks } from './install.ts';
 
 const helpMessage = `Rstack v${RSTACK_VERSION}
@@ -45,7 +45,7 @@ export const runSetupCLI = (args: string[]): void => {
   if (result.status === 'skipped') {
     const reason =
       result.reason === 'disabled' ? 'disabled by RSTACK_HOOKS' : 'not a Git repository';
-    console.log(`Git hooks setup skipped: ${reason}.`);
+    logger.info(`Git hooks setup skipped: ${color.yellow(reason)}.`);
     return;
   }
 

--- a/packages/rstack/tests/cli/setup/index.test.ts
+++ b/packages/rstack/tests/cli/setup/index.test.ts
@@ -108,7 +108,7 @@ test('installs a custom hooks directory from a nested project', ({ execCli, expe
 
 test('skips non-Git directories without creating files', ({ execCli, expect }) => {
   expect(execCli('setup', { cwd, env })).toContain(
-    'Git hooks setup skipped: not a Git repository.',
+    'info    Git hooks setup skipped: not a Git repository.',
   );
   expect(existsSync(path.join(cwd, '.rstack'))).toBe(false);
 });
@@ -116,7 +116,7 @@ test('skips non-Git directories without creating files', ({ execCli, expect }) =
 test('skips setup when hooks are disabled', ({ execCli, expect }) => {
   const output = execCli('setup', { cwd, env: { ...env, RSTACK_HOOKS: '0' } });
 
-  expect(output).toContain('Git hooks setup skipped: disabled by RSTACK_HOOKS.');
+  expect(output).toContain('info    Git hooks setup skipped: disabled by RSTACK_HOOKS.');
   expect(existsSync(path.join(cwd, '.rstack'))).toBe(false);
 });
 


### PR DESCRIPTION
This PR makes skipped `rs setup` outcomes consistent with other Rstack CLI status output. It replaces the direct console call with `logger.info` and highlights the skip reason in yellow, while leaving help output unchanged.