### PR TITLE
perf(fmt): avoid relative resolution on cache hits

### DIFF
--- a/packages/rstack/src/fmt/discoverPaths.ts
+++ b/packages/rstack/src/fmt/discoverPaths.ts
@@ -153,14 +153,13 @@ class GitIgnoreMatcher {
     return loading;
   }
 
-  #isDirectoryIgnored(
-    directoryPath: string,
-    relativePath = path.relative(this.#rootPath, directoryPath),
-  ): boolean {
+  #isDirectoryIgnored(directoryPath: string, relativePath?: string): boolean {
     const cached = this.#ignoredDirectories.get(directoryPath);
     if (cached !== undefined) {
       return cached;
     }
+
+    relativePath ??= path.relative(this.#rootPath, directoryPath);
 
     // Git cannot re-include a path below an ignored directory.
     const parentPath = path.dirname(directoryPath);


### PR DESCRIPTION
Directory ignore cache hits still evaluated `path.relative` because it was used as a default parameter. This moves the fallback computation after the cache lookup, avoiding redundant path resolution without changing ignore behavior.