### PR TITLE
docs: align formatting guide wording

### DIFF
--- a/website/docs/en/guide/formatting.mdx
+++ b/website/docs/en/guide/formatting.mdx
@@ -4,8 +4,8 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 
 Rstack CLI includes a formatter built on [Prettier](https://prettier.io/). Compared with running Prettier directly, `rs fmt` offers better performance in two ways:
 
-- **Parallel formatting**: `rs fmt` formats files concurrently in a worker pool.
-- **Yuku parser**: `rs fmt` uses the high-performance [Yuku](https://yuku.fyi/) parser by default for JavaScript, JSX, and TypeScript files.
+- **Parallel formatting**: Files are formatted concurrently in a worker pool.
+- **Yuku parser**: The high-performance [Yuku](https://yuku.fyi/) parser is used by default for JavaScript, JSX, and TypeScript files.
 
 `rs fmt` supports Prettier options and plugins and adds built-in capabilities such as [sorting package.json fields](#sort-package-json).
 
@@ -103,11 +103,11 @@ define.fmt({
 
 `rs fmt` uses the following three steps to decide which paths to format:
 
-1. **Process command-line arguments and `.gitignore`**: `rs fmt` first processes the files, directories, and glob patterns passed on the command line. A glob that starts with `!` excludes matching paths. Directory and glob scans follow `.gitignore`, while files passed directly do not. Paths excluded in this step cannot be re-included later.
-2. **Apply default ignore rules and `ignorePatterns`**: `rs fmt` ignores [lock files](#lock-files) by default, then applies `ignorePatterns`. These rules are evaluated in order, with later rules taking precedence. For example, `!pnpm-lock.yaml` re-includes the otherwise ignored file.
+1. **Process command-line arguments and `.gitignore`**: It first processes the files, directories, and glob patterns passed on the command line. A glob that starts with `!` excludes matching paths. Directory and glob scans follow `.gitignore`, while files passed directly do not. Paths excluded in this step cannot be re-included later.
+2. **Apply default ignore rules and `ignorePatterns`**: By default, the command ignores [lock files](#lock-files), then applies `ignorePatterns`. These rules are evaluated in order, with later rules taking precedence. For example, `!pnpm-lock.yaml` re-includes the otherwise ignored file.
 3. **Apply files specified with [`--ignore-path`](./cli/fmt#--ignore-path-path)**: Each ignore file is evaluated separately, and later rules take precedence within that file. Exclusions from different files and `ignorePatterns` are combined: if any source ignores a path, that path remains excluded, even if another source re-includes it.
 
-> `rs fmt` still applies the rules from the second and third steps to files passed directly on the command line and to paths specified with [`--stdin-filepath`](./cli/fmt#--stdin-filepath-path). It formats a path only if none of these rules excludes it.
+> Even when a file is passed directly on the command line, the default ignore rules, `ignorePatterns`, and rules from `--ignore-path` still apply. The same is true for paths specified with [`--stdin-filepath`](./cli/fmt#--stdin-filepath-path).
 
 ## Sort package.json fields \{#sort-package-json}
 

--- a/website/docs/zh/guide/formatting.mdx
+++ b/website/docs/zh/guide/formatting.mdx
@@ -1,10 +1,10 @@
-# 格式化
+# 格式化 \{#formatting}
 
 import { PackageManagerTabs } from '@rspress/core/theme';
 
 Rstack CLI 提供了基于 [Prettier](https://prettier.io/) 的格式化工具。相比直接使用 Prettier，`rs fmt` 的性能更好，主要得益于以下两点：
 
-- **并行格式化**：`rs fmt` 通过 worker 池并行格式化文件。
+- **并行格式化**：通过 worker 池并行格式化文件。
 - **Yuku 解析器**：默认使用高性能的 [Yuku](https://yuku.fyi/) 解析器处理 JavaScript、JSX 和 TypeScript 文件。
 
 `rs fmt` 兼容 Prettier 的选项和插件，并提供更多内置能力，例如支持[排序 package.json 字段](#sort-package-json)。
@@ -103,11 +103,11 @@ define.fmt({
 
 `rs fmt` 会通过以下三个步骤，决定需要格式化哪些路径：
 
-1. **处理命令行参数和 `.gitignore`**：`rs fmt` 首先处理命令行中指定的文件、目录和 glob 模式。以 `!` 开头的 glob 模式用于排除路径。扫描目录或 glob 模式时会遵循 `.gitignore`，直接指定的文件则不会。在这一步被排除的路径无法被后续规则重新包含。
-2. **应用默认忽略规则和 `ignorePatterns`**：`rs fmt` 默认忽略 [lock 文件](#lock-files)，随后应用 `ignorePatterns`。这些规则按顺序匹配，后面的规则优先。例如，`!pnpm-lock.yaml` 可以重新包含默认忽略的文件。
+1. **处理命令行参数和 `.gitignore`**：首先处理命令行中指定的文件、目录和 glob 模式。以 `!` 开头的 glob 模式用于排除路径。扫描目录或 glob 模式时会遵循 `.gitignore`，直接指定的文件则不会。在这一步被排除的路径无法被后续规则重新包含。
+2. **应用默认忽略规则和 `ignorePatterns`**：默认忽略 [lock 文件](#lock-files)，随后应用 `ignorePatterns`。这些规则按顺序匹配，后面的规则优先。例如，`!pnpm-lock.yaml` 可以重新包含默认忽略的文件。
 3. **应用 [`--ignore-path`](./cli/fmt#--ignore-path-path) 指定的文件**：每个 ignore 文件单独匹配，同一文件中后面的规则优先。不同 ignore 文件与 `ignorePatterns` 的排除结果会叠加：只要任一来源忽略某个路径，该路径就会保持排除，即使其他来源尝试重新包含它。
 
-> 对于命令行中直接指定的文件，以及通过 [`--stdin-filepath`](./cli/fmt#--stdin-filepath-path) 指定的路径，`rs fmt` 仍会应用第二、三步中的忽略规则。只有未被这些规则排除的路径才会被格式化。
+> 即使命令行直接指定了某个文件，默认忽略规则、`ignorePatterns` 和 `--ignore-path` 中的规则仍然有效。通过 [`--stdin-filepath`](./cli/fmt#--stdin-filepath-path) 指定的路径也是如此。
 
 ## 排序 package.json 字段 \{#sort-package-json}
 


### PR DESCRIPTION
The formatting guide repeats `rs fmt` more often than necessary, and the Chinese page is missing the anchor generated by the English heading. This PR aligns the bilingual wording, clarifies which ignore rules apply to explicitly passed files, and adds the matching `#formatting` anchor.