### PR TITLE
docs: clarify rs fmt ignore rules

### DIFF
--- a/website/docs/en/guide/cli/fmt.mdx
+++ b/website/docs/en/guide/cli/fmt.mdx
@@ -59,17 +59,33 @@ rs fmt --help
 
 ### `--ignore-path <path>`
 
-Load additional Gitignore-compatible rules from `<path>`. Repeat the option to load multiple
-ignore files:
+Use `--ignore-path` to load additional Gitignore-compatible rules from a file.
+
+Relative ignore-file paths are resolved from the current working directory. Rules inside a file are resolved from the directory containing that file.
+
+For example, run the following command from the project root:
 
 ```bash
-rs fmt --ignore-path .prettierignore --ignore-path config/docs.ignore
+rs fmt --ignore-path config/format.ignore
 ```
 
-Relative ignore paths are resolved from the current working directory. Rules in each file are
-resolved from the directory containing that ignore file and extend the built-in ignore rules and
-`define.fmt.ignorePatterns`. They apply to scanned paths, explicitly passed files, and
-`--stdin-filepath`. An unreadable ignore file causes the command to exit with code `2`.
+If `config/format.ignore` contains this rule:
+
+```text title="config/format.ignore"
+generated/**
+```
+
+Here, `config/format.ignore` is located relative to the project root. The `generated/**` rule is relative to `config/`. It therefore ignores `config/generated/**` instead of `generated/**` in the project root.
+
+Loaded rules apply to scanned paths, explicitly passed files, and `--stdin-filepath`.
+
+To load multiple ignore files, repeat the option:
+
+```bash
+rs fmt --ignore-path .prettierignore --ignore-path config/format.ignore
+```
+
+Each file acts as a separate ignore source. See [Ignore order](../formatting#ignore-order) for how these sources combine with `.gitignore`, default ignore rules, and `ignorePatterns`.
 
 ### `--list-different`
 

--- a/website/docs/en/guide/formatting.mdx
+++ b/website/docs/en/guide/formatting.mdx
@@ -45,7 +45,7 @@ In addition to Prettier options and `overrides`, Rstack provides two options:
 
 :::warning Prettier configuration files
 
-`rs fmt` does not read Prettier configuration files, `.prettierignore`, or `.editorconfig`. Keep formatting options and additional ignore rules in `define.fmt()`.
+`rs fmt` does not automatically load Prettier configuration files, `.prettierignore`, or `.editorconfig`. Keep formatting options and additional ignore rules in `define.fmt()`. To load an ignore file explicitly, use [`--ignore-path`](./cli/fmt#--ignore-path-path).
 
 :::
 
@@ -85,8 +85,6 @@ define.fmt({
 
 Patterns follow Gitignore syntax and are resolved relative to the directory containing the Rstack configuration file. Because they are applied after the files are selected, they also exclude files passed explicitly on the command line.
 
-> You can also use the [`--ignore-path`](./cli/fmt#--ignore-path-path) CLI option to ignore files.
-
 ### Lock files
 
 By default, `rs fmt` ignores common lock files, including `package-lock.json` and `pnpm-lock.yaml`.
@@ -100,6 +98,16 @@ define.fmt({
   ignorePatterns: ['!pnpm-lock.yaml'],
 });
 ```
+
+### Ignore order
+
+`rs fmt` uses the following three steps to decide which paths to format:
+
+1. **Process command-line arguments and `.gitignore`**: `rs fmt` first processes the files, directories, and glob patterns passed on the command line. A glob that starts with `!` excludes matching paths. Directory and glob scans follow `.gitignore`, while files passed directly do not. Paths excluded in this step cannot be re-included later.
+2. **Apply default ignore rules and `ignorePatterns`**: `rs fmt` ignores [lock files](#lock-files) by default, then applies `ignorePatterns`. These rules are evaluated in order, with later rules taking precedence. For example, `!pnpm-lock.yaml` re-includes the otherwise ignored file.
+3. **Apply files specified with [`--ignore-path`](./cli/fmt#--ignore-path-path)**: Each ignore file is evaluated separately, and later rules take precedence within that file. Exclusions from different files and `ignorePatterns` are combined: if any source ignores a path, that path remains excluded, even if another source re-includes it.
+
+> `rs fmt` still applies the rules from the second and third steps to files passed directly on the command line and to paths specified with [`--stdin-filepath`](./cli/fmt#--stdin-filepath-path). It formats a path only if none of these rules excludes it.
 
 ## Sort package.json fields \{#sort-package-json}
 

--- a/website/docs/zh/guide/cli/fmt.mdx
+++ b/website/docs/zh/guide/cli/fmt.mdx
@@ -59,13 +59,33 @@ rs fmt --help
 
 ### `--ignore-path <path>`
 
-从 `<path>` 加载额外的 Gitignore 兼容规则。重复传入该选项可以加载多个 ignore 文件：
+使用 `--ignore-path` 从文件中加载额外的 Gitignore 兼容规则。
+
+相对的 ignore 文件路径基于当前工作目录解析。文件中的规则基于该文件所在目录解析。
+
+例如，在项目根目录执行以下命令：
 
 ```bash
-rs fmt --ignore-path .prettierignore --ignore-path config/docs.ignore
+rs fmt --ignore-path config/format.ignore
 ```
 
-相对 ignore 路径基于当前工作目录解析；每个文件中的规则基于该 ignore 文件所在目录解析，并追加到内置忽略规则和 `define.fmt.ignorePatterns`。这些规则会作用于扫描得到的路径、显式传入的文件以及 `--stdin-filepath`。ignore 文件无法读取时，命令以状态码 `2` 退出。
+假设 `config/format.ignore` 包含以下规则：
+
+```text title="config/format.ignore"
+generated/**
+```
+
+这里，`config/format.ignore` 相对项目根目录定位。文件中的 `generated/**` 规则则相对 `config/` 目录解析。因此，它会忽略 `config/generated/**`，而不是项目根目录下的 `generated/**`。
+
+加载的规则会作用于扫描得到的路径、显式传入的文件和 `--stdin-filepath`。
+
+如需加载多个 ignore 文件，可以重复传入该选项：
+
+```bash
+rs fmt --ignore-path .prettierignore --ignore-path config/format.ignore
+```
+
+每个文件都是独立的忽略来源。关于这些来源与 `.gitignore`、默认忽略规则和 `ignorePatterns` 的组合方式，请参考[忽略顺序](../formatting#ignore-order)。
 
 ### `--list-different`
 

--- a/website/docs/zh/guide/formatting.mdx
+++ b/website/docs/zh/guide/formatting.mdx
@@ -45,7 +45,7 @@ define.fmt({
 
 :::warning Prettier 配置文件
 
-`rs fmt` 不会读取 Prettier 配置文件、`.prettierignore` 或 `.editorconfig`。请在 `define.fmt()` 中设置格式化选项和额外的忽略规则。
+`rs fmt` 不会自动加载 Prettier 配置文件、`.prettierignore` 或 `.editorconfig`。请在 `define.fmt()` 中设置格式化选项和额外的忽略规则。如需显式加载 ignore 文件，请使用 [`--ignore-path`](./cli/fmt#--ignore-path-path)。
 
 :::
 
@@ -85,8 +85,6 @@ define.fmt({
 
 这些模式遵循 Gitignore 语法，并且基于 Rstack 配置文件所在的目录解析。由于规则会在确定格式化范围后生效，因此也会排除命令行中显式传入的文件。
 
-> 你也可以使用使用 [`--ignore-path`](./cli/fmt#--ignore-path-path) CLI 选项来忽略文件。
-
 ### Lock 文件 \{#lock-files}
 
 `rs fmt` 默认忽略常见的 lock 文件，包括 `package-lock.json` 和 `pnpm-lock.yaml`。
@@ -100,6 +98,16 @@ define.fmt({
   ignorePatterns: ['!pnpm-lock.yaml'],
 });
 ```
+
+### 忽略顺序 \{#ignore-order}
+
+`rs fmt` 会通过以下三个步骤，决定需要格式化哪些路径：
+
+1. **处理命令行参数和 `.gitignore`**：`rs fmt` 首先处理命令行中指定的文件、目录和 glob 模式。以 `!` 开头的 glob 模式用于排除路径。扫描目录或 glob 模式时会遵循 `.gitignore`，直接指定的文件则不会。在这一步被排除的路径无法被后续规则重新包含。
+2. **应用默认忽略规则和 `ignorePatterns`**：`rs fmt` 默认忽略 [lock 文件](#lock-files)，随后应用 `ignorePatterns`。这些规则按顺序匹配，后面的规则优先。例如，`!pnpm-lock.yaml` 可以重新包含默认忽略的文件。
+3. **应用 [`--ignore-path`](./cli/fmt#--ignore-path-path) 指定的文件**：每个 ignore 文件单独匹配，同一文件中后面的规则优先。不同 ignore 文件与 `ignorePatterns` 的排除结果会叠加：只要任一来源忽略某个路径，该路径就会保持排除，即使其他来源尝试重新包含它。
+
+> 对于命令行中直接指定的文件，以及通过 [`--stdin-filepath`](./cli/fmt#--stdin-filepath-path) 指定的路径，`rs fmt` 仍会应用第二、三步中的忽略规则。只有未被这些规则排除的路径才会被格式化。
 
 ## 排序 package.json 字段 \{#sort-package-json}
 


### PR DESCRIPTION
Clarifies how `rs fmt` resolves `--ignore-path` files and combines `.gitignore`, default rules, `ignorePatterns`, and additional ignore files. Adds aligned English and Chinese examples and documents the order in which ignore sources are applied.