### PR TITLE
fix(fmt): align help option descriptions

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -26,13 +26,13 @@ ${color.yellow('  $ rs fmt [options] [files/globs...]')}
 Format files with Prettier.
 
 ${color.cyan('Options')}:
-  --write             Write formatted files in place (default)
-  --check             Check whether files are formatted
-  --list-different    Print paths of unformatted files
-  --ignore-path <path>  Path to an additional ignore file (repeatable)
+  --write                     Write formatted files in place (default)
+  --check                     Check whether files are formatted
+  --list-different            Print paths of unformatted files
+  --ignore-path <path>        Path to an additional ignore file (repeatable)
   --parallel-workers <count>  Number of parallel workers
-  --stdin-filepath <path>  Format stdin as if it were saved at <path>
-  -h, --help          Display this help message`;
+  --stdin-filepath <path>     Format stdin as if it were saved at <path>
+  -h, --help                  Display this help message`;
 
 const parseMaxWorkers = (
   kebabValue: string | undefined,

--- a/packages/rstack/tests/fmt/__snapshots__/cli.test.ts.snap
+++ b/packages/rstack/tests/fmt/__snapshots__/cli.test.ts.snap
@@ -1,0 +1,19 @@
+// Rstest Snapshot v1
+
+exports[`provides command help 1`] = `
+"Rstack v0.3.2
+
+Usage:
+  $ rs fmt [options] [files/globs...]
+
+Format files with Prettier.
+
+Options:
+  --write                     Write formatted files in place (default)
+  --check                     Check whether files are formatted
+  --list-different            Print paths of unformatted files
+  --ignore-path <path>        Path to an additional ignore file (repeatable)
+  --parallel-workers <count>  Number of parallel workers
+  --stdin-filepath <path>     Format stdin as if it were saved at <path>
+  -h, --help                  Display this help message"
+`;

--- a/packages/rstack/tests/fmt/__snapshots__/cli.test.ts.snap
+++ b/packages/rstack/tests/fmt/__snapshots__/cli.test.ts.snap
@@ -1,9 +1,7 @@
 // Rstest Snapshot v1
 
 exports[`provides command help 1`] = `
-"Rstack v0.3.2
-
-Usage:
+"Usage:
   $ rs fmt [options] [files/globs...]
 
 Format files with Prettier.

--- a/packages/rstack/tests/fmt/cli.test.ts
+++ b/packages/rstack/tests/fmt/cli.test.ts
@@ -142,14 +142,7 @@ test('provides command help', () => {
   const helpMessage = stripVTControlCharacters(fmtHelpMessage);
 
   expect(helpMessage).toContain('Usage:\n  $ rs fmt [options] [files/globs...]');
-  expect(helpMessage).toContain(`Options:
-  --write                     Write formatted files in place (default)
-  --check                     Check whether files are formatted
-  --list-different            Print paths of unformatted files
-  --ignore-path <path>        Path to an additional ignore file (repeatable)
-  --parallel-workers <count>  Number of parallel workers
-  --stdin-filepath <path>     Format stdin as if it were saved at <path>
-  -h, --help                  Display this help message`);
+  expect(helpMessage).toMatchSnapshot();
 });
 
 test.each([

--- a/packages/rstack/tests/fmt/cli.test.ts
+++ b/packages/rstack/tests/fmt/cli.test.ts
@@ -139,14 +139,17 @@ test('rejects file arguments with --stdin-filepath', () => {
 });
 
 test('provides command help', () => {
-  expect(fmtHelpMessage).toContain('Usage:\n  $ rs fmt [options] [files/globs...]');
-  expect(fmtHelpMessage).toContain('--write');
-  expect(fmtHelpMessage).toContain('--check');
-  expect(fmtHelpMessage).toContain('--list-different');
-  expect(fmtHelpMessage).toContain('--ignore-path <path>');
-  expect(fmtHelpMessage).toContain('--parallel-workers <count>');
-  expect(fmtHelpMessage).toContain('--stdin-filepath <path>');
-  expect(fmtHelpMessage).toContain('-h, --help');
+  const helpMessage = stripVTControlCharacters(fmtHelpMessage);
+
+  expect(helpMessage).toContain('Usage:\n  $ rs fmt [options] [files/globs...]');
+  expect(helpMessage).toContain(`Options:
+  --write                     Write formatted files in place (default)
+  --check                     Check whether files are formatted
+  --list-different            Print paths of unformatted files
+  --ignore-path <path>        Path to an additional ignore file (repeatable)
+  --parallel-workers <count>  Number of parallel workers
+  --stdin-filepath <path>     Format stdin as if it were saved at <path>
+  -h, --help                  Display this help message`);
 });
 
 test.each([

--- a/packages/rstack/tests/fmt/cli.test.ts
+++ b/packages/rstack/tests/fmt/cli.test.ts
@@ -139,7 +139,7 @@ test('rejects file arguments with --stdin-filepath', () => {
 });
 
 test('provides command help', () => {
-  const helpMessage = stripVTControlCharacters(fmtHelpMessage);
+  const helpMessage = stripVTControlCharacters(fmtHelpMessage).replace(/^Rstack v.*\n\n/, '');
 
   expect(helpMessage).toContain('Usage:\n  $ rs fmt [options] [files/globs...]');
   expect(helpMessage).toMatchSnapshot();


### PR DESCRIPTION
## Summary

The `rs fmt` help output displayed option descriptions at inconsistent columns. This PR aligns every description to the longest option and strengthens the CLI help test to preserve the layout.