### PR TITLE
fix(fmt): avoid reading unsupported cache misses

### DIFF
--- a/packages/rstack/src/fmt/worker.ts
+++ b/packages/rstack/src/fmt/worker.ts
@@ -25,20 +25,28 @@ const formatFile = async ({
 }: FormatFileTask): Promise<FmtWorkerResult> => {
   let source: string | undefined;
   let contentHash: string | undefined;
+  const fileCache = shouldWrite ? undefined : cache;
 
-  if (cache && !shouldWrite) {
+  const readSource = (): string => {
+    if (!fileCache) {
+      return readFileSync(file.path, 'utf8');
+    }
+
     const content = readFileSync(file.path);
     contentHash = hashContent(content);
-    source = content.toString('utf8');
+    return content.toString('utf8');
+  };
 
-    const { entry, optionsHash } = cache;
-    if (entry?.[0] === contentHash && entry[1] === optionsHash) {
+  if (fileCache?.entry && fileCache.entry[1] === fileCache.optionsHash) {
+    source = readSource();
+    const { entry } = fileCache;
+    if (entry[0] === contentHash) {
       return { status: entry[2] === 'clean' ? 'unchanged' : 'changed' };
     }
   }
 
   const { formatFmtSource } = await import('./format.ts');
-  const result = await formatFmtSource(file, () => (source ??= readFileSync(file.path, 'utf8')));
+  const result = await formatFmtSource(file, () => (source ??= readSource()));
   if (result.status === 'unsupported') {
     return { status: 'unsupported' };
   }
@@ -50,11 +58,15 @@ const formatFile = async ({
   }
 
   const status = unchanged ? 'unchanged' : 'changed';
-  if (!cache || contentHash === undefined) {
+  if (!fileCache || contentHash === undefined) {
     return { status };
   }
 
-  const cacheEntry: FmtCacheEntry = [contentHash, cache.optionsHash, unchanged ? 'clean' : 'dirty'];
+  const cacheEntry: FmtCacheEntry = [
+    contentHash,
+    fileCache.optionsHash,
+    unchanged ? 'clean' : 'dirty',
+  ];
   return { status, cacheEntry };
 };
 

--- a/packages/rstack/tests/fmt/worker.test.ts
+++ b/packages/rstack/tests/fmt/worker.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { readFileSync } from 'node:fs';
 import { expect, test } from 'rstack/test';
 import { sha256 } from '../../src/fmt/cacheIdentity.ts';
@@ -70,5 +71,23 @@ test('returns cached states before resolving the parser', async () => {
         }),
       ).resolves.toEqual({ status });
     }
+  });
+});
+
+test('resolves parser support before reading on a cache miss', async () => {
+  await withTempProject(async (rootPath) => {
+    await expect(
+      formatFile({
+        file: {
+          path: path.join(rootPath, 'missing.unknown'),
+          options: {},
+        },
+        shouldWrite: false,
+        cache: {
+          entry: undefined,
+          optionsHash: 'options',
+        },
+      }),
+    ).resolves.toEqual({ status: 'unsupported' });
   });
 });


### PR DESCRIPTION
This PR prevents cache misses for unsupported files from reading their contents before parser support is known, preserving the previous behavior for unreadable unknown paths. Cache lookups still pre-read only when an existing entry and matching options can produce a hit; supported misses read and hash once after parser resolution, so the hot cache path remains unchanged.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/225