### PR TITLE
feat(fmt): add -w alias for write

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -29,7 +29,7 @@ ${color.yellow('  $ rs fmt [options] [files/globs...]')}
 Format files with Prettier.
 
 ${color.cyan('Options')}:
-  --write                          Write formatted files in place (default)
+  -w, --write                      Write formatted files in place (default)
   --check                          Check whether files are formatted
   --list-different                 Print paths of unformatted files
   --ignore-path <path>             Path to an additional ignore file (repeatable)
@@ -57,7 +57,7 @@ const parseFmtCLIArgs = (args: string[]): ParsedFmtCLIArgs => {
   const { values, positionals } = parseArgs({
     args,
     options: {
-      write: { type: 'boolean' },
+      write: { type: 'boolean', short: 'w' },
       check: { type: 'boolean' },
       'list-different': { type: 'boolean' },
       'ignore-path': { type: 'string', multiple: true },

--- a/packages/rstack/tests/cli/fmt/index.test.ts
+++ b/packages/rstack/tests/cli/fmt/index.test.ts
@@ -128,6 +128,17 @@ test('formats the current directory with Prettier defaults', () => {
   expect(readProjectFile('index.ts')).toBe('const message = "hello";\n');
 });
 
+test('accepts -w as an alias for --write', () => {
+  writeProjectFile('index.ts', 'const message="hello"');
+
+  const result = runFmt(['-w', 'index.ts']);
+
+  expect(result.status).toBe(0);
+  expectWriteSummary(result.stdout, 1, 1);
+  expect(result.stderr).toBe('');
+  expect(readProjectFile('index.ts')).toBe('const message = "hello";\n');
+});
+
 test('formats files in node_modules with --with-node-modules', () => {
   const source = 'const message="hello"';
   writeProjectFile('node_modules/example/index.ts', source);

--- a/packages/rstack/tests/fmt/__snapshots__/cli.test.ts.snap
+++ b/packages/rstack/tests/fmt/__snapshots__/cli.test.ts.snap
@@ -7,7 +7,7 @@ exports[`provides command help 1`] = `
 Format files with Prettier.
 
 Options:
-  --write                          Write formatted files in place (default)
+  -w, --write                      Write formatted files in place (default)
   --check                          Check whether files are formatted
   --list-different                 Print paths of unformatted files
   --ignore-path <path>             Path to an additional ignore file (repeatable)

--- a/packages/rstack/tests/fmt/cli.test.ts
+++ b/packages/rstack/tests/fmt/cli.test.ts
@@ -31,6 +31,7 @@ test('uses write mode by default', () => {
 });
 
 test.each([
+  ['-w', 'write'],
   ['--write', 'write'],
   ['--check', 'check'],
   ['--list-different', 'list-different'],

--- a/website/docs/en/guide/cli/fmt.mdx
+++ b/website/docs/en/guide/cli/fmt.mdx
@@ -167,4 +167,10 @@ Write formatted files in place. This is the default mode, so specifying `--write
 rs fmt src --write
 ```
 
+The short option `-w` is an alias for `--write`:
+
+```bash
+rs fmt -w src
+```
+
 `--write` cannot be combined with `--check` or `--list-different`.

--- a/website/docs/zh/guide/cli/fmt.mdx
+++ b/website/docs/zh/guide/cli/fmt.mdx
@@ -167,4 +167,10 @@ rs fmt --with-node-modules node_modules/example/index.js
 rs fmt src --write
 ```
 
+短选项 `-w` 是 `--write` 的别名：
+
+```bash
+rs fmt -w src
+```
+
 `--write` 不能与 `--check` 或 `--list-different` 同时使用。


### PR DESCRIPTION
## Summary

This PR adds `-w` as a short alias for `rs fmt --write`. It updates command help, English and Chinese documentation, and unit and end-to-end coverage.