### PR TITLE
fix(fmt): error when no files match

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -243,9 +243,11 @@ const runFmtCLI = async (args: string[]): Promise<void> => {
     });
 
     if (files.length === 0) {
-      if (mode !== 'list-different') {
-        logger.info('No files matched.');
-      }
+      const targets = (patterns.length ? patterns : ['.'])
+        .map((pattern) => color.cyan(JSON.stringify(pattern)))
+        .join(', ');
+      logger.error(`No supported files matched ${targets}, or all matching files were ignored.`);
+      process.exitCode = 2;
       return;
     }
 

--- a/packages/rstack/tests/cli/fmt/index.test.ts
+++ b/packages/rstack/tests/cli/fmt/index.test.ts
@@ -585,16 +585,15 @@ test('writes nothing for empty stdin', () => {
   expect(result.stderr).toBe('');
 });
 
-test('reports when no files match', () => {
-  const writeResult = runFmt(['missing/**/*.ts']);
+test('returns exit code 2 when no files match', () => {
+  for (const modeArgs of [[], ['--check'], ['--list-different']]) {
+    const result = runFmt([...modeArgs, 'missing/**/*.ts']);
 
-  expect(writeResult.status).toBe(0);
-  expect(writeResult.stdout).toBe('info    No files matched.\n');
-  expect(writeResult.stderr).toBe('');
-
-  const checkResult = runFmt(['--check', 'missing/**/*.ts']);
-
-  expect(checkResult.status).toBe(0);
-  expect(checkResult.stdout).toBe('info    No files matched.\n');
-  expect(checkResult.stderr).toBe('');
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain(
+      'No supported files matched "missing/**/*.ts", or all matching files were ignored.',
+    );
+    expect(result.stderr).not.toContain('\n    at ');
+  }
 });


### PR DESCRIPTION
This PR makes `rs fmt` exit with code 2 when discovery selects no supported files, preventing missing or fully ignored targets from silently succeeding.

The error identifies the requested paths or globs and behaves consistently across write, check, and list-different modes.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/175