### PR TITLE
feat(fmt): use dedicated cache directory

### DIFF
--- a/packages/rstack/src/fmt/cacheStore.ts
+++ b/packages/rstack/src/fmt/cacheStore.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-const fmtCacheFileName = 'fmt-v1.json';
+const fmtCacheFileName = 'v1.json';
 const fmtCacheVersion = 1;
 
 type FmtCacheState = 'clean' | 'dirty';

--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -301,7 +301,7 @@ const runFmtCLI = async (args: string[]): Promise<void> => {
       const cacheDir = await ensureProjectCacheDir(config.rootPath);
       if (cacheDir.status === 'available') {
         cacheContext = {
-          filePath: path.join(cacheDir.path, fmtCacheFileName),
+          filePath: path.join(cacheDir.path, 'fmt', fmtCacheFileName),
           rootPath: config.rootPath,
         };
       }

--- a/packages/rstack/tests/cli/fmt/index.test.ts
+++ b/packages/rstack/tests/cli/fmt/index.test.ts
@@ -170,17 +170,19 @@ test.each([
   ['list-different', ['--list-different']],
 ] as const)('uses the default cache in %s mode', (_, args) => {
   writeProjectFile('index.ts', 'const value = 1;\n');
+  writeProjectFile('.rstack/cache/fmt-v1.json', 'legacy');
 
   const result = runFmt([...args, 'index.ts']);
 
   expect(result.status).toBe(0);
   expect(readProjectFile('.rstack/cache/.gitignore')).toBe('*\n');
-  expect(JSON.parse(readProjectFile('.rstack/cache/fmt-v1.json'))).toMatchObject({
+  expect(JSON.parse(readProjectFile('.rstack/cache/fmt/v1.json'))).toMatchObject({
     version: 1,
     files: {
       'index.ts': [expect.any(String), expect.any(String), 'clean'],
     },
   });
+  expect(readProjectFile('.rstack/cache/fmt-v1.json')).toBe('legacy');
 });
 
 test('--no-cache bypasses cache reads and writes', () => {
@@ -209,9 +211,9 @@ test('uses an explicit config root cache from a subdirectory', () => {
 
   expect(result.status).toBe(0);
   expect(readProjectFile('packages/app/index.ts')).toBe('const value = 1;\n');
-  expect(existsSync(path.join(projectPath, '.rstack/cache/fmt-v1.json'))).toBe(true);
+  expect(existsSync(path.join(projectPath, '.rstack/cache/fmt/v1.json'))).toBe(true);
   expect(existsSync(path.join(appPath, '.rstack'))).toBe(false);
-  expect(JSON.parse(readProjectFile('.rstack/cache/fmt-v1.json'))).toMatchObject({
+  expect(JSON.parse(readProjectFile('.rstack/cache/fmt/v1.json'))).toMatchObject({
     files: {
       'packages/app/index.ts': [expect.any(String), expect.any(String), 'clean'],
     },
@@ -221,14 +223,14 @@ test('uses an explicit config root cache from a subdirectory', () => {
 test('recovers from a corrupted cache', () => {
   writeProjectFile('index.ts', 'const value = 1;\n');
   const first = runFmt(['--check', 'index.ts']);
-  writeProjectFile('.rstack/cache/fmt-v1.json', '{');
+  writeProjectFile('.rstack/cache/fmt/v1.json', '{');
 
   const second = runFmt(['--check', 'index.ts']);
 
   expect(second.status).toBe(0);
   expect(normalizeDuration(second.stdout)).toBe(normalizeDuration(first.stdout));
   expect(second.stderr).toBe(first.stderr);
-  expect(JSON.parse(readProjectFile('.rstack/cache/fmt-v1.json'))).toMatchObject({ version: 1 });
+  expect(JSON.parse(readProjectFile('.rstack/cache/fmt/v1.json'))).toMatchObject({ version: 1 });
 });
 
 test('formats without a writable cache directory', () => {

--- a/website/docs/en/guide/cli/fmt.mdx
+++ b/website/docs/en/guide/cli/fmt.mdx
@@ -129,7 +129,7 @@ Disable the persistent formatting cache for the current invocation:
 rs fmt --no-cache
 ```
 
-Without this option, `rs fmt` stores cache data in `.rstack/cache` under the Rstack configuration root. `--no-cache` prevents the command from reading, creating, or updating that cache. Stdin formatting never uses the persistent cache.
+Without this option, `rs fmt` stores cache data in `.rstack/cache/fmt` under the Rstack configuration root. `--no-cache` prevents the command from reading, creating, or updating that cache. Stdin formatting never uses the persistent cache.
 
 See [Cache](../formatting#cache) for cache behavior and cleanup guidance.
 

--- a/website/docs/en/guide/formatting.mdx
+++ b/website/docs/en/guide/formatting.mdx
@@ -178,7 +178,7 @@ define.fmt({
 
 `rs fmt` uses a persistent cache by default for file-based `--write`, `--check`, and `--list-different` runs. Cache entries use file content and final formatting options, so changing either causes the file to be formatted again. Files that use custom Prettier plugins currently bypass the cache.
 
-The default cache file is `.rstack/cache/fmt-v1.json` under the Rstack configuration root. When a command runs from a subdirectory, it continues to use the cache next to the resolved `rstack.config.*` file. Stdin formatting does not use this cache.
+The default cache directory is `.rstack/cache/fmt` under the Rstack configuration root. When a command runs from a subdirectory, it continues to use the cache next to the resolved `rstack.config.*` file. Stdin formatting does not use this cache.
 
 Use [`--no-cache`](./cli/fmt#--no-cache) to run without reading, creating, or updating the cache:
 

--- a/website/docs/zh/guide/cli/fmt.mdx
+++ b/website/docs/zh/guide/cli/fmt.mdx
@@ -129,7 +129,7 @@ rs fmt -l
 rs fmt --no-cache
 ```
 
-默认情况下，`rs fmt` 会将缓存数据保存在 Rstack 配置根目录下的 `.rstack/cache` 中。`--no-cache` 会阻止命令读取、创建或更新该缓存。stdin 格式化始终不会使用持久化缓存。
+默认情况下，`rs fmt` 会将缓存数据保存在 Rstack 配置根目录下的 `.rstack/cache/fmt` 中。`--no-cache` 会阻止命令读取、创建或更新该缓存。stdin 格式化始终不会使用持久化缓存。
 
 缓存行为和清理方式请参考[缓存](../formatting#cache)。
 

--- a/website/docs/zh/guide/formatting.mdx
+++ b/website/docs/zh/guide/formatting.mdx
@@ -178,7 +178,7 @@ define.fmt({
 
 `rs fmt` 默认会在基于文件的 `--write`、`--check` 和 `--list-different` 调用中使用持久化缓存。缓存条目基于文件内容和最终格式化选项；任意一项发生变化时，文件都会重新格式化。使用自定义 Prettier 插件的文件目前会绕过缓存。
 
-默认缓存文件位于 Rstack 配置根目录下的 `.rstack/cache/fmt-v1.json`。从子目录运行命令时，仍会使用解析到的 `rstack.config.*` 文件旁的缓存。stdin 格式化不会使用该缓存。
+默认缓存目录位于 Rstack 配置根目录下的 `.rstack/cache/fmt`。从子目录运行命令时，仍会使用解析到的 `rstack.config.*` 文件旁的缓存。stdin 格式化不会使用该缓存。
 
 使用 [`--no-cache`](./cli/fmt#--no-cache) 可以在运行时跳过缓存读取、创建和更新：
 


### PR DESCRIPTION
This PR moves the default formatting cache from `.rstack/cache/fmt-v1.json` to `.rstack/cache/fmt/v1.json`, reserving a dedicated directory for future formatter cache files.

The legacy cache file is intentionally not migrated; the next formatting run creates a fresh cache at the new location.