### PR TITLE
feat(fmt): improve formatting check output

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -94,7 +94,7 @@ const logFmtResult = (result: FmtRunResult, mode: FmtMode, cwd: string): void =>
       logger.success(displayPath);
     } else if (file.status === 'different') {
       differentCount++;
-      logger[mode === 'check' ? 'warn' : 'log'](displayPath);
+      logger[mode === 'check' ? 'error' : 'log'](displayPath);
     } else if (file.status === 'error') {
       errorCount++;
       logger.error(`${displayPath}: ${String(file.error)}`);
@@ -107,9 +107,9 @@ const logFmtResult = (result: FmtRunResult, mode: FmtMode, cwd: string): void =>
 
   if (differentCount > 0) {
     const files = differentCount === 1 ? 'file' : 'files';
-    logger.warn(
-      `Code style issues found in ${differentCount} ${files}. Run rs fmt --write to fix.`,
-    );
+    const count = color.bold(color.red(differentCount));
+    const writeCommand = color.cyan('rs fmt --write');
+    logger.error(`Code style issues found in ${count} ${files}. Run ${writeCommand} to fix.`);
   } else if (errorCount === 0) {
     logger.success('All matched files are correctly formatted.');
   }

--- a/packages/rstack/tests/cli/fmt/index.test.ts
+++ b/packages/rstack/tests/cli/fmt/index.test.ts
@@ -222,9 +222,9 @@ test('checks formatting without writing files', () => {
 
   expect(result.status).toBe(1);
   expect(result.stdout).toBe('start   Checking formatting...\n');
-  expect(result.stderr).toContain('warn    index.ts');
+  expect(result.stderr).toContain('error   index.ts');
   expect(result.stderr).toContain(
-    'warn    Code style issues found in 1 file. Run rs fmt --write to fix.',
+    'error   Code style issues found in 1 file. Run rs fmt --write to fix.',
   );
   expect(readProjectFile('index.ts')).toBe(source);
 


### PR DESCRIPTION
This PR makes failed `rs fmt --check` results more prominent in terminal output. It reports differing files and the summary at the error level, highlights the file count in bold red, and colors the suggested `rs fmt --write` command cyan. `--list-different` output remains unchanged for scripting compatibility.