### PR TITLE
docs(skills): add formatting migration guide

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/SKILL.md
+++ b/.agents/skills/migrate-to-rstack-cli/SKILL.md
@@ -32,7 +32,7 @@ Read every matching reference before editing. Load only the tools present in the
 8. Refresh the lockfile with the repository's package manager. Confirm the expected tool version changes and resolve peer dependency warnings.
 9. Run the repository's existing migrated scripts and required checks. Compare generated artifacts or runtime behavior where relevant.
 
-The underlying Rsbuild, Rslib, Rstest, Rslint, Prettier, and sort-package-json packages remain transitive dependencies of `rstack`. Do not require their names to disappear from the lockfile; require obsolete direct manifest entries and imports to disappear.
+The underlying Rsbuild, Rslib, Rstest, Rslint, and Prettier packages remain transitive dependencies of `rstack`. Do not require their names to disappear from the lockfile; require obsolete direct manifest entries and imports to disappear.
 
 ## Configuration Rules
 

--- a/.agents/skills/migrate-to-rstack-cli/SKILL.md
+++ b/.agents/skills/migrate-to-rstack-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migrate-to-rstack-cli
-description: Use when migrating projects from standalone Rsbuild, Rslib, Rstest, Rslint, Rspress, lint-staged, husky or simple-git-hooks tooling to the unified `rstack` package, `rs` commands, and `rstack.config.*`.
+description: Use when migrating projects from standalone Rsbuild, Rslib, Rstest, Rslint, Rspress, Prettier, sort-package-json, lint-staged, husky, or simple-git-hooks tooling to the unified `rstack` package, `rs` commands, and `rstack.config.*`.
 ---
 
 # Migrate to Rstack CLI
@@ -15,13 +15,14 @@ Read every matching reference before editing. Load only the tools present in the
 - `@rslib/core`, `rslib.config.*`, `rslib` commands, or Rslib types: [rslib.md](references/rslib.md)
 - `@rstest/core`, `@rstest/adapter-*`, `rstest.config.*`, `rstest` commands, or test imports: [rstest.md](references/rstest.md)
 - `@rslint/core`, `rslint.config.*`, `rslint` commands, or lint imports: [rslint.md](references/rslint.md)
+- `prettier`, `package.json#prettier`, `.prettierrc*`, `prettier.config.*`, `.prettierignore`, `.editorconfig`, `sort-package-json`, Prettier plugins, or formatting scripts: [prettier.md](references/prettier.md)
 - `@rspress/core`, `rspress.config.*`, `rspress` commands, themes, or plugins: [rspress.md](references/rspress.md)
 - `lint-staged`, `nano-staged`, their configs: [lint-staged.md](references/lint-staged.md)
 - `husky`, `.husky/`, `package.json#husky`, `simple-git-hooks`, `.simple-git-hooks.*`, or Git hook installer scripts: [git-hooks.md](references/git-hooks.md)
 
 ## Workflow
 
-1. Inspect manifests, workspace catalogs, lock files, scripts, standalone configs, Git hooks, TypeScript `types`, and source imports.
+1. Inspect manifests, workspace catalogs, lock files, scripts, standalone configs, ignore files, Git hooks, TypeScript `types`, and source imports.
 2. Read the matching references and inventory behavior that must survive: config functions, CLI arguments, plugins, presets, adapters, custom config paths, and chained commands.
 3. Check the latest `rstack` version and inspect its Node.js engine and underlying tool versions. Resolve plugin and adapter peer ranges first; upgrade incompatible extensions or stop when no compatible version exists. Add `rstack` using the repository's existing package manager and version convention, usually as a development dependency.
 4. If a matching reference uses a `define.*` registration, create `rstack.config.ts` and move the standalone configuration into it.
@@ -31,7 +32,7 @@ Read every matching reference before editing. Load only the tools present in the
 8. Refresh the lockfile with the repository's package manager. Confirm the expected tool version changes and resolve peer dependency warnings.
 9. Run the repository's existing migrated scripts and required checks. Compare generated artifacts or runtime behavior where relevant.
 
-Underlying Rsbuild, Rslib, Rstest, and Rslint packages remain transitive dependencies of `rstack`. Do not require their names to disappear from the lockfile; require obsolete direct manifest entries and imports to disappear.
+The underlying Rsbuild, Rslib, Rstest, Rslint, Prettier, and sort-package-json packages remain transitive dependencies of `rstack`. Do not require their names to disappear from the lockfile; require obsolete direct manifest entries and imports to disappear.
 
 ## Configuration Rules
 

--- a/.agents/skills/migrate-to-rstack-cli/references/lint-staged.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/lint-staged.md
@@ -4,6 +4,8 @@
 
 Read this reference when the project uses `lint-staged`, `nano-staged`, a staged-file config, or a staged-file Git hook.
 
+If staged tasks invoke Prettier, also read [prettier.md](prettier.md).
+
 ## Steps
 
 1. Replace staged-file script invocations with `rs staged`.
@@ -17,8 +19,8 @@ Read this reference when the project uses `lint-staged`, `nano-staged`, a staged
 import { define } from 'rstack';
 
 define.staged({
-  '*.{ts,tsx,js,jsx}': ['rs lint --fix', 'prettier -w'],
-  '*.{json,md}': 'prettier -w',
+  '*.{ts,tsx,js,jsx}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,md}': 'rs fmt',
 });
 ```
 

--- a/.agents/skills/migrate-to-rstack-cli/references/prettier.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/prettier.md
@@ -8,7 +8,7 @@ Read this reference when the project uses the `prettier` CLI or API, `package.js
 
 1. Inventory formatting commands and inputs, Prettier options and overrides, ignore rules, `.editorconfig`, plugins, package.json sorting, and programmatic API calls.
 2. Move Prettier options and overrides into `define.fmt` in `rstack.config.*`.
-3. Move `.prettierignore` or custom `--ignore-path` rules into `ignorePatterns`, preserving rule order and negations. Translate relevant `.editorconfig` values into explicit formatting options.
+3. Move `.prettierignore` or custom `--ignore-path` rules into `ignorePatterns`. Rebase patterns from each ignore file's directory to the Rstack configuration directory when they differ, preserving rule order and negations. Translate relevant `.editorconfig` values into explicit formatting options.
 4. Replace Prettier CLI commands with the matching `rs fmt` commands and preserve their file or glob arguments.
 5. Reference plugins by package name, file path, or URL. Do not pass imported plugin objects, and keep each plugin package as a direct dependency.
 6. When replacing `prettier-plugin-packagejson`, enable `sortPackageJson` and preserve the original manifest paths.

--- a/.agents/skills/migrate-to-rstack-cli/references/prettier.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/prettier.md
@@ -1,0 +1,36 @@
+# Prettier Migration
+
+`rs fmt` is Rstack's faster, Prettier-based formatter. See the [formatting guide](https://rstack.rs/guide/formatting) for supported options, file discovery, overrides, plugins, and Rstack-specific capabilities.
+
+Read this reference when the project uses the `prettier` CLI or API, `package.json#prettier`, Prettier configuration files, `.prettierignore`, `.editorconfig`, `sort-package-json`, Prettier plugins, or formatting scripts.
+
+## Steps
+
+1. Inventory formatting commands and inputs, Prettier options and overrides, ignore rules, `.editorconfig`, plugins, package.json sorting, and programmatic API calls.
+2. Move Prettier options and overrides into `define.fmt` in `rstack.config.*`.
+3. Move `.prettierignore` or custom `--ignore-path` rules into `ignorePatterns`, preserving rule order and negations. Translate relevant `.editorconfig` values into explicit formatting options.
+4. Replace Prettier CLI commands with the matching `rs fmt` commands and preserve their file or glob arguments.
+5. Reference plugins by package name, file path, or URL. Do not pass imported plugin objects, and keep each plugin package as a direct dependency.
+6. When replacing `prettier-plugin-packagejson`, enable `sortPackageJson` and preserve the original manifest paths.
+7. Delete old config and ignore files only after their behavior is represented in `define.fmt`.
+8. Remove direct dependencies only when no script, config, API call, plugin peer requirement, or other tool still needs them.
+
+`rs fmt` does not read Prettier configuration files, `.prettierignore`, or `.editorconfig`.
+
+Keep `.editorconfig` when editors or other tools use it. Keep Prettier when application code uses APIs such as `prettier.format()`; `rs fmt` is not a drop-in replacement for the programmatic API.
+
+## Command Mapping
+
+| Prettier                      | Rstack CLI                |
+| ----------------------------- | ------------------------- |
+| `prettier --write .`          | `rs fmt`                  |
+| `prettier --check .`          | `rs fmt --check`          |
+| `prettier --list-different .` | `rs fmt --list-different` |
+
+`rs fmt` writes by default. Move formatting flags such as `--single-quote` into `define.fmt` instead of passing them to `rs fmt`. Keep Prettier or redesign commands that rely on stdin or other unsupported CLI behavior.
+
+## Validate
+
+1. Run the migrated write command and review the changed files, especially files handled by plugins or `sortPackageJson`.
+2. Run `rs fmt --check` and confirm it exits successfully.
+3. Compare the selected file set with the old command. Directory and glob discovery follows `.gitignore`, while explicitly named files do not; use `ignorePatterns` for unconditional exclusions.

--- a/.agents/skills/migrate-to-rstack-cli/references/rslint.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rslint.md
@@ -23,11 +23,13 @@ define.lint(async () => {
 
 ## Script Pattern
 
+If a script also runs Prettier, migrate its formatting command as described in [prettier.md](prettier.md).
+
 ```json
 {
   "scripts": {
-    "lint": "rs lint && prettier -c .",
-    "lint:write": "rs lint --fix && prettier -w ."
+    "lint": "rs lint && rs fmt --check",
+    "lint:write": "rs lint --fix && rs fmt"
   }
 }
 ```


### PR DESCRIPTION
This PR adds Prettier migration guidance to the `migrate-to-rstack-cli` skill so formatting behavior is preserved when adopting `rs fmt`.

It also updates the lint-staged and Rslint migration examples to use `rs fmt`.

## Related Links

- https://rstack.rs/guide/formatting