### PR TITLE
perf(fmt): optimize root gitignore matching

### DIFF
--- a/packages/rstack/src/fmt/discoverPaths.ts
+++ b/packages/rstack/src/fmt/discoverPaths.ts
@@ -164,6 +164,15 @@ class GitIgnoreMatcher {
   }
 
   #matches(relativePath: string, isDirectory: boolean): boolean {
+    // Most repositories only use a root `.gitignore`. Avoid checking every path
+    // segment when no nested matcher can override its result.
+    const rootMatcher = this.#matchers.size === 1 ? this.#matchers.get(this.#rootPath) : undefined;
+    if (rootMatcher) {
+      // `ignore` expects POSIX separators and uses a trailing slash to distinguish directories.
+      const pathFromMatcher = toPosixPath(relativePath);
+      return rootMatcher.test(isDirectory ? `${pathFromMatcher}/` : pathFromMatcher).ignored;
+    }
+
     const segments = relativePath.split(path.sep);
     let directoryPath = this.#rootPath;
     let pathFromMatcher = segments.join('/');


### PR DESCRIPTION
## Summary

Most projects only have a root `.gitignore`, but formatting discovery still walked every path segment and performed matcher map lookups for each candidate. This PR directly uses the root matcher when it is the only loaded matcher, while retaining layered matching as soon as a nested `.gitignore` is present.

## Benchmark

`discoverFmtPaths("packages")` with 10,001 candidate files (representative path depth: 7), only a root `.gitignore`, Node.js v24.12.0 on macOS arm64. Median of 20 runs after 5 warmups:

| | Before | After |
| --- | ---: | ---: |
| End-to-end discovery | 144.50 ms | 94.68 ms |

This reduces discovery time by 34.5%, a 1.53× speedup.