### PR TITLE
feat(fmt): add -l alias for list different

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -31,7 +31,7 @@ Format files with Prettier.
 ${color.cyan('Options')}:
   -w, --write                      Write formatted files in place (default)
   --check                          Check whether files are formatted
-  --list-different                 Print paths of unformatted files
+  -l, --list-different             Print paths of unformatted files
   --ignore-path <path>             Path to an additional ignore file (repeatable)
   -u, --ignore-unknown             Ignore unknown files
   --no-error-on-unmatched-pattern  Do not error when no files match
@@ -59,7 +59,7 @@ const parseFmtCLIArgs = (args: string[]): ParsedFmtCLIArgs => {
     options: {
       write: { type: 'boolean', short: 'w' },
       check: { type: 'boolean' },
-      'list-different': { type: 'boolean' },
+      'list-different': { type: 'boolean', short: 'l' },
       'ignore-path': { type: 'string', multiple: true },
       'ignore-unknown': { type: 'boolean', short: 'u' },
       'no-error-on-unmatched-pattern': { type: 'boolean' },

--- a/packages/rstack/tests/cli/fmt/index.test.ts
+++ b/packages/rstack/tests/cli/fmt/index.test.ts
@@ -337,12 +337,12 @@ test('checks formatting without writing files', () => {
   expect(formattedResult.stderr).toBe('');
 });
 
-test('lists only paths that differ', () => {
+test.each(['-l', '--list-different'])('lists only paths that differ with %s', (option) => {
   const source = 'const message="hello"';
   writeProjectFile('src/index.ts', source);
   writeProjectFile('src/formatted.ts', 'const formatted = true;\n');
 
-  const result = runFmt(['--list-different', 'src/*.ts']);
+  const result = runFmt([option, 'src/*.ts']);
 
   expect(result.status).toBe(1);
   expect(result.stdout).toBe('src/index.ts\n');

--- a/packages/rstack/tests/fmt/__snapshots__/cli.test.ts.snap
+++ b/packages/rstack/tests/fmt/__snapshots__/cli.test.ts.snap
@@ -9,7 +9,7 @@ Format files with Prettier.
 Options:
   -w, --write                      Write formatted files in place (default)
   --check                          Check whether files are formatted
-  --list-different                 Print paths of unformatted files
+  -l, --list-different             Print paths of unformatted files
   --ignore-path <path>             Path to an additional ignore file (repeatable)
   -u, --ignore-unknown             Ignore unknown files
   --no-error-on-unmatched-pattern  Do not error when no files match

--- a/packages/rstack/tests/fmt/cli.test.ts
+++ b/packages/rstack/tests/fmt/cli.test.ts
@@ -34,6 +34,7 @@ test.each([
   ['-w', 'write'],
   ['--write', 'write'],
   ['--check', 'check'],
+  ['-l', 'list-different'],
   ['--list-different', 'list-different'],
 ] as const)('parses %s mode', (option, mode) => {
   expect(parseFmtCLIArgs([option])).toEqual({

--- a/website/docs/en/guide/cli/fmt.mdx
+++ b/website/docs/en/guide/cli/fmt.mdx
@@ -36,7 +36,7 @@ rs format
 Check whether files are formatted without changing them. The output lists files with formatting issues and includes a human-friendly summary, making this option useful in CI:
 
 ```bash
-rs fmt . --check
+rs fmt --check
 ```
 
 `--check` cannot be combined with `--write` or `--list-different`.
@@ -110,7 +110,13 @@ When used with `--stdin-filepath`, unsupported input is skipped without writing 
 Print the paths of unformatted files without the summary produced by `--check`. This is useful when another command needs to consume the output:
 
 ```bash
-rs fmt . --list-different
+rs fmt --list-different
+```
+
+The short option `-l` is an alias for `--list-different`:
+
+```bash
+rs fmt -l
 ```
 
 The option uses the same exit codes as `--check` and cannot be combined with `--write` or `--check`.
@@ -132,7 +138,7 @@ For example, a pre-commit script may always run `rs fmt`, even when the staged c
 Set the maximum number of formatting workers to a positive integer:
 
 ```bash
-rs fmt . --parallel-workers 4
+rs fmt --parallel-workers 4
 ```
 
 When this option is omitted, `rs fmt` automatically chooses up to eight workers based on the available CPU parallelism and the number of matched files. Set a lower value to limit CPU or memory usage in constrained environments.

--- a/website/docs/zh/guide/cli/fmt.mdx
+++ b/website/docs/zh/guide/cli/fmt.mdx
@@ -36,7 +36,7 @@ rs format
 检查文件是否已格式化，但不修改文件。输出会列出存在格式问题的文件，并提供便于阅读的汇总信息，因此适合在 CI 中使用：
 
 ```bash
-rs fmt . --check
+rs fmt --check
 ```
 
 `--check` 不能与 `--write` 或 `--list-different` 同时使用。
@@ -110,7 +110,13 @@ rs fmt -u
 输出未格式化文件的路径，但不提供 `--check` 的汇总信息。需要将结果交给其他命令处理时，可以使用此选项：
 
 ```bash
-rs fmt . --list-different
+rs fmt --list-different
+```
+
+短选项 `-l` 是 `--list-different` 的别名：
+
+```bash
+rs fmt -l
 ```
 
 此选项与 `--check` 使用相同的退出状态码，且不能与 `--write` 或 `--check` 同时使用。
@@ -132,7 +138,7 @@ rs fmt --no-error-on-unmatched-pattern 'src/**/*.ts'
 将格式化 worker 的最大数量设置为正整数：
 
 ```bash
-rs fmt . --parallel-workers 4
+rs fmt --parallel-workers 4
 ```
 
 省略此选项时，`rs fmt` 会根据可用的 CPU 并行度和匹配的文件数量，自动选择最多 8 个 worker。在资源受限的环境中，可以设置较小的值来限制 CPU 或内存用量。


### PR DESCRIPTION
This PR adds `-l` as a short alias for `--list-different`, matching Prettier's CLI behavior. It updates CLI help, parser and end-to-end coverage, and aligned English and Chinese examples while removing redundant current-directory arguments.