### PR TITLE
perf(fmt): load plugin resolver on demand

### DIFF
--- a/packages/rstack/src/fmt/discovery.ts
+++ b/packages/rstack/src/fmt/discovery.ts
@@ -1,16 +1,11 @@
 import { resolveFmtOptions } from './config.ts';
 import { discoverFmtPaths } from './discoverPaths.ts';
 import { createFmtIgnoreMatcher } from './ignore.ts';
-import { createFmtPluginResolver, type FmtPluginResolver } from './plugins.ts';
 import type { DiscoverFmtFilesOptions, FmtFileRequest, ResolvedFmtConfig } from './types.ts';
 
-const createFileRequest = (
-  filePath: string,
-  config: ResolvedFmtConfig,
-  resolvePlugins: FmtPluginResolver,
-): FmtFileRequest => ({
+const createFileRequest = (filePath: string, config: ResolvedFmtConfig): FmtFileRequest => ({
   path: filePath,
-  options: resolvePlugins(resolveFmtOptions(filePath, config)),
+  options: resolveFmtOptions(filePath, config),
 });
 
 /** Discovers worker-ready files without reading Prettier config files or `.prettierignore`. */
@@ -26,9 +21,18 @@ const discoverFmtFiles = async ({
 
   const isFmtIgnored = createFmtIgnoreMatcher(config);
   const filePaths = candidates.filter((filePath) => !isFmtIgnored(filePath));
+  const files = filePaths.map((filePath) => createFileRequest(filePath, config));
+  if (!files.some((file) => file.options.plugins?.length)) {
+    return files;
+  }
+
+  const { createFmtPluginResolver } = await import(
+    /* rspackChunkName: 'fmtPlugins' */
+    './plugins.ts'
+  );
   const resolvePlugins = createFmtPluginResolver(config.rootPath);
 
-  return filePaths.map((filePath) => createFileRequest(filePath, config, resolvePlugins));
+  return files.map((file) => ({ ...file, options: resolvePlugins(file.options) }));
 };
 
 export { discoverFmtFiles };


### PR DESCRIPTION
Formatting without third-party plugins currently loads the plugin resolver and its import-meta-resolve dependency. This PR resolves per-file options first and loads the resolver only when a discovered file actually uses plugins, keeping unmatched plugin overrides off the common path.