### PR TITLE
perf(cli): lazy-load setup and staged commands

### DIFF
--- a/packages/rstack/rslib.config.ts
+++ b/packages/rstack/rslib.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@rslib/core';
 import pkgJson from './package.json' with { type: 'json' };
 
-const fullyMinifiedChunks = /lintStaged\.js$/;
+const fullyMinifiedChunks = /staged\.js$/;
 
 export default defineConfig({
   lib: [{ syntax: 'es2023', dts: true }],
@@ -32,7 +32,8 @@ export default defineConfig({
       css: false,
       jsOptions: [
         {
-          // Fully minify the bundled lint-staged code to reduce package size.
+          // Fully minify the staged chunk, including bundled lint-staged code,
+          // to reduce package size.
           include: fullyMinifiedChunks,
         },
         {

--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -1,8 +1,6 @@
 import { join } from 'node:path';
 import { color } from 'rslog';
 import { getConfigState } from '../config.ts';
-import { runSetupCLI } from '../setup/index.ts';
-import { runStagedCLI } from '../staged.ts';
 import { insertConfigArg, parseCliArgs } from './args.ts';
 
 declare global {
@@ -154,11 +152,19 @@ export async function setupCommands(): Promise<void> {
   }
 
   if (command === 'staged') {
+    const { runStagedCLI } = await import(
+      /* rspackChunkName: 'staged' */
+      '../staged.ts'
+    );
     await runStagedCLI(args.slice(1));
     return;
   }
 
   if (command === 'setup') {
+    const { runSetupCLI } = await import(
+      /* rspackChunkName: 'setup' */
+      '../setup/index.ts'
+    );
     runSetupCLI(args.slice(1));
     return;
   }

--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from 'node:util';
+import lintStaged from 'lint-staged';
 import { color } from 'rslog';
 import { loadRstackConfig } from './config.ts';
 
@@ -70,10 +71,6 @@ export async function runStagedCLI(args: string[]): Promise<void> {
     );
   }
 
-  const { default: lintStaged } = await import(
-    /* rspackChunkName: 'lintStaged' */
-    'lint-staged'
-  );
   const success = await lintStaged({
     allowEmpty: values['allow-empty'] ?? values.allowEmpty,
     concurrent: values.concurrent === undefined ? undefined : JSON.parse(values.concurrent),


### PR DESCRIPTION
Rstack currently loads the setup and staged command implementations for every CLI invocation. This PR loads both commands only when selected and keeps lint-staged bundled into the fully minified staged chunk, avoiding a second dynamic-import boundary.