### PR TITLE
docs(skills): use bundled Rstack docs index

### DIFF
--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -11,23 +11,17 @@ Before any Rstack work, find and read the relevant Markdown documentation shippe
 installed `rstack` package. Model knowledge and summaries in this skill can be outdated; the
 installed documentation is the source of truth for the project's Rstack version.
 
-1. Resolve the documentation root from the project or workspace directory:
+1. Read only the pages relevant to the task under `node_modules/rstack/dist/docs` before proposing
+   or making changes.
 
-   ```sh
-   node -p "require('node:path').join(require('node:path').dirname(require.resolve('rstack/package.json')), 'dist/docs')"
-   ```
-
-   The usual location is `node_modules/rstack/dist/docs`.
-
-2. Read only the pages relevant to the task before proposing or making changes. If the correct
-   page is unclear, start with the documentation index and search the documentation root with
-   `rg -n "<keyword>" <docs-root>`.
+2. If the correct page is unclear, start with the documentation index and search the documentation
+   root with `rg -n "<keyword>" <docs-root>`.
 
 3. For exact CLI flags and behavior, also run `rs -h` or `rs <command> -h` when supported.
 
-If the package or bundled documentation cannot be resolved, verify that `rstack` is installed,
-report the installed version, and use CLI help plus the online Rstack documentation as a fallback.
-Do not guess from model memory.
+If the bundled docs are not available at that path, locate the installed `rstack` package. If they
+are still unavailable, verify that `rstack` is installed, report the installed version, and use CLI
+help plus the online Rstack documentation as a fallback. Do not guess from model memory.
 
 ## Documentation map
 

--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -14,10 +14,7 @@ installed documentation is the source of truth for the project's Rstack version.
 1. Start with `node_modules/rstack/dist/docs/llms.txt`, then read only the linked pages relevant to
    the task before proposing or making changes.
 
-2. If `llms.txt` is unavailable, start with `node_modules/rstack/dist/docs/index.md` and search the
-   documentation directory with `rg -n "<keyword>" node_modules/rstack/dist/docs`.
-
-3. For exact CLI flags and behavior, also run `rs -h` or `rs <command> -h` when supported.
+2. For exact CLI flags and behavior, also run `rs -h` or `rs <command> -h` when supported.
 
 If the bundled docs are not available at that path, locate the installed `rstack` package. If they
 are still unavailable, verify that `rstack` is installed, report the installed version, and use CLI

--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rstack-cli-best-practices
-description: Guidance for Rstack CLI tasks. Use when running `rs` commands, editing `rstack.config.*`, using `rstack` package imports, or working with Rstack-powered apps, libraries, docs, tests, linting, formatting, Git hooks, staged files, and monorepos. Requires reading the version-matched documentation shipped in the installed `rstack` package before making changes.
+description: Guidance for Rstack CLI work involving `rs` commands, `rstack.config.*`, package APIs, or Rstack-based projects and tooling. Requires reading the version-matched docs bundled with the installed `rstack` package first.
 ---
 
 # Rstack CLI Best Practices

--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rstack-cli-best-practices
-description: Guidance for Rstack CLI work involving `rs` commands, `rstack.config.*`, package APIs, or Rstack-based projects and tooling. Requires reading the version-matched docs bundled with the installed `rstack` package first.
+description: Guidance for Rstack CLI work involving `rs` commands, `rstack.config.*`, package APIs, or Rstack-based projects and tooling.
 ---
 
 # Rstack CLI Best Practices

--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -1,92 +1,53 @@
 ---
 name: rstack-cli-best-practices
-description: Guidance on using Rstack CLI, including `rs` commands, the `rstack.config.ts` file, and import paths from the `rstack` package. Use for Rstack CLI-related tasks.
+description: Guidance for Rstack CLI tasks. Use when running `rs` commands, editing `rstack.config.*`, using `rstack` package imports, or working with Rstack-powered apps, libraries, docs, tests, linting, formatting, Git hooks, staged files, and monorepos. Requires reading the version-matched documentation shipped in the installed `rstack` package before making changes.
 ---
 
 # Rstack CLI Best Practices
 
-Rstack CLI is the `rstack` package, exposed through the `rs` binaries. It provides one CLI, one config file, and a consistent workflow for the Rstack JavaScript toolchain.
+## Rstack: ALWAYS read installed docs before working
 
-It covers web app, library, docs, test, lint, formatting, Git hook, and staged-file workflows.
+Before any Rstack work, find and read the relevant Markdown documentation shipped with the
+installed `rstack` package. Model knowledge and summaries in this skill can be outdated; the
+installed documentation is the source of truth for the project's Rstack version.
 
-## Commands
+1. Resolve the documentation root from the project or workspace directory:
 
-Use `rs -h` for top-level help, and `rs <command> -h` for command help where supported.
+   ```sh
+   node -p "require('node:path').join(require('node:path').dirname(require.resolve('rstack/package.json')), 'dist/docs')"
+   ```
 
-| Command      | Purpose                          | Underlying tool | Config          |
-| ------------ | -------------------------------- | --------------- | --------------- |
-| `rs dev`     | Run the app dev server           | Rsbuild         | `define.app`    |
-| `rs build`   | Build the app for production     | Rsbuild         | `define.app`    |
-| `rs preview` | Preview the app production build | Rsbuild         | `define.app`    |
-| `rs lib`     | Build a library                  | Rslib           | `define.lib`    |
-| `rs doc`     | Serve or build docs              | Rspress         | `define.doc`    |
-| `rs test`    | Run tests                        | Rstest          | `define.test`   |
-| `rs lint`    | Lint code                        | Rslint          | `define.lint`   |
-| `rs fmt`     | Format code                      | Prettier        | `define.fmt`    |
-| `rs setup`   | Install project-local Git hooks  | None            | None            |
-| `rs staged`  | Run tasks on staged Git files    | lint-staged     | `define.staged` |
+   The usual location is `node_modules/rstack/dist/docs`.
 
-Key behavior:
+2. Read only the pages relevant to the task before proposing or making changes. If the correct
+   page is unclear, start with the documentation index and search the documentation root with
+   `rg -n "<keyword>" <docs-root>`.
 
-- Unless `define.test` already sets `extends`, `rs test` extends `define.app` through `@rstest/adapter-rsbuild` or falls back to `define.lib` through `@rstest/adapter-rslib`. The app config takes precedence when both are defined.
-- `rs doc` requires the optional `@rspress/core` dependency.
+3. For exact CLI flags and behavior, also run `rs -h` or `rs <command> -h` when supported.
 
-## rstack.config.ts
+If the package or bundled documentation cannot be resolved, verify that `rstack` is installed,
+report the installed version, and use CLI help plus the online Rstack documentation as a fallback.
+Do not guess from model memory.
 
-Rstack CLI loads `rstack.config.{ts,js,mts,mjs}` by default.
+## Documentation map
 
-Register config with `define.*`:
+These links target the usual project-local skill installation. If a link does not resolve, open
+the same relative path under the resolved documentation root.
 
-```ts
-import { define } from 'rstack';
-
-define.app({
-  // Rsbuild config for `rs dev`, `rs build`, and `rs preview`
-});
-
-define.test({
-  // Rstest config for `rs test`
-});
-```
-
-- `define.app(config)`: Rsbuild config for `rs dev`, `rs build`, and `rs preview`. Docs: https://rsbuild.rs/config/
-- `define.lib(config)`: Rslib config for `rs lib`; Docs: https://rslib.rs/config/
-- `define.doc(config)`: Rspress config for `rs doc`; Docs: https://rspress.rs/api/config/config-basic
-- `define.test(config)`: Rstest config for `rs test`; Docs: https://rstest.rs/config/
-- `define.lint(config)`: Rslint config for `rs lint`; Docs: https://rslint.rs/config/
-- `define.fmt(config)`: Formatting options for `rs fmt`.
-- `define.staged(config)`: lint-staged config for `rs staged`; accepts `Record<string, string | string[]>`.
-
-### Lazy Configuration
-
-Prefer async functions with dynamic imports for dependencies. Avoid top-level sync imports of heavy dependencies in `rstack.config.ts`.
-
-```ts
-import { define } from 'rstack';
-
-define.app(async () => {
-  const { pluginReact } = await import('@rsbuild/plugin-react');
-  return {
-    plugins: [pluginReact()],
-  };
-});
-```
-
-## Import Paths
-
-Prefer Rstack-exported paths:
-
-| Instead of                | Prefer                   |
-| ------------------------- | ------------------------ |
-| `@rsbuild/core`           | `rstack/app`             |
-| `@rslib/core`             | `rstack/lib`             |
-| `@rstest/core`            | `rstack/test`            |
-| `@rslint/core`            | `rstack/lint`            |
-| `@rsbuild/core/types`     | `rstack/types`           |
-| `@rslib/core/types`       | `rstack/types`           |
-| `@rstest/core/globals`    | `rstack/test/globals`    |
-| `@rstest/core/importMeta` | `rstack/test/importMeta` |
-
-## Git Hooks
-
-Use [`rs setup`](https://rstack.rs/guide/cli/setup) for project-local Git hooks, commonly with `rs staged` in a `pre-commit` hook.
+- [Overview](../../../node_modules/rstack/dist/docs/index.md)
+- [Quick start and command overview](../../../node_modules/rstack/dist/docs/guide/quick-start.md)
+- [Configuration](../../../node_modules/rstack/dist/docs/guide/configuration.md)
+- [API and import paths](../../../node_modules/rstack/dist/docs/guide/api-reference.md)
+- [Monorepos](../../../node_modules/rstack/dist/docs/guide/monorepo.md)
+- [Testing](../../../node_modules/rstack/dist/docs/guide/testing.md)
+- [Formatting](../../../node_modules/rstack/dist/docs/guide/formatting.md)
+- CLI commands: [dev](../../../node_modules/rstack/dist/docs/guide/cli/dev.md),
+  [build](../../../node_modules/rstack/dist/docs/guide/cli/build.md),
+  [preview](../../../node_modules/rstack/dist/docs/guide/cli/preview.md),
+  [lib](../../../node_modules/rstack/dist/docs/guide/cli/lib.md),
+  [doc](../../../node_modules/rstack/dist/docs/guide/cli/doc.md),
+  [test](../../../node_modules/rstack/dist/docs/guide/cli/test.md),
+  [lint](../../../node_modules/rstack/dist/docs/guide/cli/lint.md),
+  [fmt](../../../node_modules/rstack/dist/docs/guide/cli/fmt.md),
+  [setup](../../../node_modules/rstack/dist/docs/guide/cli/setup.md), and
+  [staged](../../../node_modules/rstack/dist/docs/guide/cli/staged.md)

--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -10,17 +10,16 @@ config file, and a consistent workflow for the Rstack JavaScript toolchain.
 
 It covers web app, library, docs, test, lint, formatting, Git hook, and staged-file workflows.
 
-## Rstack: ALWAYS read installed docs before working
+## ALWAYS read installed docs before working
 
-Before any Rstack work, find and read the relevant Markdown documentation shipped with the
-installed `rstack` package. Model knowledge and summaries in this skill can be outdated; the
-installed documentation is the source of truth for the project's Rstack version.
+Before any Rstack work, find and read the relevant Markdown documentation shipped with the installed `rstack` package.
 
-1. Start with `node_modules/rstack/dist/docs/llms.txt`, then read only the linked pages relevant to
-   the task before proposing or making changes.
+Model knowledge can be outdated; the installed documentation is the source of truth for the project's Rstack version.
+
+1. Start with `node_modules/rstack/dist/docs/llms.txt`, then read only the linked pages relevant to the task before proposing or making changes.
 
 2. For exact CLI flags and behavior, also run `rs -h` or `rs <command> -h` when supported.
 
-If the bundled docs are not available at that path, locate the installed `rstack` package. If they
-are still unavailable, verify that `rstack` is installed, report the installed version, and use CLI
-help plus the online Rstack documentation as a fallback. Do not guess from model memory.
+If the bundled docs are not available at that path, locate the installed `rstack` package.
+
+If they are still unavailable, verify that `rstack` is installed, and use CLI help plus the online [Rstack documentation](https://rstack.rs/) as a fallback.

--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -11,37 +11,14 @@ Before any Rstack work, find and read the relevant Markdown documentation shippe
 installed `rstack` package. Model knowledge and summaries in this skill can be outdated; the
 installed documentation is the source of truth for the project's Rstack version.
 
-1. Read only the pages relevant to the task under `node_modules/rstack/dist/docs` before proposing
-   or making changes.
+1. Start with `node_modules/rstack/dist/docs/llms.txt`, then read only the linked pages relevant to
+   the task before proposing or making changes.
 
-2. If the correct page is unclear, start with the documentation index and search the documentation
-   root with `rg -n "<keyword>" <docs-root>`.
+2. If `llms.txt` is unavailable, start with `node_modules/rstack/dist/docs/index.md` and search the
+   documentation directory with `rg -n "<keyword>" node_modules/rstack/dist/docs`.
 
 3. For exact CLI flags and behavior, also run `rs -h` or `rs <command> -h` when supported.
 
 If the bundled docs are not available at that path, locate the installed `rstack` package. If they
 are still unavailable, verify that `rstack` is installed, report the installed version, and use CLI
 help plus the online Rstack documentation as a fallback. Do not guess from model memory.
-
-## Documentation map
-
-These links target the usual project-local skill installation. If a link does not resolve, open
-the same relative path under the resolved documentation root.
-
-- [Overview](../../../node_modules/rstack/dist/docs/index.md)
-- [Quick start and command overview](../../../node_modules/rstack/dist/docs/guide/quick-start.md)
-- [Configuration](../../../node_modules/rstack/dist/docs/guide/configuration.md)
-- [API and import paths](../../../node_modules/rstack/dist/docs/guide/api-reference.md)
-- [Monorepos](../../../node_modules/rstack/dist/docs/guide/monorepo.md)
-- [Testing](../../../node_modules/rstack/dist/docs/guide/testing.md)
-- [Formatting](../../../node_modules/rstack/dist/docs/guide/formatting.md)
-- CLI commands: [dev](../../../node_modules/rstack/dist/docs/guide/cli/dev.md),
-  [build](../../../node_modules/rstack/dist/docs/guide/cli/build.md),
-  [preview](../../../node_modules/rstack/dist/docs/guide/cli/preview.md),
-  [lib](../../../node_modules/rstack/dist/docs/guide/cli/lib.md),
-  [doc](../../../node_modules/rstack/dist/docs/guide/cli/doc.md),
-  [test](../../../node_modules/rstack/dist/docs/guide/cli/test.md),
-  [lint](../../../node_modules/rstack/dist/docs/guide/cli/lint.md),
-  [fmt](../../../node_modules/rstack/dist/docs/guide/cli/fmt.md),
-  [setup](../../../node_modules/rstack/dist/docs/guide/cli/setup.md), and
-  [staged](../../../node_modules/rstack/dist/docs/guide/cli/staged.md)

--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -5,6 +5,11 @@ description: Guidance for Rstack CLI work involving `rs` commands, `rstack.confi
 
 # Rstack CLI Best Practices
 
+Rstack CLI is the `rstack` package, exposed through the `rs` binaries. It provides one CLI, one
+config file, and a consistent workflow for the Rstack JavaScript toolchain.
+
+It covers web app, library, docs, test, lint, formatting, Git hook, and staged-file workflows.
+
 ## Rstack: ALWAYS read installed docs before working
 
 Before any Rstack work, find and read the relevant Markdown documentation shipped with the

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
-import { copyFile, mkdir, readdir, rm } from 'node:fs/promises';
+import { copyFile, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 const rootDir = path.resolve(import.meta.dirname, '..');
@@ -71,4 +71,10 @@ for (const relativePath of markdownFiles) {
   await copyFile(path.join(websiteDistDir, relativePath), destination);
 }
 
-console.log(`Copied ${markdownFiles.length} English Markdown files to ${packageDocsDir}.`);
+const llmsTxt = await readFile(path.join(websiteDistDir, 'llms.txt'), 'utf8');
+const packageLlmsTxt = llmsTxt.replace(/\]\(\/(?!\/)/g, '](./');
+await writeFile(path.join(packageDocsDir, 'llms.txt'), packageLlmsTxt);
+
+console.log(
+  `Copied ${markdownFiles.length} English Markdown files and llms.txt to ${packageDocsDir}.`,
+);


### PR DESCRIPTION
## Summary

This PR keeps the Rstack best-practices skill aligned with the version installed in each project by directing agents to read the bundled documentation before Rstack work.
It packages Rspress's generated `llms.txt` alongside the Markdown pages, rewrites its routes as local relative links, and uses that index instead of maintaining a duplicate documentation map in the skill.

## Related Links

- https://nextjs.org/docs/app/guides/ai-agents#new-projects
- https://github.com/rstackjs/rstack-cli/pull/194