### PR TITLE
chore: add rstack package metadata

### DIFF
--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -1,7 +1,16 @@
 {
   "name": "rstack",
   "version": "0.3.3",
-  "repository": "https://github.com/rstackjs/rstack-cli",
+  "description": "One CLI for JavaScript development, powered by Rstack.",
+  "homepage": "https://rstack.rs",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rstack-cli/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstackjs/rstack-cli.git",
+    "directory": "packages/rstack"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
The published `rstack` package is missing standard metadata used by npm and repository tooling. This PR adds a concise description, the project homepage and issue tracker, and a monorepo-aware repository reference.