### PR TITLE
feat(fmt): add -u alias for ignore unknown

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -32,7 +32,7 @@ ${color.cyan('Options')}:
   --check                          Check whether files are formatted
   --list-different                 Print paths of unformatted files
   --ignore-path <path>             Path to an additional ignore file (repeatable)
-  --ignore-unknown                 Ignore unknown files
+  -u, --ignore-unknown             Ignore unknown files
   --no-error-on-unmatched-pattern  Do not error when no files match
   --parallel-workers <count>       Number of parallel workers
   --stdin-filepath <path>          Format stdin as if it were saved at <path>
@@ -59,7 +59,7 @@ const parseFmtCLIArgs = (args: string[]): ParsedFmtCLIArgs => {
       check: { type: 'boolean' },
       'list-different': { type: 'boolean' },
       'ignore-path': { type: 'string', multiple: true },
-      'ignore-unknown': { type: 'boolean' },
+      'ignore-unknown': { type: 'boolean', short: 'u' },
       'no-error-on-unmatched-pattern': { type: 'boolean' },
       'parallel-workers': { type: 'string' },
       'stdin-filepath': { type: 'string' },

--- a/packages/rstack/tests/cli/fmt/index.test.ts
+++ b/packages/rstack/tests/cli/fmt/index.test.ts
@@ -640,7 +640,7 @@ test('ignores unsupported files with --ignore-unknown', () => {
   writeProjectFile('notes.unknown', 'plain text');
 
   for (const modeArgs of [[], ['--check'], ['--list-different']]) {
-    const result = runFmt([...modeArgs, '--ignoreUnknown', 'notes.unknown']);
+    const result = runFmt([...modeArgs, '--ignore-unknown', 'notes.unknown']);
 
     expect(result.status).toBe(0);
     expect(result.stdout).toBe(
@@ -650,6 +650,16 @@ test('ignores unsupported files with --ignore-unknown', () => {
     );
     expect(result.stderr).toBe('');
   }
+});
+
+test('supports -u as an alias for --ignore-unknown', () => {
+  writeProjectFile('notes.unknown', 'plain text');
+
+  const result = runFmt(['-u', 'notes.unknown']);
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toBe('');
+  expect(result.stderr).toBe('');
 });
 
 test('does not treat unmatched patterns as unknown files', () => {

--- a/packages/rstack/tests/fmt/__snapshots__/cli.test.ts.snap
+++ b/packages/rstack/tests/fmt/__snapshots__/cli.test.ts.snap
@@ -11,7 +11,7 @@ Options:
   --check                          Check whether files are formatted
   --list-different                 Print paths of unformatted files
   --ignore-path <path>             Path to an additional ignore file (repeatable)
-  --ignore-unknown                 Ignore unknown files
+  -u, --ignore-unknown             Ignore unknown files
   --no-error-on-unmatched-pattern  Do not error when no files match
   --parallel-workers <count>       Number of parallel workers
   --stdin-filepath <path>          Format stdin as if it were saved at <path>

--- a/packages/rstack/tests/fmt/cli.test.ts
+++ b/packages/rstack/tests/fmt/cli.test.ts
@@ -107,7 +107,7 @@ test('parses --no-error-on-unmatched-pattern', () => {
   expect(parseFmtCLIArgs(['--no-error-on-unmatched-pattern']).noErrorOnUnmatchedPattern).toBe(true);
 });
 
-test.each(['--ignore-unknown', '--ignoreUnknown'])('parses %s', (option) => {
+test.each(['-u', '--ignore-unknown', '--ignoreUnknown'])('parses %s', (option) => {
   expect(parseFmtCLIArgs([option]).ignoreUnknown).toBe(true);
 });
 

--- a/website/docs/en/guide/cli/fmt.mdx
+++ b/website/docs/en/guide/cli/fmt.mdx
@@ -92,7 +92,13 @@ Each file acts as a separate ignore source. See [Ignore order](../formatting#ign
 Ignore matched files when no parser can be inferred. This allows the command to exit successfully even when every matched file has an unknown type:
 
 ```bash
-rs fmt --ignore-unknown '**/*'
+rs fmt --ignore-unknown
+```
+
+The short option `-u` is an alias for `--ignore-unknown`.
+
+```bash
+rs fmt -u
 ```
 
 This option does not suppress errors for unmatched paths or globs. Combine it with [`--no-error-on-unmatched-pattern`](#--no-error-on-unmatched-pattern) when an integration needs to tolerate both cases.

--- a/website/docs/zh/guide/cli/fmt.mdx
+++ b/website/docs/zh/guide/cli/fmt.mdx
@@ -92,7 +92,13 @@ rs fmt --ignore-path .prettierignore --ignore-path config/format.ignore
 忽略无法推断 parser 的匹配文件。即使所有匹配文件的类型均未知，该选项也可以让命令成功退出：
 
 ```bash
-rs fmt --ignore-unknown '**/*'
+rs fmt --ignore-unknown
+```
+
+短选项 `-u` 是 `--ignore-unknown` 的别名。
+
+```bash
+rs fmt -u
 ```
 
 此选项不会忽略未匹配路径或 glob 的错误。如果集成需要同时容忍这两种情况，可以将它与 [`--no-error-on-unmatched-pattern`](#--no-error-on-unmatched-pattern) 一起使用。


### PR DESCRIPTION
Prettier-compatible scripts can use `-u` as shorthand for `--ignore-unknown`. This PR registers the alias, updates CLI help and bilingual documentation, and adds parser and end-to-end coverage without changing the existing long-option behavior.