### PR TITLE
perf(fmt): skip unused ignore matcher wrapper

### DIFF
--- a/packages/rstack/src/fmt/ignore.ts
+++ b/packages/rstack/src/fmt/ignore.ts
@@ -62,6 +62,10 @@ const createIgnoreMatcher = async ({
     config.rootPath,
     [...defaultIgnorePatterns, ...config.ignorePatterns].join('\n'),
   );
+  if (ignorePaths.length === 0) {
+    return configMatcher;
+  }
+
   const ignoreMatchers = await Promise.all(
     ignorePaths.map((ignorePath) => loadIgnoreMatcher(cwd, ignorePath)),
   );


### PR DESCRIPTION
This follow-up removes per-path wrapper overhead from the common `rs fmt` path where no additional ignore files are configured. `createIgnoreMatcher` now returns the config matcher directly, avoiding `Promise.all([])` and an empty `.some()` while preserving ignore behavior.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/183