### PR TITLE
refactor(fmt): centralize path helpers

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -1,11 +1,10 @@
-import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { color, logger } from 'rslog';
 import { parseArgs } from '../cli/args.ts';
 import { loadRstackConfig } from '../config.ts';
 import { resolveFmtConfig } from './config.ts';
 import { discoverFmtFiles } from './discovery.ts';
-import { createRelativePathResolver } from './relativePath.ts';
+import { createRelativePathResolver, toPosixPath } from './pathHelpers.ts';
 import { runFmtFiles } from './runner.ts';
 import type { FmtMode, FmtRunResult, ResolvedFmtConfig } from './types.ts';
 
@@ -119,9 +118,7 @@ const parseFmtCLIArgs = (args: string[]): ParsedFmtCLIArgs => {
 const createDisplayPathResolver = (cwd: string): ((filePath: string) => string) => {
   const resolveRelativePath = createRelativePathResolver(cwd);
 
-  return path.sep === '\\'
-    ? (filePath) => resolveRelativePath(filePath).replaceAll('\\', '/')
-    : resolveRelativePath;
+  return (filePath) => toPosixPath(resolveRelativePath(filePath));
 };
 
 const prettyTime = (seconds: number): string => {

--- a/packages/rstack/src/fmt/config.ts
+++ b/packages/rstack/src/fmt/config.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'node:path';
 import micromatch from 'micromatch';
-import { createRelativePathResolver } from './relativePath.ts';
+import { createRelativePathResolver } from './pathHelpers.ts';
 import type {
   FmtConfig,
   FmtConfigDefinition,

--- a/packages/rstack/src/fmt/discoverPaths.ts
+++ b/packages/rstack/src/fmt/discoverPaths.ts
@@ -4,7 +4,11 @@ import ignore from 'ignore';
 import isBinaryPath from 'is-binary-path';
 import micromatch from 'micromatch';
 import readdir, { type Dirent, type DirentLike } from 'tiny-readdir';
-import { createRelativePathResolver, type RelativePathResolver } from './relativePath.ts';
+import {
+  createRelativePathResolver,
+  toPosixPath,
+  type RelativePathResolver,
+} from './pathHelpers.ts';
 
 const defaultIgnoredDirNames = new Set(['.git', '.sl', '.svn', '.hg', '.jj', 'node_modules']);
 
@@ -38,9 +42,6 @@ const isRelativePathInside = (relativePath: string): boolean =>
 
 const isPathInside = (rootPath: string, filePath: string): boolean =>
   isRelativePathInside(path.relative(rootPath, filePath));
-
-const toPosixPath = (filePath: string): string =>
-  path.sep === '\\' ? filePath.replaceAll('\\', '/') : filePath;
 
 /** Supports both the legacy tiny-readdir type and Node.js 24 Dirent. */
 const getDirentParentPath = (dirent: Dirent): string =>

--- a/packages/rstack/src/fmt/ignore.ts
+++ b/packages/rstack/src/fmt/ignore.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import createIgnore from 'ignore';
-import { createRelativePathResolver } from './relativePath.ts';
+import { createRelativePathResolver } from './pathHelpers.ts';
 import type { ResolvedFmtConfig } from './types.ts';
 
 /**

--- a/packages/rstack/src/fmt/pathHelpers.ts
+++ b/packages/rstack/src/fmt/pathHelpers.ts
@@ -2,6 +2,9 @@ import path from 'node:path';
 
 type RelativePathResolver = (filePath: string) => string;
 
+const toPosixPath: (filePath: string) => string =
+  path.sep === '\\' ? (filePath) => filePath.replaceAll('\\', '/') : (filePath) => filePath;
+
 const createRelativePathResolver = (rootPath: string): RelativePathResolver => {
   const rootPrefix = rootPath.endsWith(path.sep) ? rootPath : `${rootPath}${path.sep}`;
 
@@ -13,5 +16,5 @@ const createRelativePathResolver = (rootPath: string): RelativePathResolver => {
         : path.relative(rootPath, filePath);
 };
 
-export { createRelativePathResolver };
+export { createRelativePathResolver, toPosixPath };
 export type { RelativePathResolver };

--- a/packages/rstack/tests/fmt/pathHelpers.test.ts
+++ b/packages/rstack/tests/fmt/pathHelpers.test.ts
@@ -1,8 +1,12 @@
 import path from 'node:path';
 import { expect, test } from 'rstack/test';
-import { createRelativePathResolver } from '../../src/fmt/relativePath.ts';
+import { createRelativePathResolver, toPosixPath } from '../../src/fmt/pathHelpers.ts';
 
 const rootPath = path.join(import.meta.dirname, 'project');
+
+test('converts platform paths to POSIX paths', () => {
+  expect(toPosixPath(path.join('src', 'index.ts'))).toBe('src/index.ts');
+});
 
 test('resolves paths relative to a fixed root', () => {
   const resolveRelativePath = createRelativePathResolver(rootPath);


### PR DESCRIPTION
Path normalization is currently defined inside discovery even though CLI reporting needs the same conversion. This PR renames `relativePath.ts` to `pathHelpers.ts`, centralizes `toPosixPath` with a platform-selected implementation, and reuses it across discovery and CLI without changing output.