### PR TITLE
perf(fmt): avoid relative path resolution under root

### DIFF
--- a/packages/rstack/src/fmt/ignore.ts
+++ b/packages/rstack/src/fmt/ignore.ts
@@ -22,9 +22,12 @@ interface CreateIgnoreMatcherOptions {
 
 const createPatternMatcher = (rootPath: string, patterns: string): IgnoreMatcher => {
   const matcher = createIgnore({ allowRelativePaths: true }).add(patterns);
+  const rootPrefix = rootPath.endsWith(path.sep) ? rootPath : `${rootPath}${path.sep}`;
 
   return (filePath, isDirectory = false) => {
-    const relativePath = path.relative(rootPath, filePath);
+    const relativePath = filePath.startsWith(rootPrefix)
+      ? filePath.slice(rootPrefix.length)
+      : path.relative(rootPath, filePath);
     if (relativePath === '') {
       return false;
     }


### PR DESCRIPTION
This follow-up reduces ignore-matcher overhead for the normalized absolute paths produced during formatting. Paths inside the matcher root now use prefix slicing, while paths outside it still fall back to `path.relative()` so parent-relative patterns remain supported.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/179