### PR TITLE
perf(fmt): avoid redundant discovery ignore checks

### DIFF
--- a/packages/rstack/src/fmt/discoverPaths.ts
+++ b/packages/rstack/src/fmt/discoverPaths.ts
@@ -26,7 +26,7 @@ interface DiscoverFmtPathsOptions {
   patterns?: string[];
   /** Whether files inside node_modules may be discovered. */
   withNodeModules?: boolean;
-  /** Returns whether a scanned path can be excluded during traversal. */
+  /** Returns whether a candidate path should be excluded. */
   isIgnored?: (filePath: string, isDirectory: boolean) => boolean;
 }
 
@@ -384,7 +384,9 @@ const discoverFmtPaths = async ({
   } = await classifyPatterns(cwd, patterns, ignoredDirNames);
   const directoryRoots = getOutermostPaths(directories);
   const globMatchers = globs.map((pattern) => micromatch.matcher(pattern, { dot: true }));
-  const candidates = new Set(explicitFiles);
+  const candidates = new Set(
+    isIgnored ? explicitFiles.filter((filePath) => !isIgnored(filePath, false)) : explicitFiles,
+  );
   const traversalRoots = getTraversalRoots(cwd, directoryRoots, globs);
 
   if (traversalRoots.length) {

--- a/packages/rstack/src/fmt/discovery.ts
+++ b/packages/rstack/src/fmt/discovery.ts
@@ -32,17 +32,16 @@ const discoverFmtFiles = async ({
     ? (filePath: string, isDirectory = false) =>
         isExcluded(filePath) || isIgnored(filePath, isDirectory)
     : isIgnored;
-  const candidates = await discoverFmtPaths({
+  const filePaths = await discoverFmtPaths({
     cwd,
     patterns,
     withNodeModules,
     isIgnored: shouldIgnore,
   });
-  if (candidates.length === 0) {
+  if (filePaths.length === 0) {
     return [];
   }
 
-  const filePaths = candidates.filter((filePath) => !shouldIgnore(filePath));
   const resolveOptions = createFmtOptionsResolver(config);
   const files = filePaths.map((filePath) => createFileRequest(filePath, resolveOptions));
   if (!files.some((file) => file.options.plugins?.length)) {

--- a/packages/rstack/tests/fmt/discoverPaths.test.ts
+++ b/packages/rstack/tests/fmt/discoverPaths.test.ts
@@ -139,7 +139,7 @@ test('lets explicit files bypass gitignore', async () => {
   });
 });
 
-test('applies an external ignore matcher during traversal', async () => {
+test('applies an external ignore matcher to traversed and explicit paths', async () => {
   await withTempProject(async (rootPath) => {
     writeProjectFile(rootPath, 'generated/nested/output.ts');
     const ignoredFilePath = writeProjectFile(rootPath, 'src/ignored.ts');
@@ -160,9 +160,15 @@ test('applies an external ignore matcher during traversal', async () => {
       patterns: ['generated'],
       isIgnored,
     });
+    const explicitIgnoredFile = await discoverFmtPaths({
+      cwd: rootPath,
+      patterns: [ignoredFilePath],
+      isIgnored,
+    });
 
     expect(relativePaths(rootPath, files)).toEqual([path.join('src', 'index.ts')]);
     expect(ignoredRoot).toEqual([]);
+    expect(explicitIgnoredFile).toEqual([]);
     expect(checkedPaths).toContainEqual({ path: 'generated', isDirectory: true });
     expect(checkedPaths).toContainEqual({
       path: path.join('src', 'ignored.ts'),


### PR DESCRIPTION
## Summary

This PR removes the redundant ignore pass after formatter discovery, since directory and glob candidates are already filtered during traversal. Explicit files are now filtered when they enter the candidate set, preserving `ignorePatterns`, `--ignore-path`, and cache-directory exclusions while keeping `.gitignore` traversal-only. On Rspack's 4,569 discovery candidates, the removed pass took about 1.0 ms at the median.