### PR TITLE
docs: refine CLI and configuration guides

### DIFF
--- a/website/docs/en/guide/cli/lib.mdx
+++ b/website/docs/en/guide/cli/lib.mdx
@@ -26,6 +26,14 @@ rs lib --watch
 
 ## Subcommands
 
+### build
+
+[`rs lib build`](https://rslib.rs/guide/basic/cli#rslib) builds library outputs for production. It is equivalent to running `rs lib` without a subcommand.
+
+```bash
+rs lib build
+```
+
 ### inspect
 
 [`rs lib inspect`](https://rslib.rs/guide/basic/cli#rslib-inspect) generates the normalized Rslib configuration and the corresponding Rsbuild and Rspack configurations for inspection.

--- a/website/docs/en/guide/configuration.mdx
+++ b/website/docs/en/guide/configuration.mdx
@@ -1,5 +1,7 @@
 # Configuration
 
+import { PackageManagerTabs } from '@rspress/core/theme';
+
 Rstack centralizes the configuration for your project's tools in a single file. Define only the configurations your project needs with the `define.*()` APIs.
 
 ## Configuration file
@@ -125,9 +127,7 @@ define.doc({
 
 `@rspress/core` is an optional dependency of Rstack. Install it in every project that uses the `rs doc` command:
 
-```bash
-pnpm add -D @rspress/core
-```
+<PackageManagerTabs command="install -D @rspress/core" />
 
 ### `define.test()` \{#define-test}
 

--- a/website/docs/en/guide/formatting.mdx
+++ b/website/docs/en/guide/formatting.mdx
@@ -123,7 +123,7 @@ define.fmt({
 
 ### Pattern matching
 
-The `files` and `excludeFiles` patterns are resolved relative to the directory containing `rstack.config.ts`.
+The `files` and `excludeFiles` patterns are resolved relative to the directory containing the Rstack configuration file.
 
 In `files`, a pattern without `/` matches file names at any depth, while a pattern containing `/` matches relative paths. In this example, `*.md` matches Markdown files in any directory, while `scripts/**/*.js` matches paths relative to the configuration directory:
 

--- a/website/docs/zh/guide/cli/lib.mdx
+++ b/website/docs/zh/guide/cli/lib.mdx
@@ -26,6 +26,14 @@ rs lib --watch
 
 ## 子命令 \{#subcommands}
 
+### build
+
+[`rs lib build`](https://rslib.rs/zh/guide/basic/cli#rslib) 用于构建生产环境的库产物，其效果与直接运行 `rs lib` 相同。
+
+```bash
+rs lib build
+```
+
 ### inspect
 
 [`rs lib inspect`](https://rslib.rs/zh/guide/basic/cli#rslib-inspect) 用于生成归一化后的 Rslib 配置及对应的 Rsbuild 和 Rspack 配置，以便检查最终生效的配置。

--- a/website/docs/zh/guide/configuration.mdx
+++ b/website/docs/zh/guide/configuration.mdx
@@ -1,5 +1,7 @@
 # 配置 \{#configuration}
 
+import { PackageManagerTabs } from '@rspress/core/theme';
+
 Rstack 将项目所用工具的配置集中到一份文件中。通过 `define.*()` API 定义项目实际需要的配置即可。
 
 ## 配置文件 \{#configuration-file}
@@ -125,9 +127,7 @@ define.doc({
 
 `@rspress/core` 是 Rstack 的可选依赖。每个使用 `rs doc` 命令的项目都需要安装该依赖：
 
-```bash
-pnpm add -D @rspress/core
-```
+<PackageManagerTabs command="install -D @rspress/core" />
 
 ### `define.test()` \{#define-test}
 

--- a/website/docs/zh/guide/formatting.mdx
+++ b/website/docs/zh/guide/formatting.mdx
@@ -123,7 +123,7 @@ define.fmt({
 
 ### 模式匹配 \{#pattern-matching}
 
-`files` 和 `excludeFiles` 模式都基于 `rstack.config.ts` 所在目录解析。
+`files` 和 `excludeFiles` 模式都基于 Rstack 配置文件所在目录解析。
 
 在 `files` 中，不包含 `/` 的模式会匹配任意深度的文件名，包含 `/` 的模式则匹配相对路径。下面示例中的 `*.md` 会匹配任意目录中的 Markdown 文件，而 `scripts/**/*.js` 会匹配相对于 Rstack 配置文件所在目录的路径：
 

--- a/website/i18n.json
+++ b/website/i18n.json
@@ -16,8 +16,8 @@
     "zh": "统一命令行"
   },
   "unifiedCliDesc": {
-    "en": "Develop, build, test, lint, publish libraries, and serve docs with the rs command.",
-    "zh": "通过 rs 命令完成开发、构建、测试、检查、库构建和文档开发。"
+    "en": "Develop, build, test, lint, format code, build libraries, and serve docs with the rs command.",
+    "zh": "通过 rs 命令完成开发、构建、测试、检查、格式化、库构建和文档开发。"
   },
   "oneConfig": {
     "en": "One Configuration",


### PR DESCRIPTION
This PR fixes several documentation inconsistencies across the English and Chinese guides. It documents the `rs lib build` subcommand, makes formatting paths configuration-file agnostic, uses package-manager tabs for `@rspress/core`, and updates the homepage CLI capabilities.

## Related Links

- https://rslib.rs/guide/basic/cli#rslib