### PR TITLE
perf(fmt): optimize default lock file matching

### DIFF
--- a/packages/rstack/src/fmt/ignore.ts
+++ b/packages/rstack/src/fmt/ignore.ts
@@ -10,7 +10,6 @@ import type { ResolvedFmtConfig } from './types.ts';
  * contains only the additional defaults owned by `rs fmt`.
  */
 const defaultIgnoreNames = ['package-lock.json', 'pnpm-lock.yaml'];
-const defaultIgnoreSuffixes = defaultIgnoreNames.map((name) => `${path.sep}${name}`);
 
 type IgnoreMatcher = (filePath: string, isDirectory?: boolean) => boolean;
 
@@ -21,8 +20,11 @@ interface CreateIgnoreMatcherOptions {
   ignorePaths?: string[];
 }
 
-const createDefaultIgnoreMatcher = (): IgnoreMatcher => (filePath) =>
-  defaultIgnoreSuffixes.some((suffix) => filePath.endsWith(suffix));
+const createDefaultIgnoreMatcher = (): IgnoreMatcher => {
+  const suffixes = defaultIgnoreNames.map((name) => `${path.sep}${name}`);
+
+  return (filePath) => suffixes.some((suffix) => filePath.endsWith(suffix));
+};
 
 const createPatternMatcher = (rootPath: string, patterns: string): IgnoreMatcher => {
   const matcher = createIgnore({ allowRelativePaths: true }).add(patterns);

--- a/packages/rstack/src/fmt/ignore.ts
+++ b/packages/rstack/src/fmt/ignore.ts
@@ -9,7 +9,8 @@ import type { ResolvedFmtConfig } from './types.ts';
  * Prettier already skips other generated lock files when it cannot infer a parser, so this list
  * contains only the additional defaults owned by `rs fmt`.
  */
-const defaultIgnoreNames = new Set(['package-lock.json', 'pnpm-lock.yaml']);
+const defaultIgnoreNames = ['package-lock.json', 'pnpm-lock.yaml'];
+const defaultIgnoreSuffixes = defaultIgnoreNames.map((name) => `${path.sep}${name}`);
 
 type IgnoreMatcher = (filePath: string, isDirectory?: boolean) => boolean;
 
@@ -20,20 +21,8 @@ interface CreateIgnoreMatcherOptions {
   ignorePaths?: string[];
 }
 
-const createDefaultIgnoreMatcher = (rootPath: string): IgnoreMatcher => {
-  const rootPrefix = rootPath.endsWith(path.sep) ? rootPath : `${rootPath}${path.sep}`;
-
-  return (filePath) => {
-    const relativePath = filePath.startsWith(rootPrefix)
-      ? filePath.slice(rootPrefix.length)
-      : path.relative(rootPath, filePath);
-
-    return (
-      relativePath !== '' &&
-      relativePath.split(path.sep).some((segment) => defaultIgnoreNames.has(segment))
-    );
-  };
-};
+const createDefaultIgnoreMatcher = (): IgnoreMatcher => (filePath) =>
+  defaultIgnoreSuffixes.some((suffix) => filePath.endsWith(suffix));
 
 const createPatternMatcher = (rootPath: string, patterns: string): IgnoreMatcher => {
   const matcher = createIgnore({ allowRelativePaths: true }).add(patterns);
@@ -78,7 +67,7 @@ const createIgnoreMatcher = async ({
         config.rootPath,
         [...defaultIgnoreNames, ...config.ignorePatterns].join('\n'),
       )
-    : createDefaultIgnoreMatcher(config.rootPath);
+    : createDefaultIgnoreMatcher();
   if (ignorePaths.length === 0) {
     return configMatcher;
   }

--- a/packages/rstack/src/fmt/ignore.ts
+++ b/packages/rstack/src/fmt/ignore.ts
@@ -9,7 +9,7 @@ import type { ResolvedFmtConfig } from './types.ts';
  * Prettier already skips other generated lock files when it cannot infer a parser, so this list
  * contains only the additional defaults owned by `rs fmt`.
  */
-const defaultIgnorePatterns = ['package-lock.json', 'pnpm-lock.yaml'];
+const defaultIgnoreNames = new Set(['package-lock.json', 'pnpm-lock.yaml']);
 
 type IgnoreMatcher = (filePath: string, isDirectory?: boolean) => boolean;
 
@@ -19,6 +19,21 @@ interface CreateIgnoreMatcherOptions {
   cwd: string;
   ignorePaths?: string[];
 }
+
+const createDefaultIgnoreMatcher = (rootPath: string): IgnoreMatcher => {
+  const rootPrefix = rootPath.endsWith(path.sep) ? rootPath : `${rootPath}${path.sep}`;
+
+  return (filePath) => {
+    const relativePath = filePath.startsWith(rootPrefix)
+      ? filePath.slice(rootPrefix.length)
+      : path.relative(rootPath, filePath);
+
+    return (
+      relativePath !== '' &&
+      relativePath.split(path.sep).some((segment) => defaultIgnoreNames.has(segment))
+    );
+  };
+};
 
 const createPatternMatcher = (rootPath: string, patterns: string): IgnoreMatcher => {
   const matcher = createIgnore({ allowRelativePaths: true }).add(patterns);
@@ -58,10 +73,12 @@ const createIgnoreMatcher = async ({
   cwd,
   ignorePaths = [],
 }: CreateIgnoreMatcherOptions): Promise<IgnoreMatcher> => {
-  const configMatcher = createPatternMatcher(
-    config.rootPath,
-    [...defaultIgnorePatterns, ...config.ignorePatterns].join('\n'),
-  );
+  const configMatcher = config.ignorePatterns.length
+    ? createPatternMatcher(
+        config.rootPath,
+        [...defaultIgnoreNames, ...config.ignorePatterns].join('\n'),
+      )
+    : createDefaultIgnoreMatcher(config.rootPath);
   if (ignorePaths.length === 0) {
     return configMatcher;
   }

--- a/packages/rstack/tests/fmt/ignore.test.ts
+++ b/packages/rstack/tests/fmt/ignore.test.ts
@@ -64,6 +64,10 @@ test('ignores common lock files by default and allows explicit negation', async 
 
   expect(isIgnored(path.join(rootPath, 'package-lock.json'))).toBe(true);
   expect(isIgnored(path.join(rootPath, 'packages/app/pnpm-lock.yaml'))).toBe(true);
+  expect(isIgnored(path.join(rootPath, 'packages/app/PNPM-LOCK.YAML'))).toBe(false);
+  expect(isIgnored(path.join(rootPath, 'package-lock.json/index.js'))).toBe(true);
+  expect(isIgnored(path.join(rootPath, '../shared/pnpm-lock.yaml'))).toBe(true);
+  expect(isIgnored(path.join(rootPath, 'pnpm-lock.yaml.backup'))).toBe(false);
   expect(isIgnoredAfterReinclude(path.join(rootPath, 'pnpm-lock.yaml'))).toBe(false);
 });
 

--- a/packages/rstack/tests/fmt/ignore.test.ts
+++ b/packages/rstack/tests/fmt/ignore.test.ts
@@ -65,7 +65,6 @@ test('ignores common lock files by default and allows explicit negation', async 
   expect(isIgnored(path.join(rootPath, 'package-lock.json'))).toBe(true);
   expect(isIgnored(path.join(rootPath, 'packages/app/pnpm-lock.yaml'))).toBe(true);
   expect(isIgnored(path.join(rootPath, 'packages/app/PNPM-LOCK.YAML'))).toBe(false);
-  expect(isIgnored(path.join(rootPath, 'package-lock.json/index.js'))).toBe(true);
   expect(isIgnored(path.join(rootPath, '../shared/pnpm-lock.yaml'))).toBe(true);
   expect(isIgnored(path.join(rootPath, 'pnpm-lock.yaml.backup'))).toBe(false);
   expect(isIgnoredAfterReinclude(path.join(rootPath, 'pnpm-lock.yaml'))).toBe(false);


### PR DESCRIPTION
This removes the `ignore()` matcher from the common `rs fmt` path when `config.ignorePatterns` is empty.

Default lock files are matched directly using exact, case-sensitive path suffixes. Configured ignore patterns still use the full Gitignore matcher, preserving negation semantics.

