### PR TITLE
release: v0.3.3

### DIFF
--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rstack",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "repository": "https://github.com/rstackjs/rstack-cli",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
This PR prepares the `rstack` package v0.3.3 release by updating its package version from 0.3.2 to 0.3.3.