### PR TITLE
chore(deps): upgrade Rslib to 1.0.0-beta.2

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/references/rslib.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rslib.md
@@ -18,7 +18,7 @@ Read this reference when the project uses `@rslib/core`, `rslib.config.*`, `rsli
 import { define } from 'rstack';
 
 define.lib({
-  lib: [{ dts: true }],
+  dts: true,
 });
 ```
 

--- a/examples/lib-node/rstack.config.ts
+++ b/examples/lib-node/rstack.config.ts
@@ -2,7 +2,8 @@
 import { define } from 'rstack';
 
 define.lib({
-  lib: [{ syntax: ['node 22'], dts: true }],
+  dts: true,
+  syntax: ['node 22'],
 });
 
 define.lint(async () => {

--- a/examples/lib-react/rstack.config.ts
+++ b/examples/lib-react/rstack.config.ts
@@ -4,12 +4,13 @@ import { define } from 'rstack';
 define.lib(async () => {
   const { pluginReact } = await import('@rsbuild/plugin-react');
   return {
+    bundle: false,
+    dts: true,
     source: {
       entry: {
         index: ['./src/**'],
       },
     },
-    lib: [{ bundle: false, dts: true }],
     output: {
       target: 'web',
     },

--- a/packages/rstack/rslib.config.ts
+++ b/packages/rstack/rslib.config.ts
@@ -4,7 +4,8 @@ import pkgJson from './package.json' with { type: 'json' };
 const fullyMinifiedChunks = /(?:fmt(?:Plugins)?|sortPackageJsonPlugin|staged)\.js$/;
 
 export default defineConfig({
-  lib: [{ syntax: 'es2023', dts: true }],
+  dts: true,
+  syntax: 'es2023',
   source: {
     entry: {
       index: './src/index.ts',
@@ -48,6 +49,18 @@ export default defineConfig({
           },
         },
       ],
+    },
+  },
+  tools: {
+    rspack: {
+      module: {
+        parser: {
+          javascript: {
+            // @rstest/adapter-rslib resolves extended tsconfig paths from a runtime base.
+            createRequire: false,
+          },
+        },
+      },
     },
   },
 });

--- a/packages/rstack/src/fmt/workerPool.ts
+++ b/packages/rstack/src/fmt/workerPool.ts
@@ -28,7 +28,7 @@ const getFmtWorkerUrl = (): URL => {
   const workerPath = new URL(import.meta.url).pathname.endsWith('.ts')
     ? '../../dist/fmtWorker.js'
     : './fmtWorker.js';
-  return new URL(workerPath, import.meta.url);
+  return new URL(/* rspackIgnore: true */ workerPath, import.meta.url);
 };
 
 /** Creates and starts every worker before formatting can begin. */

--- a/packages/rstack/tests/config/define-app-lib/rstack.config.ts
+++ b/packages/rstack/tests/config/define-app-lib/rstack.config.ts
@@ -9,7 +9,6 @@ define.app({
 });
 
 define.lib({
-  lib: [{}],
   source: {
     define: {
       RSTACK_INHERITED_CONFIG: JSON.stringify('lib'),

--- a/packages/rstack/tests/config/define-lib/rstack.config.ts
+++ b/packages/rstack/tests/config/define-lib/rstack.config.ts
@@ -1,7 +1,6 @@
 import { define } from 'rstack';
 
 define.lib({
-  lib: [{}],
   source: {
     define: {
       DEFINE_LIB_TEST_VALUE: JSON.stringify('define.lib works'),

--- a/packages/rstack/tests/config/define-test-projects-lib/rstack.config.ts
+++ b/packages/rstack/tests/config/define-test-projects-lib/rstack.config.ts
@@ -7,7 +7,6 @@ define.lib(() => {
   libConfigCalls += 1;
 
   return {
-    lib: [{}],
     source: {
       define: {
         RSTACK_INHERITED_CONFIG: JSON.stringify('lib'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ catalogs:
       specifier: ^2.0.1
       version: 2.0.1
     '@rslib/core':
-      specifier: ~1.0.0-beta.1
-      version: 1.0.0-beta.1
+      specifier: ~1.0.0-beta.2
+      version: 1.0.0-beta.2
     '@rslint/core':
       specifier: ~0.7.3
       version: 0.7.3
@@ -329,7 +329,7 @@ importers:
         version: 2.1.10
       '@rslib/core':
         specifier: 'catalog:'
-        version: 1.0.0-beta.1(typescript@7.0.2)
+        version: 1.0.0-beta.2(typescript@7.0.2)
       '@rslint/core':
         specifier: 'catalog:'
         version: 0.7.3
@@ -360,7 +360,7 @@ importers:
         version: 0.11.5(@rsbuild/core@2.1.10)(@rstest/core@0.11.5)
       '@rstest/adapter-rslib':
         specifier: 'catalog:'
-        version: 0.11.5(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.5)(typescript@7.0.2)
+        version: 0.11.5(@rslib/core@1.0.0-beta.2)(@rstest/core@0.11.5)(typescript@7.0.2)
       '@types/micromatch':
         specifier: 'catalog:'
         version: 4.0.10
@@ -663,8 +663,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rslib/core@1.0.0-beta.1':
-    resolution: {integrity: sha512-HHPZ+wTUKT/3bEhw2y0JB0O62wMuljkSHVZelLbSGhBflCaUt+D3LohBcIxYW6bhzPbUp4gkJXo1pdTpxiuNLQ==}
+  '@rslib/core@1.0.0-beta.2':
+    resolution: {integrity: sha512-A0j3MBP8Kga8Qrh7znO2UKf00Sga37PJCiTGUqVVBHb+u58fNoGXZtFAgeH6qKjf5eU1wYt4WptXX/1blOAfRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1972,8 +1972,8 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  rsbuild-plugin-dts@1.0.0-beta.1:
-    resolution: {integrity: sha512-hAEjOXhfIHR4erqjsqjRvA9Yqzc6Thry06tHheXDJUVwmR3VbN8BSMDC8kBZzyKdypDF0IJ98FmLQRiC194sMA==}
+  rsbuild-plugin-dts@1.0.0-beta.2:
+    resolution: {integrity: sha512-xOYa/kw/y29kKFFNjd+CIemlq+CB8E7LhqNkIzg7HT9dYNBVBpZvnnL6OEsOgjeuqzKpGSCRgZN/dDoVOk4VhQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -2505,10 +2505,10 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.10
 
-  '@rslib/core@1.0.0-beta.1(typescript@7.0.2)':
+  '@rslib/core@1.0.0-beta.2(typescript@7.0.2)':
     dependencies:
       '@rsbuild/core': 2.1.10
-      rsbuild-plugin-dts: 1.0.0-beta.1(@rsbuild/core@2.1.10)(typescript@7.0.2)
+      rsbuild-plugin-dts: 1.0.0-beta.2(@rsbuild/core@2.1.10)(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
@@ -2700,9 +2700,9 @@ snapshots:
       '@rsbuild/core': 2.1.10
       '@rstest/core': 0.11.5(happy-dom@20.11.1)
 
-  '@rstest/adapter-rslib@0.11.5(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.5)(typescript@7.0.2)':
+  '@rstest/adapter-rslib@0.11.5(@rslib/core@1.0.0-beta.2)(@rstest/core@0.11.5)(typescript@7.0.2)':
     dependencies:
-      '@rslib/core': 1.0.0-beta.1(typescript@7.0.2)
+      '@rslib/core': 1.0.0-beta.2(typescript@7.0.2)
       '@rstest/core': 0.11.5(happy-dom@20.11.1)
     optionalDependencies:
       typescript: 7.0.2
@@ -4095,7 +4095,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  rsbuild-plugin-dts@1.0.0-beta.1(@rsbuild/core@2.1.10)(typescript@7.0.2):
+  rsbuild-plugin-dts@1.0.0-beta.2(@rsbuild/core@2.1.10)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.1.10

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalog:
   '@rsbuild/core': '~2.1.10'
   '@rsbuild/plugin-react': '^2.1.0'
   '@rsbuild/plugin-sass': '^2.0.1'
-  '@rslib/core': '~1.0.0-beta.1'
+  '@rslib/core': '~1.0.0-beta.2'
   '@rslint/core': '~0.7.3'
   '@rspress/core': '^2.0.19'
   '@rspress/plugin-client-redirects': '^2.0.19'

--- a/website/docs/en/guide/cli/lib.mdx
+++ b/website/docs/en/guide/cli/lib.mdx
@@ -58,11 +58,7 @@ Configure library builds through [`define.lib()`](../configuration#define-lib) i
 import { define } from 'rstack';
 
 define.lib({
-  lib: [
-    {
-      dts: true,
-      format: 'esm',
-    },
-  ],
+  dts: true,
+  format: 'esm',
 });
 ```

--- a/website/docs/en/guide/configuration.mdx
+++ b/website/docs/en/guide/configuration.mdx
@@ -103,12 +103,8 @@ Defines the [Rslib configuration](https://rslib.rs/config/) for a library. It ac
 import { define } from 'rstack';
 
 define.lib({
-  lib: [
-    {
-      dts: true,
-      format: 'esm',
-    },
-  ],
+  dts: true,
+  format: 'esm',
 });
 ```
 

--- a/website/docs/en/guide/monorepo.mdx
+++ b/website/docs/en/guide/monorepo.mdx
@@ -146,12 +146,8 @@ A library can define its build, test, and documentation configuration in one fil
 import { define } from 'rstack';
 
 define.lib({
-  lib: [
-    {
-      format: 'esm',
-      dts: true,
-    },
-  ],
+  dts: true,
+  format: 'esm',
 });
 
 define.test({

--- a/website/docs/zh/guide/cli/lib.mdx
+++ b/website/docs/zh/guide/cli/lib.mdx
@@ -58,11 +58,7 @@ rs lib mf-dev
 import { define } from 'rstack';
 
 define.lib({
-  lib: [
-    {
-      dts: true,
-      format: 'esm',
-    },
-  ],
+  dts: true,
+  format: 'esm',
 });
 ```

--- a/website/docs/zh/guide/configuration.mdx
+++ b/website/docs/zh/guide/configuration.mdx
@@ -103,12 +103,8 @@ define.app({
 import { define } from 'rstack';
 
 define.lib({
-  lib: [
-    {
-      dts: true,
-      format: 'esm',
-    },
-  ],
+  dts: true,
+  format: 'esm',
 });
 ```
 

--- a/website/docs/zh/guide/monorepo.mdx
+++ b/website/docs/zh/guide/monorepo.mdx
@@ -146,12 +146,8 @@ define.test({
 import { define } from 'rstack';
 
 define.lib({
-  lib: [
-    {
-      format: 'esm',
-      dts: true,
-    },
-  ],
+  dts: true,
+  format: 'esm',
 });
 
 define.test({


### PR DESCRIPTION
## Summary

This PR upgrades Rslib to v1.0.0-beta.2 and adopts its shared top-level library configuration fields across package configs, examples, tests, docs, and migration guidance. It also preserves the formatter worker's runtime URL and `@rstest/adapter-rslib`'s runtime `createRequire` behavior under the new parser defaults.

## Related Links

- https://github.com/web-infra-dev/rslib/releases/tag/v1.0.0-beta.2