### PR TITLE
fix(setup): avoid redundant hooks config writes

### DIFF
--- a/packages/rstack/src/setup/install.ts
+++ b/packages/rstack/src/setup/install.ts
@@ -126,9 +126,10 @@ export const installHooks = ({
 
   const directory = path.join(cwd, resolvedDir, '_');
   const files = Object.entries(createHookFiles());
+  const hooksPathMatches = path.resolve(cwd, configuredHooksPath) === directory;
   // Skip all writes only when the config, generated content, and executable modes match.
   const unchanged =
-    path.resolve(cwd, configuredHooksPath) === directory &&
+    hooksPathMatches &&
     isCurrentFile(path.join(directory, '.gitignore'), gitignore) &&
     files.every(([name, content]) => isCurrentFile(path.join(directory, name), content, true));
 
@@ -149,6 +150,11 @@ export const installHooks = ({
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return fail('write-failed', `Failed to write Git hook files: ${message}`);
+  }
+
+  // Avoid rewriting .git/config when only the generated files needed repair.
+  if (hooksPathMatches) {
+    return { status: 'installed', hooksPath };
   }
 
   // Point Git at the generated directory only after every runtime file is ready.

--- a/packages/rstack/tests/setup/install.test.ts
+++ b/packages/rstack/tests/setup/install.test.ts
@@ -50,6 +50,18 @@ test.runIf(process.platform !== 'win32')('restores executable mode on existing s
   });
 });
 
+test('repairs generated files without rewriting an unchanged hooksPath', () => {
+  withRepository((cwd) => {
+    expect(installHooks({ cwd }).status).toBe('installed');
+    const runner = path.join(cwd, hooksPath, 'runner');
+    writeFileSync(runner, 'stale\n');
+    writeFileSync(path.join(cwd, '.git', 'config.lock'), 'locked');
+
+    expect(installHooks({ cwd })).toEqual({ status: 'installed', hooksPath });
+    expect(readFileSync(runner, 'utf8')).toBe(createHookFiles().runner);
+  });
+});
+
 test('skips non-Git directories without creating files', () => {
   withDirectory((cwd) => {
     expect(installHooks({ cwd })).toEqual({


### PR DESCRIPTION
Repairing generated hooks currently rewrites `core.hooksPath` even when it already points to the correct directory, which can fail unnecessarily when `.git/config` is locked.

This PR reuses the existing path comparison to skip redundant Git config writes while preserving generated-file repairs.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/205