### PR TITLE
chore: align VS Code formatting with Rstack config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,9 @@
   },
   "mdx.validate.validateFileLinks": "ignore",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
+  // Temporary workaround until we switch to the Rstack VS Code extension.
+  "prettier.printWidth": 100,
+  "prettier.singleQuote": true,
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"


### PR DESCRIPTION
## Summary

This PR keeps VS Code formatting consistent with the repository's Rstack configuration while the Rstack VS Code extension is unavailable. It configures the Prettier extension to use a 100-character print width and single quotes.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8228