### PR TITLE
docs: add Rstack CLI migration guide

### DIFF
--- a/website/docs/en/guide/_meta.json
+++ b/website/docs/en/guide/_meta.json
@@ -24,6 +24,11 @@
   },
   {
     "type": "file",
+    "name": "migration",
+    "label": "Migration"
+  },
+  {
+    "type": "file",
     "name": "testing",
     "label": "Testing"
   },

--- a/website/docs/en/guide/migration.mdx
+++ b/website/docs/en/guide/migration.mdx
@@ -33,7 +33,7 @@ The Skill can directly migrate the following standalone tools:
 
 The Skill does not directly migrate tools outside the list above. If your project uses any of the following tools, migrate it to the corresponding Rstack tool first, then run the `migrate-to-rstack-cli` Skill:
 
-- **Application builds:** Migrate [webpack](https://rsbuild.rs/guide/migration/webpack), [Vite](https://rsbuild.rs/guide/migration/vite), [Create React App](https://rsbuild.rs/guide/migration/cra), or [Vue CLI](https://rsbuild.rs/guide/migration/vue-cli) projects to Rsbuild.
-- **Library builds:** Migrate projects built with [tsup](https://rslib.rs/guide/migration/tsup) or [tsc](https://rslib.rs/guide/migration/tsc) to Rslib.
-- **Testing:** Migrate [Jest](https://rstest.rs/guide/migration/jest) or [Vitest](https://rstest.rs/guide/migration/vitest) projects to Rstest.
-- **Linting:** Follow the [Rslint guide](https://rslint.rs/guide/) to migrate ESLint or other linters to Rslint.
+- **Application builds:** Follow the Rsbuild [webpack migration guide](https://rsbuild.rs/guide/migration/webpack), [Vite migration guide](https://rsbuild.rs/guide/migration/vite), [Create React App migration guide](https://rsbuild.rs/guide/migration/cra), or [Vue CLI migration guide](https://rsbuild.rs/guide/migration/vue-cli) to migrate the project to Rsbuild.
+- **Library builds:** Follow the Rslib [tsup migration guide](https://rslib.rs/guide/migration/tsup) or [tsc migration guide](https://rslib.rs/guide/migration/tsc) to migrate the library to Rslib.
+- **Testing:** Follow the Rstest [Jest migration guide](https://rstest.rs/guide/migration/jest) or [Vitest migration guide](https://rstest.rs/guide/migration/vitest) to migrate the project to Rstest.
+- **Linting:** Follow the [Rslint getting started guide](https://rslint.rs/guide/) to migrate ESLint or other linters to Rslint.

--- a/website/docs/en/guide/migration.mdx
+++ b/website/docs/en/guide/migration.mdx
@@ -1,0 +1,39 @@
+---
+description: 'Migrate an existing project to Rstack CLI with the recommended migration Skill.'
+---
+
+# Migrate to Rstack CLI
+
+To migrate an existing project, we recommend using the `migrate-to-rstack-cli` Skill. It inspects the project and automatically migrates supported tools used in the repository—including Rstack tools, Prettier, and Husky—to Rstack CLI.
+
+## Use the migration skill
+
+First, install the Skill:
+
+```bash
+npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
+```
+
+Then ask your coding agent to perform the migration with this prompt:
+
+```text
+Use the migrate-to-rstack-cli Skill to migrate this project to Rstack CLI.
+```
+
+## Supported tools
+
+The Skill can directly migrate the following standalone tools:
+
+- **Rstack toolchain:** [Rsbuild](https://rsbuild.rs/), [Rslib](https://rslib.rs/), [Rstest](https://rstest.rs/), [Rslint](https://rslint.rs/), and [Rspress](https://rspress.rs/)
+- **Code formatting:** [Prettier](https://github.com/prettier/prettier)
+- **Staged-file tasks:** [lint-staged](https://github.com/lint-staged/lint-staged) and [nano-staged](https://github.com/usmanyunusov/nano-staged)
+- **Git hooks:** [Husky](https://github.com/typicode/husky) and [simple-git-hooks](https://github.com/toplenboren/simple-git-hooks)
+
+## Unsupported tools
+
+The Skill does not directly migrate tools outside the list above. If your project uses any of the following tools, migrate it to the corresponding Rstack tool first, then run the `migrate-to-rstack-cli` Skill:
+
+- **Application builds:** Migrate [webpack](https://rsbuild.rs/guide/migration/webpack), [Vite](https://rsbuild.rs/guide/migration/vite), [Create React App](https://rsbuild.rs/guide/migration/cra), or [Vue CLI](https://rsbuild.rs/guide/migration/vue-cli) projects to Rsbuild.
+- **Library builds:** Migrate projects built with [tsup](https://rslib.rs/guide/migration/tsup) or [tsc](https://rslib.rs/guide/migration/tsc) to Rslib.
+- **Testing:** Migrate [Jest](https://rstest.rs/guide/migration/jest) or [Vitest](https://rstest.rs/guide/migration/vitest) projects to Rstest.
+- **Linting:** Follow the [Rslint guide](https://rslint.rs/guide/) to migrate ESLint or other linters to Rslint.

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -106,4 +106,4 @@ Install the migration skill so the agent can migrate existing projects to Rstack
 npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
 ```
 
-For supported tools and migration instructions, see the [migration guide](./migration).
+For supported tools and migration instructions, see [Migrate to Rstack CLI](./migration).

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -106,4 +106,4 @@ Install the migration skill so the agent can migrate existing projects to Rstack
 npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
 ```
 
-For supported tools and migration instructions, see [Migrate to Rstack CLI](./migration).
+For supported tools and migration instructions, see the [migration guide](./migration).

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -105,3 +105,5 @@ Install the migration skill so the agent can migrate existing projects to Rstack
 ```bash
 npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
 ```
+
+For supported tools and migration instructions, see [Migrate to Rstack CLI](./migration).

--- a/website/docs/zh/guide/_meta.json
+++ b/website/docs/zh/guide/_meta.json
@@ -24,6 +24,11 @@
   },
   {
     "type": "file",
+    "name": "migration",
+    "label": "迁移"
+  },
+  {
+    "type": "file",
     "name": "testing",
     "label": "测试"
   },

--- a/website/docs/zh/guide/migration.mdx
+++ b/website/docs/zh/guide/migration.mdx
@@ -33,7 +33,7 @@ npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
 
 该 Skill 不会直接迁移上面列表之外的工具。如果项目使用以下工具，请先将其迁移到对应的 Rstack 工具，再运行 `migrate-to-rstack-cli` Skill：
 
-- **应用构建：**将 [webpack](https://rsbuild.rs/zh/guide/migration/webpack)、[Vite](https://rsbuild.rs/zh/guide/migration/vite)、[Create React App](https://rsbuild.rs/zh/guide/migration/cra) 或 [Vue CLI](https://rsbuild.rs/zh/guide/migration/vue-cli) 项目迁移到 Rsbuild。
-- **库构建：**将使用 [tsup](https://rslib.rs/zh/guide/migration/tsup) 或 [tsc](https://rslib.rs/zh/guide/migration/tsc) 构建的库迁移到 Rslib。
-- **测试：**将 [Jest](https://rstest.rs/zh/guide/migration/jest) 或 [Vitest](https://rstest.rs/zh/guide/migration/vitest) 项目迁移到 Rstest。
-- **代码检查：**参考 [Rslint 指南](https://rslint.rs/guide/)，将 ESLint 或其他代码检查工具迁移到 Rslint。
+- **应用构建：**参考 Rsbuild 的 [webpack 迁移指南](https://rsbuild.rs/zh/guide/migration/webpack)、[Vite 迁移指南](https://rsbuild.rs/zh/guide/migration/vite)、[Create React App 迁移指南](https://rsbuild.rs/zh/guide/migration/cra) 或 [Vue CLI 迁移指南](https://rsbuild.rs/zh/guide/migration/vue-cli)，将项目迁移到 Rsbuild。
+- **库构建：**参考 Rslib 的 [tsup 迁移指南](https://rslib.rs/zh/guide/migration/tsup) 或 [tsc 迁移指南](https://rslib.rs/zh/guide/migration/tsc)，将库迁移到 Rslib。
+- **测试：**参考 Rstest 的 [Jest 迁移指南](https://rstest.rs/zh/guide/migration/jest) 或 [Vitest 迁移指南](https://rstest.rs/zh/guide/migration/vitest)，将项目迁移到 Rstest。
+- **代码检查：**参考 [Rslint 入门指南](https://rslint.rs/guide/)，将 ESLint 或其他代码检查工具迁移到 Rslint。

--- a/website/docs/zh/guide/migration.mdx
+++ b/website/docs/zh/guide/migration.mdx
@@ -1,0 +1,39 @@
+---
+description: '使用推荐的迁移 Skill，将现有项目迁移到 Rstack CLI。'
+---
+
+# 迁移到 Rstack CLI \{#migrate-to-rstack-cli}
+
+迁移现有项目时，推荐使用 `migrate-to-rstack-cli` Skill。该 Skill 会分析项目，并自动将仓库中使用的 Rstack 工具及 Prettier、Husky 等受支持工具迁移到 Rstack CLI。
+
+## 使用迁移 Skill \{#use-the-migration-skill}
+
+首先安装该 Skill：
+
+```bash
+npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
+```
+
+安装完成后，向 Coding Agent 发送以下 Prompt：
+
+```text
+使用 migrate-to-rstack-cli Skill 将当前项目迁移到 Rstack CLI。
+```
+
+## 支持的工具 \{#supported-tools}
+
+该 Skill 可以直接迁移以下独立工具：
+
+- **Rstack 工具链：**[Rsbuild](https://rsbuild.rs/zh/)、[Rslib](https://rslib.rs/zh/)、[Rstest](https://rstest.rs/zh/)、[Rslint](https://rslint.rs/) 和 [Rspress](https://rspress.rs/zh/)
+- **代码格式化：**[Prettier](https://github.com/prettier/prettier)
+- **暂存文件处理：**[lint-staged](https://github.com/lint-staged/lint-staged) 和 [nano-staged](https://github.com/usmanyunusov/nano-staged)
+- **Git hooks：**[Husky](https://github.com/typicode/husky) 和 [simple-git-hooks](https://github.com/toplenboren/simple-git-hooks)
+
+## 不支持的工具 \{#unsupported-tools}
+
+该 Skill 不会直接迁移上面列表之外的工具。如果项目使用以下工具，请先将其迁移到对应的 Rstack 工具，再运行 `migrate-to-rstack-cli` Skill：
+
+- **应用构建：**将 [webpack](https://rsbuild.rs/zh/guide/migration/webpack)、[Vite](https://rsbuild.rs/zh/guide/migration/vite)、[Create React App](https://rsbuild.rs/zh/guide/migration/cra) 或 [Vue CLI](https://rsbuild.rs/zh/guide/migration/vue-cli) 项目迁移到 Rsbuild。
+- **库构建：**将使用 [tsup](https://rslib.rs/zh/guide/migration/tsup) 或 [tsc](https://rslib.rs/zh/guide/migration/tsc) 构建的库迁移到 Rslib。
+- **测试：**将 [Jest](https://rstest.rs/zh/guide/migration/jest) 或 [Vitest](https://rstest.rs/zh/guide/migration/vitest) 项目迁移到 Rstest。
+- **代码检查：**参考 [Rslint 指南](https://rslint.rs/guide/)，将 ESLint 或其他代码检查工具迁移到 Rslint。

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -106,4 +106,4 @@ npx skills add rstackjs/rstack-cli --skill rstack-cli-best-practices
 npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
 ```
 
-支持的工具和迁移说明请参阅[迁移到 Rstack CLI](./migration)。
+支持的工具和迁移说明请参阅[迁移指南](./migration)。

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -106,4 +106,4 @@ npx skills add rstackjs/rstack-cli --skill rstack-cli-best-practices
 npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
 ```
 
-支持的工具和迁移说明请参阅[迁移指南](./migration)。
+支持的工具和迁移说明请参阅[迁移到 Rstack CLI](./migration)。

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -105,3 +105,5 @@ npx skills add rstackjs/rstack-cli --skill rstack-cli-best-practices
 ```bash
 npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
 ```
+
+支持的工具和迁移说明请参阅[迁移到 Rstack CLI](./migration)。


### PR DESCRIPTION
## Summary

This PR adds a dedicated Rstack CLI migration guide so users can follow the recommended Skill-based workflow. It documents the supported tools, directs unsupported projects to the existing Rsbuild, Rslib, Rstest, and Rslint migration guides, and links the guide from Quick start. English and Chinese content are kept aligned.