### PR TITLE
feat(fmt): support --ignorePath

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -62,6 +62,7 @@ const parseFmtCLIArgs = (args: string[]): ParsedFmtCLIArgs => {
       'list-different': { type: 'boolean' },
       listDifferent: { type: 'boolean' },
       'ignore-path': { type: 'string', multiple: true },
+      ignorePath: { type: 'string', multiple: true },
       'no-error-on-unmatched-pattern': { type: 'boolean' },
       noErrorOnUnmatchedPattern: { type: 'boolean' },
       'parallel-workers': { type: 'string' },
@@ -81,6 +82,7 @@ const parseFmtCLIArgs = (args: string[]): ParsedFmtCLIArgs => {
   }
 
   const mode = values.check ? 'check' : listDifferent ? 'list-different' : 'write';
+  const ignorePaths = [...(values['ignore-path'] ?? []), ...(values.ignorePath ?? [])];
   const noErrorOnUnmatchedPattern =
     values['no-error-on-unmatched-pattern'] ?? values.noErrorOnUnmatchedPattern ?? false;
   const maxWorkers = parseMaxWorkers(values['parallel-workers'], values.parallelWorkers);
@@ -101,7 +103,7 @@ const parseFmtCLIArgs = (args: string[]): ParsedFmtCLIArgs => {
   return {
     mode,
     patterns: positionals,
-    ignorePaths: values['ignore-path'] ?? [],
+    ignorePaths,
     noErrorOnUnmatchedPattern,
     maxWorkers,
     help: values.help ?? false,

--- a/packages/rstack/tests/cli/fmt/index.test.ts
+++ b/packages/rstack/tests/cli/fmt/index.test.ts
@@ -195,7 +195,7 @@ test('does not load Prettier config or ignore files', () => {
   expect(readProjectFile('index.ts')).toBe('function getMessage() {\n  return "hello";\n}\n');
 });
 
-test('applies repeated ignore paths to explicit files', () => {
+test.each(['--ignore-path', '--ignorePath'])('applies repeated ignore paths with %s', (option) => {
   writeProjectFile('.prettierignore', 'src/ignored-by-root.ts\n');
   writeProjectFile('config/extra.ignore', '../src/ignored-by-extra.ts\n');
   writeProjectFile('src/ignored-by-root.ts', 'const root="ignored"');
@@ -203,9 +203,9 @@ test('applies repeated ignore paths to explicit files', () => {
   writeProjectFile('src/index.ts', 'const index="formatted"');
 
   const result = runFmt([
-    '--ignore-path',
+    option,
     '.prettierignore',
-    '--ignore-path=config/extra.ignore',
+    `${option}=config/extra.ignore`,
     'src/ignored-by-root.ts',
     'src/ignored-by-extra.ts',
     'src/index.ts',

--- a/packages/rstack/tests/fmt/cli.test.ts
+++ b/packages/rstack/tests/fmt/cli.test.ts
@@ -99,9 +99,15 @@ test.each(['--help', '-h'])('parses %s', (option) => {
   expect(parseFmtCLIArgs([option]).help).toBe(true);
 });
 
-test('collects repeated ignore paths', () => {
+test.each(['--ignore-path', '--ignorePath'])('collects repeated ignore paths with %s', (option) => {
   expect(
-    parseFmtCLIArgs(['--ignore-path', '.prettierignore', '--ignore-path=config/format.ignore'])
+    parseFmtCLIArgs([option, '.prettierignore', `${option}=config/format.ignore`]).ignorePaths,
+  ).toEqual(['.prettierignore', 'config/format.ignore']);
+});
+
+test('combines kebab-case and camel-case ignore paths', () => {
+  expect(
+    parseFmtCLIArgs(['--ignore-path', '.prettierignore', '--ignorePath', 'config/format.ignore'])
       .ignorePaths,
   ).toEqual(['.prettierignore', 'config/format.ignore']);
 });


### PR DESCRIPTION
## Summary

`rs fmt` supports camel-case aliases for CLI options, but `--ignore-path` only accepted kebab-case.

This PR adds `--ignorePath` as a repeatable alias and combines values from both spellings when they are used together.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/178