### PR TITLE
feat(create-rstack): add default template tooling

### DIFF
--- a/packages/create-rstack/template-app-react-js/package.json
+++ b/packages/create-rstack/template-app-react-js/package.json
@@ -5,8 +5,11 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "dev": "rs dev --open",
-    "preview": "rs preview"
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test"
   },
   "dependencies": {
     "react": "^19.2.8",

--- a/packages/create-rstack/template-app-react-js/rstack.config.js
+++ b/packages/create-rstack/template-app-react-js/rstack.config.js
@@ -9,3 +9,17 @@ define.app(async () => {
     plugins: [pluginReact()],
   };
 });
+
+define.test({
+  // Configure Rstest
+});
+
+define.lint(async () => {
+  const { js, reactHooksPlugin, reactPlugin } = await import('rstack/lint');
+
+  return [
+    js.configs.recommended,
+    reactPlugin.configs.recommended,
+    reactHooksPlugin.configs.recommended,
+  ];
+});

--- a/packages/create-rstack/template-app-react-ts/package.json
+++ b/packages/create-rstack/template-app-react-ts/package.json
@@ -5,8 +5,11 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "dev": "rs dev --open",
-    "preview": "rs preview"
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test"
   },
   "dependencies": {
     "react": "^19.2.8",

--- a/packages/create-rstack/template-app-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-react-ts/rstack.config.ts
@@ -8,3 +8,18 @@ define.app(async () => {
     plugins: [pluginReact()],
   };
 });
+
+define.test({
+  // Configure Rstest
+});
+
+define.lint(async () => {
+  const { js, ts, reactPlugin, reactHooksPlugin } = await import('rstack/lint');
+
+  return [
+    js.configs.recommended,
+    ts.configs.recommended,
+    reactPlugin.configs.recommended,
+    reactHooksPlugin.configs.recommended,
+  ];
+});

--- a/packages/create-rstack/template-app-vanilla-js/package.json
+++ b/packages/create-rstack/template-app-vanilla-js/package.json
@@ -5,8 +5,11 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "dev": "rs dev --open",
-    "preview": "rs preview"
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test"
   },
   "devDependencies": {
     "rstack": "^0.3.5"

--- a/packages/create-rstack/template-app-vanilla-js/rstack.config.js
+++ b/packages/create-rstack/template-app-vanilla-js/rstack.config.js
@@ -2,4 +2,16 @@
 // Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
-define.app({});
+define.app({
+  // Configure Rsbuild
+});
+
+define.test({
+  // Configure Rstest
+});
+
+define.lint(async () => {
+  const { js } = await import('rstack/lint');
+
+  return [js.configs.recommended];
+});

--- a/packages/create-rstack/template-app-vanilla-ts/package.json
+++ b/packages/create-rstack/template-app-vanilla-ts/package.json
@@ -5,8 +5,11 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "dev": "rs dev --open",
-    "preview": "rs preview"
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",

--- a/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
@@ -1,4 +1,16 @@
 // Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
-define.app({});
+define.app({
+  // Configure Rsbuild
+});
+
+define.test({
+  // Configure Rstest
+});
+
+define.lint(async () => {
+  const { js, ts } = await import('rstack/lint');
+
+  return [js.configs.recommended, ts.configs.recommended];
+});

--- a/packages/create-rstack/template-lib-js/package.json
+++ b/packages/create-rstack/template-lib-js/package.json
@@ -15,6 +15,8 @@
   "scripts": {
     "build": "rs lib",
     "dev": "rs lib --watch",
+    "format": "rs fmt",
+    "lint": "rs lint",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-js/rstack.config.js
@@ -5,3 +5,13 @@ import { define } from 'rstack';
 define.lib({
   syntax: ['node 22'],
 });
+
+define.test({
+  // Configure Rstest
+});
+
+define.lint(async () => {
+  const { js } = await import('rstack/lint');
+
+  return [js.configs.recommended];
+});

--- a/packages/create-rstack/template-lib-ts/package.json
+++ b/packages/create-rstack/template-lib-ts/package.json
@@ -17,6 +17,8 @@
   "scripts": {
     "build": "rs lib",
     "dev": "rs lib --watch",
+    "format": "rs fmt",
+    "lint": "rs lint",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-ts/rstack.config.ts
@@ -5,3 +5,13 @@ define.lib({
   syntax: ['node 22'],
   dts: true,
 });
+
+define.test({
+  // Configure Rstest
+});
+
+define.lint(async () => {
+  const { js, ts } = await import('rstack/lint');
+
+  return [js.configs.recommended, ts.configs.recommended];
+});

--- a/packages/create-rstack/template-lib-ts/tsconfig.json
+++ b/packages/create-rstack/template-lib-ts/tsconfig.json
@@ -6,6 +6,7 @@
     "skipLibCheck": true,
     "types": ["rstack/types", "node"],
     "useDefineForClassFields": true,
+    "rootDir": "src",
 
     /* modules */
     "moduleDetection": "force",


### PR DESCRIPTION
Generated create-rstack projects currently omit the standard test, lint, and format workflow.

This adds the corresponding scripts and Rstack configuration to every app and library template, selects the appropriate default Rslint presets for each framework and language variant, and fixes the TypeScript library template's source root.