### PR TITLE
fix(create-rstack): disable built-in tools

### DIFF
--- a/packages/create-rstack/src/index.ts
+++ b/packages/create-rstack/src/index.ts
@@ -37,6 +37,7 @@ await create({
   root: path.join(import.meta.dirname, '..'),
   name: 'rstack',
   templates: ['app-js', 'app-ts'],
+  builtinTools: [],
   getTemplateName,
   mapESLintTemplate,
   mapRslintTemplate,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ catalogs:
       specifier: 1.14.7
       version: 1.14.7
     '@rstackjs/create-toolkit':
-      specifier: 2.1.4
-      version: 2.1.4
+      specifier: 2.1.5
+      version: 2.1.5
     '@rstackjs/load-config':
       specifier: ^0.1.2
       version: 0.1.2
@@ -332,7 +332,7 @@ importers:
     dependencies:
       '@rstackjs/create-toolkit':
         specifier: 'catalog:'
-        version: 2.1.4
+        version: 2.1.5
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -871,8 +871,8 @@ packages:
       '@rspress/core':
         optional: true
 
-  '@rstackjs/create-toolkit@2.1.4':
-    resolution: {integrity: sha512-kwPhfMdgWN7z/Op5UKMszhmZy7+hzqXeiQPli4uycYYTLxCVUGLlEW3etoGoZlrM2t5zLqXZQAgL60PTUR/ocw==}
+  '@rstackjs/create-toolkit@2.1.5':
+    resolution: {integrity: sha512-55hmJqJJbyvdz9ET2NLXpQ+AF1+keb75duvLXMEU423sEPM1e8GdIE7aS3ODsXYKJ7CoYphDjVkcaDeB0TS5uw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@rstackjs/load-config@0.1.2':
@@ -2723,7 +2723,7 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.19(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
-  '@rstackjs/create-toolkit@2.1.4': {}
+  '@rstackjs/create-toolkit@2.1.5': {}
 
   '@rstackjs/load-config@0.1.2': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   '@rspress/plugin-client-redirects': '^2.0.19'
   '@rspress/plugin-sitemap': '^2.0.19'
   '@rstack-dev/doc-ui': '1.14.7'
-  '@rstackjs/create-toolkit': '2.1.4'
+  '@rstackjs/create-toolkit': '2.1.5'
   '@rstackjs/load-config': ^0.1.2
   '@rstackjs/test-utils': ^0.2.0
   '@rstest/adapter-rsbuild': '~0.11.5'


### PR DESCRIPTION
This PR disables create-toolkit's built-in tool selection for create-rstack, keeping generated projects focused on the Rstack defaults. It upgrades `@rstackjs/create-toolkit` to v2.1.5 and passes `builtinTools: []`.

## Related Links

- https://github.com/rstackjs/create-toolkit/releases/tag/v2.1.5