### PR TITLE
perf(fmt): share compile cache with workers

### DIFF
--- a/packages/rstack/bin/rs.js
+++ b/packages/rstack/bin/rs.js
@@ -3,11 +3,11 @@ import nodeModule from 'node:module';
 
 // enable on-disk code caching and share its directory with child workers
 // requires Nodejs >= 22.8.0
-const { enableCompileCache } = nodeModule;
+const { enableCompileCache, constants } = nodeModule;
 if (enableCompileCache) {
   try {
-    const { directory } = enableCompileCache();
-    if (directory) {
+    const { directory, status } = enableCompileCache();
+    if (directory && status === constants.compileCacheStatus.ENABLED) {
       process.env.NODE_COMPILE_CACHE = directory;
     }
   } catch {

--- a/packages/rstack/bin/rs.js
+++ b/packages/rstack/bin/rs.js
@@ -7,6 +7,8 @@ const { enableCompileCache, constants } = nodeModule;
 if (enableCompileCache) {
   try {
     const { directory, status } = enableCompileCache();
+    // ALREADY_ENABLED returns the active version-specific cache directory.
+    // Passing it to workers would append another version directory.
     if (directory && status === constants.compileCacheStatus.ENABLED) {
       process.env.NODE_COMPILE_CACHE = directory;
     }

--- a/packages/rstack/bin/rs.js
+++ b/packages/rstack/bin/rs.js
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 import nodeModule from 'node:module';
 
-// enable on-disk code caching of all modules loaded by Node.js
+// enable on-disk code caching and share its directory with child workers
 // requires Nodejs >= 22.8.0
 const { enableCompileCache } = nodeModule;
 if (enableCompileCache) {
   try {
-    enableCompileCache();
+    const { directory } = enableCompileCache();
+    if (directory) {
+      process.env.NODE_COMPILE_CACHE = directory;
+    }
   } catch {
     // ignore errors
   }


### PR DESCRIPTION
Node's compile cache was enabled only for the main CLI process, so `rs fmt` workers could not reuse compiled modules. This PR propagates the directory returned by `module.enableCompileCache()` through `NODE_COMPILE_CACHE`, allowing subsequently spawned workers to share the same on-disk cache while preserving the existing Node version guard.