### PR TITLE
fix(fmt): report partial writes on errors

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -122,10 +122,12 @@ const logFmtResult = (
   matchedFileCount: number,
   durationSeconds: number,
 ): void => {
+  let writtenCount = 0;
   let differentCount = 0;
 
   for (const file of result.files) {
     if (file.status === 'written') {
+      writtenCount++;
       continue;
     }
 
@@ -139,18 +141,17 @@ const logFmtResult = (
   }
 
   if (mode === 'write') {
-    if (result.exitCode !== 0) {
+    if (writtenCount === 0 && result.exitCode !== 0) {
       return;
     }
 
-    const writtenCount = result.files.length;
     const matchedFiles = formatFileCount(matchedFileCount);
     const time = prettyTime(durationSeconds);
-    if (writtenCount > 0) {
-      logger.success(`Formatted ${formatCount(writtenCount)} of ${matchedFiles} in ${time}.`);
-    } else {
-      logger.success(`Checked ${matchedFiles} in ${time}. No changes needed.`);
-    }
+    const message =
+      writtenCount > 0
+        ? `Formatted ${formatCount(writtenCount)} of ${matchedFiles} in ${time}.`
+        : `Checked ${matchedFiles} in ${time}. No changes needed.`;
+    logger[result.exitCode === 0 ? 'success' : 'info'](message);
     return;
   }
 

--- a/packages/rstack/tests/cli/fmt/index.test.ts
+++ b/packages/rstack/tests/cli/fmt/index.test.ts
@@ -370,6 +370,19 @@ test('returns exit code 2 for formatting errors', () => {
   expect(result.stderr).toContain('error   index.ts: SyntaxError:');
 });
 
+test('reports partial writes when formatting fails', () => {
+  writeProjectFile('valid.ts', 'const value=true');
+  writeProjectFile('invalid.ts', 'const invalid = ;');
+
+  const result = runFmt(['valid.ts', 'invalid.ts']);
+
+  expect(result.status).toBe(2);
+  expect(normalizeDuration(result.stdout)).toBe('info    Formatted 1 of 2 files in <duration>.\n');
+  expect(result.stderr).toContain('error   invalid.ts: SyntaxError:');
+  expect(readProjectFile('valid.ts')).toBe('const value = true;\n');
+  expect(readProjectFile('invalid.ts')).toBe('const invalid = ;');
+});
+
 test('reports when no files match', () => {
   const writeResult = runFmt(['missing/**/*.ts']);
 


### PR DESCRIPTION
`rs fmt --write` can modify valid files even when another file fails to format, but the CLI currently reports only the error and hides those writes. This PR tracks successful writes and emits a neutral summary for partial results while retaining the failing exit code and per-file errors.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/157