### PR TITLE
test(cli): simplify option alias coverage

### DIFF
--- a/packages/rstack/tests/cli/fmt/index.test.ts
+++ b/packages/rstack/tests/cli/fmt/index.test.ts
@@ -195,7 +195,7 @@ test('does not load Prettier config or ignore files', () => {
   expect(readProjectFile('index.ts')).toBe('function getMessage() {\n  return "hello";\n}\n');
 });
 
-test.each(['--ignore-path', '--ignorePath'])('applies repeated ignore paths with %s', (option) => {
+test('applies repeated ignore paths', () => {
   writeProjectFile('.prettierignore', 'src/ignored-by-root.ts\n');
   writeProjectFile('config/extra.ignore', '../src/ignored-by-extra.ts\n');
   writeProjectFile('src/ignored-by-root.ts', 'const root="ignored"');
@@ -203,9 +203,9 @@ test.each(['--ignore-path', '--ignorePath'])('applies repeated ignore paths with
   writeProjectFile('src/index.ts', 'const index="formatted"');
 
   const result = runFmt([
-    option,
+    '--ignore-path',
     '.prettierignore',
-    `${option}=config/extra.ignore`,
+    '--ignore-path=config/extra.ignore',
     'src/ignored-by-root.ts',
     'src/ignored-by-extra.ts',
     'src/index.ts',
@@ -437,14 +437,6 @@ test('formats stdin for the given filepath', () => {
   expect(result.stderr).toBe('');
 });
 
-test('formats stdin with the camel-case option', () => {
-  const result = runFmtStdin(['--stdinFilepath', 'data.json'], '{"a":1,"b":[2,3]}');
-
-  expect(result.status).toBe(0);
-  expect(result.stdout).toBe('{ "a": 1, "b": [2, 3] }\n');
-  expect(result.stderr).toBe('');
-});
-
 test('applies define.fmt options and overrides to stdin', () => {
   writeProjectFile(
     'rstack.config.ts',
@@ -598,18 +590,15 @@ test('returns exit code 2 when no files match', () => {
   }
 });
 
-test.each(['--no-error-on-unmatched-pattern', '--noErrorOnUnmatchedPattern'])(
-  'allows no files to match with %s',
-  (option) => {
-    for (const modeArgs of [[], ['--check'], ['--list-different']]) {
-      const result = runFmt([...modeArgs, option, 'missing/**/*.ts']);
+test('allows no files to match with --no-error-on-unmatched-pattern', () => {
+  for (const modeArgs of [[], ['--check'], ['--list-different']]) {
+    const result = runFmt([...modeArgs, '--no-error-on-unmatched-pattern', 'missing/**/*.ts']);
 
-      expect(result.status).toBe(0);
-      expect(result.stdout).toBe('');
-      expect(result.stderr).toBe('');
-    }
-  },
-);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
+  }
+});
 
 test('counts only supported files', () => {
   writeProjectFile('index.ts', 'const value = 1;\n');

--- a/packages/rstack/tests/cli/staged/index.test.ts
+++ b/packages/rstack/tests/cli/staged/index.test.ts
@@ -89,11 +89,11 @@ test('should pass long options to lint-staged', async ({ expect }) => {
   });
 });
 
-test('should pass short options and aliases to lint-staged', async ({ expect }) => {
-  await runStagedCLI(['--allowEmpty', '-p', '1', '-d', '-q', '-r', '-v']);
+test('should pass short options to lint-staged', async ({ expect }) => {
+  await runStagedCLI(['-p', '1', '-d', '-q', '-r', '-v']);
 
   expect(mocks.lintStaged).toHaveBeenCalledWith({
-    allowEmpty: true,
+    allowEmpty: undefined,
     concurrent: 1,
     config: stagedConfig,
     cwd: undefined,

--- a/packages/rstack/tests/fmt/cli.test.ts
+++ b/packages/rstack/tests/fmt/cli.test.ts
@@ -32,7 +32,6 @@ test.each([
   ['--write', 'write'],
   ['--check', 'check'],
   ['--list-different', 'list-different'],
-  ['--listDifferent', 'list-different'],
 ] as const)('parses %s mode', (option, mode) => {
   expect(parseFmtCLIArgs([option])).toEqual({
     mode,
@@ -44,19 +43,16 @@ test.each([
   });
 });
 
-test.each(['--parallel-workers', '--parallelWorkers'])(
-  'configures parallel worker count with %s',
-  (option) => {
-    expect(parseFmtCLIArgs([option, '3'])).toEqual({
-      mode: 'write',
-      patterns: [],
-      ignorePaths: [],
-      noErrorOnUnmatchedPattern: false,
-      maxWorkers: 3,
-      help: false,
-    });
-  },
-);
+test('configures parallel worker count', () => {
+  expect(parseFmtCLIArgs(['--parallel-workers', '3'])).toEqual({
+    mode: 'write',
+    patterns: [],
+    ignorePaths: [],
+    noErrorOnUnmatchedPattern: false,
+    maxWorkers: 3,
+    help: false,
+  });
+});
 
 test.each(['0', '-1', '1.5', 'invalid', '9007199254740992'])(
   'rejects invalid parallel worker count %s',
@@ -66,10 +62,6 @@ test.each(['0', '-1', '1.5', 'invalid', '9007199254740992'])(
     );
   },
 );
-
-test('prefers the kebab-case parallel worker option', () => {
-  expect(parseFmtCLIArgs(['--parallel-workers', '2', '--parallelWorkers', '3']).maxWorkers).toBe(2);
-});
 
 test('preserves file paths and globs', () => {
   const patterns = ['src/file with spaces.ts', 'src/**/*.{js,ts}', '!src/generated/**'];
@@ -99,28 +91,19 @@ test.each(['--help', '-h'])('parses %s', (option) => {
   expect(parseFmtCLIArgs([option]).help).toBe(true);
 });
 
-test.each(['--ignore-path', '--ignorePath'])('collects repeated ignore paths with %s', (option) => {
+test('collects repeated ignore paths', () => {
   expect(
-    parseFmtCLIArgs([option, '.prettierignore', `${option}=config/format.ignore`]).ignorePaths,
-  ).toEqual(['.prettierignore', 'config/format.ignore']);
-});
-
-test('combines kebab-case and camel-case ignore paths', () => {
-  expect(
-    parseFmtCLIArgs(['--ignore-path', '.prettierignore', '--ignorePath', 'config/format.ignore'])
+    parseFmtCLIArgs(['--ignore-path', '.prettierignore', '--ignore-path=config/format.ignore'])
       .ignorePaths,
   ).toEqual(['.prettierignore', 'config/format.ignore']);
 });
 
-test.each(['--no-error-on-unmatched-pattern', '--noErrorOnUnmatchedPattern'])(
-  'parses %s',
-  (option) => {
-    expect(parseFmtCLIArgs([option]).noErrorOnUnmatchedPattern).toBe(true);
-  },
-);
+test('parses --no-error-on-unmatched-pattern', () => {
+  expect(parseFmtCLIArgs(['--no-error-on-unmatched-pattern']).noErrorOnUnmatchedPattern).toBe(true);
+});
 
-test.each(['--stdin-filepath', '--stdinFilepath'])('parses %s', (option) => {
-  expect(parseFmtCLIArgs([option, 'src/index.ts'])).toEqual({
+test('parses --stdin-filepath', () => {
+  expect(parseFmtCLIArgs(['--stdin-filepath', 'src/index.ts'])).toEqual({
     mode: 'write',
     patterns: [],
     ignorePaths: [],
@@ -143,7 +126,7 @@ test('accepts a worker count with --stdin-filepath', () => {
   });
 });
 
-test.each(['--write', '--check', '--list-different', '--listDifferent'])(
+test.each(['--write', '--check', '--list-different'])(
   'rejects %s with --stdin-filepath',
   (option) => {
     expect(() => parseFmtCLIArgs(['--stdin-filepath', 'index.ts', option])).toThrow(
@@ -168,7 +151,6 @@ test('provides command help', () => {
 test.each([
   ['--write', '--check'],
   ['--write', '--list-different'],
-  ['--write', '--listDifferent'],
   ['--check', '--list-different'],
   ['--write', '--check', '--list-different'],
 ])('rejects conflicting modes: %s', (...args) => {
@@ -177,7 +159,7 @@ test.each([
   );
 });
 
-test.each(['--unknown', '--no-cache', '--no-parallel', '--noParallel'])(
+test.each(['--unknown', '--no-cache', '--no-parallel'])(
   'rejects unsupported option %s',
   (option) => {
     expect(() => parseFmtCLIArgs([option])).toThrow();


### PR DESCRIPTION
This PR removes duplicate kebab-case and camelCase permutations from command-specific tests now that `parseArgs` owns alias behavior. CLI tests continue to cover canonical kebab-case behavior, while the `parseArgs` tests remain the single source of truth for alias conversion and mixed repeated values.

## Related Links

https://github.com/rstackjs/rstack-cli/pull/182