### PR TITLE
feat(config): expose config loader APIs

### DIFF
--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -18,6 +18,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./config": {
+      "types": "./dist/configExports.d.ts",
+      "default": "./dist/configExports.js"
+    },
     "./app": {
       "types": "./dist/app.d.ts",
       "default": "./dist/app.js"

--- a/packages/rstack/rslib.config.ts
+++ b/packages/rstack/rslib.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   source: {
     entry: {
       index: './src/index.ts',
+      configExports: './src/configExports.ts',
       rsbuildConfig: './src/rsbuildConfig.ts',
       rslibConfig: './src/rslibConfig.ts',
       rslintConfig: './src/rslintConfig.ts',

--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -21,13 +21,13 @@ export type Configs = {
   staged?: StagedConfig;
 };
 
-type LoadedRstackConfig = {
+export type LoadedRstackConfig = {
   configs: Configs;
   filePath: string | null;
   dependencies: string[];
 };
 
-type LoadRstackConfigOptions = {
+export type LoadRstackConfigOptions = {
   /**
    * The path to the Rstack config file, can be a relative or absolute path.
    * If `configFilePath` is not provided, the config path set by the CLI is used.

--- a/packages/rstack/src/configExports.ts
+++ b/packages/rstack/src/configExports.ts
@@ -1,0 +1,7 @@
+/** Public configuration APIs exposed through `rstack/config`. */
+export {
+  loadRstackConfig,
+  type Configs,
+  type LoadedRstackConfig,
+  type LoadRstackConfigOptions,
+} from './config.ts';

--- a/packages/rstack/tests/exports/config-subpath/index.test.ts
+++ b/packages/rstack/tests/exports/config-subpath/index.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'rstack/test';
+
+test('should expose only the config loader API from `rstack/config`', async () => {
+  const config = await import('rstack/config');
+
+  expect(Object.keys(config)).toEqual(['loadRstackConfig']);
+});

--- a/packages/rstack/tests/types/resolution-bundler/index.ts
+++ b/packages/rstack/tests/types/resolution-bundler/index.ts
@@ -4,12 +4,24 @@ import 'rstack/test/importMeta';
 import 'rstack/types';
 import { define } from 'rstack';
 import { createRsbuild, defineConfig as defineAppConfig } from 'rstack/app';
+import {
+  loadRstackConfig,
+  type Configs,
+  type LoadedRstackConfig,
+  type LoadRstackConfigOptions,
+} from 'rstack/config';
 import { defineConfig as defineLibConfig } from 'rstack/lib';
 import { js, ts } from 'rstack/lint';
 import { expect as importedExpect, test as importedTest } from 'rstack/test';
 
 const appConfig = defineAppConfig({});
 const libConfig = defineLibConfig({});
+const loadOptions: LoadRstackConfigOptions = { configFilePath: 'rstack.config.ts' };
+const loadedConfig: Promise<LoadedRstackConfig> = loadRstackConfig(loadOptions);
+const configs: Configs = {};
+
+void loadedConfig;
+void configs;
 
 createRsbuild({ config: appConfig });
 define.app(appConfig);

--- a/packages/rstack/tests/types/resolution-nodenext/index.ts
+++ b/packages/rstack/tests/types/resolution-nodenext/index.ts
@@ -4,12 +4,24 @@ import 'rstack/test/importMeta';
 import 'rstack/types';
 import { define } from 'rstack';
 import { createRsbuild, defineConfig as defineAppConfig } from 'rstack/app';
+import {
+  loadRstackConfig,
+  type Configs,
+  type LoadedRstackConfig,
+  type LoadRstackConfigOptions,
+} from 'rstack/config';
 import { defineConfig as defineLibConfig } from 'rstack/lib';
 import { js, ts } from 'rstack/lint';
 import { expect as importedExpect, test as importedTest } from 'rstack/test';
 
 const appConfig = defineAppConfig({});
 const libConfig = defineLibConfig({});
+const loadOptions: LoadRstackConfigOptions = { configFilePath: 'rstack.config.ts' };
+const loadedConfig: Promise<LoadedRstackConfig> = loadRstackConfig(loadOptions);
+const configs: Configs = {};
+
+void loadedConfig;
+void configs;
 
 createRsbuild({ config: appConfig });
 define.app(appConfig);


### PR DESCRIPTION
Rstack integrations currently cannot access the internal config loader through the package exports. This PR adds a `rstack/config` subpath that exposes `loadRstackConfig` and its related public types while keeping internal configuration state private. It also covers the runtime export surface and Bundler and NodeNext type resolution.