### PR TITLE
fix(types): disallow parseArgs option defaults

### DIFF
--- a/packages/rstack/src/cli/args.ts
+++ b/packages/rstack/src/cli/args.ts
@@ -1,8 +1,17 @@
 import {
   parseArgs as nodeParseArgs,
-  type ParseArgsConfig,
+  type ParseArgsConfig as NodeParseArgsConfig,
+  type ParseArgsOptionDescriptor as NodeParseArgsOptionDescriptor,
   type ParseArgsOptionsConfig,
 } from 'node:util';
+
+type ParseArgsOptionDescriptor = Omit<NodeParseArgsOptionDescriptor, 'default'> & {
+  default?: never;
+};
+
+type ParseArgsConfig = Omit<NodeParseArgsConfig, 'options'> & {
+  options?: Record<string, ParseArgsOptionDescriptor>;
+};
 
 type CamelCase<Value extends string> = Value extends `${infer Head}-${infer Tail}`
   ? `${Head}${Capitalize<CamelCase<Tail>>}`


### PR DESCRIPTION
This PR makes the internal `parseArgs` contract match its intended scope by rejecting option defaults at type-check time. It prevents callers from relying on default behavior that the kebab-case and camelCase alias merge does not support.

## Related Links

- Follow-up to [review feedback on #182](https://github.com/rstackjs/rstack-cli/pull/182#discussion_r3717558683)