### PR TITLE
perf(fmt): use one-shot crypto hash

### DIFF
--- a/packages/rstack/src/fmt/cacheIdentity.ts
+++ b/packages/rstack/src/fmt/cacheIdentity.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { hash } from 'node:crypto';
 import { isAbsolute } from 'node:path';
 import stableStringify from 'fast-json-stable-stringify';
 import { fmtCacheVersion } from './cacheStore.ts';
@@ -12,8 +12,7 @@ type CacheKeyResolver = (filePath: string) => string | undefined;
 type OptionsHasher = (options: ResolvedFmtOptions) => string | undefined;
 type PluginFingerprints = ReadonlyMap<string, string>;
 
-const sha256 = (content: string | Uint8Array): string =>
-  createHash('sha256').update(content).digest('hex');
+const sha256 = (content: string | Uint8Array): string => hash('sha256', content, 'hex');
 
 /** Identifies formatter behavior shared by all cache entries in this process. */
 const cacheNamespace: string = JSON.stringify([fmtCacheVersion, RSTACK_VERSION, PRETTIER_VERSION]);

--- a/packages/rstack/src/fmt/worker.ts
+++ b/packages/rstack/src/fmt/worker.ts
@@ -1,6 +1,6 @@
 // Derived from @prettier/cli, see THIRD_PARTY_NOTICES.md
 
-import { createHash } from 'node:crypto';
+import { hash } from 'node:crypto';
 import { readFileSync, writeFileSync } from 'node:fs';
 import type { FmtCacheEntry } from './cacheStore.ts';
 import type { FmtFileCache, FmtFileRequest, FmtWorkerResult } from './types.ts';
@@ -11,8 +11,7 @@ interface FormatFileTask {
   cache?: FmtFileCache;
 }
 
-const hashContent = (content: string | Uint8Array): string =>
-  createHash('sha256').update(content).digest('hex');
+const hashContent = (content: string | Uint8Array): string => hash('sha256', content, 'hex');
 
 /**
  * Use synchronous direct I/O inside the dedicated worker to avoid libuv


### PR DESCRIPTION
Repeated content hashing on formatter cache paths currently creates a `Hash` object for every digest. This switches the formatter worker and cache identity helper to Node.js's one-shot `crypto.hash()` API, reducing per-call setup overhead while preserving the existing SHA-256 hex digests and cache compatibility.