### PR TITLE
perf(fmt): avoid duplicate binary path checks

### DIFF
--- a/packages/rstack/src/fmt/discoverPaths.ts
+++ b/packages/rstack/src/fmt/discoverPaths.ts
@@ -296,7 +296,7 @@ const classifyPatterns = async (
 
       const stats = await lstatSafe(filePath);
       if (stats?.isFile()) {
-        return { kind: 'file', value: filePath };
+        return isBinaryPath(filePath) ? undefined : { kind: 'file', value: filePath };
       }
       if (stats?.isDirectory()) {
         return { kind: 'directory', value: filePath };
@@ -436,10 +436,6 @@ const discoverFmtPaths = async ({
   const filePaths: string[] = [];
 
   for (const filePath of candidates) {
-    if (isBinaryPath(filePath)) {
-      continue;
-    }
-
     if (negativeGlobMatchers.length) {
       const relativePath = toPosixPath(path.relative(cwd, filePath));
       if (negativeGlobMatchers.some((matches) => matches(relativePath))) {


### PR DESCRIPTION
Binary files found during directory traversal are already filtered before they enter the candidate set, but every candidate was checked again afterward. This moves the check for explicit files into pattern classification and removes the redundant candidate-level check.