### PR TITLE
perf(fmt): load stdin formatter on demand

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -6,7 +6,6 @@ import { loadRstackConfig } from '../config.ts';
 import { resolveFmtConfig } from './config.ts';
 import { discoverFmtFiles } from './discovery.ts';
 import { runFmtFiles } from './runner.ts';
-import { runFmtStdin } from './stdin.ts';
 import type { FmtMode, FmtRunResult, ResolvedFmtConfig } from './types.ts';
 
 interface ParsedFmtCLIArgs {
@@ -218,6 +217,10 @@ const runFmtCLI = async (args: string[]): Promise<void> => {
     }
 
     if (stdinFilepath !== undefined) {
+      const { runFmtStdin } = await import(
+        /* rspackChunkName: 'fmtStdin' */
+        './stdin.ts'
+      );
       await runFmtStdin({ filepath: stdinFilepath, cwd, loadConfig: () => loadFmtConfig(cwd) });
       return;
     }


### PR DESCRIPTION
## Summary

`rs fmt` currently loads the stdin formatter, Prettier, and bundled parser support for every invocation, including `--help` and file-based formatting. This change loads `./stdin.ts` only after `--stdin-filepath` selects stdin mode and emits it as the separate `fmtStdin` chunk, preserving stdin behavior while avoiding formatter startup work for other modes.

## Performance

Measured on macOS arm64 with Node.js v24.12.0 using `hyperfine --warmup 5 --runs 30 'node packages/rstack/bin/rs.js fmt --help'`:

| | Mean |
| --- | ---: |
| Before | 48.9 ms ± 2.8 ms |
| After | 32.8 ms ± 2.6 ms |

This reduces mean startup time by approximately 33%.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/167