### PR TITLE
feat(create-rstack): add Vue app templates

### DIFF
--- a/packages/create-rstack/README.md
+++ b/packages/create-rstack/README.md
@@ -25,6 +25,8 @@ npx create-rstack -d my-project -t app-vanilla-ts
 - `app-vanilla-ts` - TypeScript Vanilla application
 - `app-react-js` - JavaScript React application
 - `app-react-ts` - TypeScript React application
+- `app-vue-js` - JavaScript Vue application
+- `app-vue-ts` - TypeScript Vue application
 - `lib-node-js` - JavaScript Node.js library
 - `lib-node-ts` - TypeScript Node.js library
 - `lib-react-js` - JavaScript React library

--- a/packages/create-rstack/src/index.ts
+++ b/packages/create-rstack/src/index.ts
@@ -45,6 +45,7 @@ const getTemplateName = async ({ template }: Argv): Promise<string> => {
           ? [
               { value: 'vanilla', label: 'Vanilla' },
               { value: 'react', label: 'React' },
+              { value: 'vue', label: 'Vue' },
             ]
           : [
               { value: 'node', label: 'Node.js' },
@@ -74,6 +75,8 @@ await create({
     'app-vanilla-ts',
     'app-react-js',
     'app-react-ts',
+    'app-vue-js',
+    'app-vue-ts',
     'lib-node-js',
     'lib-node-ts',
     'lib-react-js',

--- a/packages/create-rstack/template-app-vue-js/AGENTS.md
+++ b/packages/create-rstack/template-app-vue-js/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Commands
+
+- `{{ packageManager }} run dev` - Start the development server
+- `{{ packageManager }} run build` - Build the app for production
+- `{{ packageManager }} run preview` - Preview the production build locally
+
+## Docs
+
+- Rsbuild: https://rsbuild.rs/llms.txt
+- Rspack: https://rspack.rs/llms.txt

--- a/packages/create-rstack/template-app-vue-js/package.json
+++ b/packages/create-rstack/template-app-vue-js/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "rstack-app-vue-js",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rs build",
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test"
+  },
+  "dependencies": {
+    "vue": "^3.5.40"
+  },
+  "devDependencies": {
+    "@rsbuild/plugin-vue": "^2.0.1",
+    "rstack": "^0.3.5"
+  }
+}

--- a/packages/create-rstack/template-app-vue-js/rstack.config.js
+++ b/packages/create-rstack/template-app-vue-js/rstack.config.js
@@ -1,0 +1,21 @@
+// @ts-check
+// Rstack configuration guide: https://rstack.rs/config
+import { define } from 'rstack';
+
+define.app(async () => {
+  const { pluginVue } = await import('@rsbuild/plugin-vue');
+
+  return {
+    plugins: [pluginVue()],
+  };
+});
+
+define.test({
+  // Configure Rstest
+});
+
+define.lint(async () => {
+  const { js } = await import('rstack/lint');
+
+  return [js.configs.recommended];
+});

--- a/packages/create-rstack/template-app-vue-js/src/App.vue
+++ b/packages/create-rstack/template-app-vue-js/src/App.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="content">
+    <h1>Rstack with Vue</h1>
+    <p>Start building amazing things with Rstack.</p>
+  </div>
+</template>
+
+<style scoped>
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}
+</style>

--- a/packages/create-rstack/template-app-vue-js/src/index.css
+++ b/packages/create-rstack/template-app-vue-js/src/index.css
@@ -1,0 +1,6 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}

--- a/packages/create-rstack/template-app-vue-js/src/index.js
+++ b/packages/create-rstack/template-app-vue-js/src/index.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import './index.css';
+
+createApp(App).mount('#root');

--- a/packages/create-rstack/template-app-vue-ts/AGENTS.md
+++ b/packages/create-rstack/template-app-vue-ts/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Commands
+
+- `{{ packageManager }} run dev` - Start the development server
+- `{{ packageManager }} run build` - Build the app for production
+- `{{ packageManager }} run preview` - Preview the production build locally
+
+## Docs
+
+- Rsbuild: https://rsbuild.rs/llms.txt
+- Rspack: https://rspack.rs/llms.txt

--- a/packages/create-rstack/template-app-vue-ts/package.json
+++ b/packages/create-rstack/template-app-vue-ts/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "rstack-app-vue-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vue-tsc && rs build",
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test"
+  },
+  "dependencies": {
+    "vue": "^3.5.40"
+  },
+  "devDependencies": {
+    "@rsbuild/plugin-vue": "^2.0.1",
+    "@types/node": "^24.13.3",
+    "rstack": "^0.3.5",
+    "typescript": "^6.0.3",
+    "vue-tsc": "^3.3.9"
+  }
+}

--- a/packages/create-rstack/template-app-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vue-ts/rstack.config.ts
@@ -1,0 +1,20 @@
+// Rstack configuration guide: https://rstack.rs/config
+import { define } from 'rstack';
+
+define.app(async () => {
+  const { pluginVue } = await import('@rsbuild/plugin-vue');
+
+  return {
+    plugins: [pluginVue()],
+  };
+});
+
+define.test({
+  // Configure Rstest
+});
+
+define.lint(async () => {
+  const { js, ts } = await import('rstack/lint');
+
+  return [js.configs.recommended, ts.configs.recommended];
+});

--- a/packages/create-rstack/template-app-vue-ts/src/App.vue
+++ b/packages/create-rstack/template-app-vue-ts/src/App.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="content">
+    <h1>Rstack with Vue</h1>
+    <p>Start building amazing things with Rstack.</p>
+  </div>
+</template>
+
+<style scoped>
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}
+</style>

--- a/packages/create-rstack/template-app-vue-ts/src/index.css
+++ b/packages/create-rstack/template-app-vue-ts/src/index.css
@@ -1,0 +1,6 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}

--- a/packages/create-rstack/template-app-vue-ts/src/index.ts
+++ b/packages/create-rstack/template-app-vue-ts/src/index.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import './index.css';
+
+createApp(App).mount('#root');

--- a/packages/create-rstack/template-app-vue-ts/tsconfig.json
+++ b/packages/create-rstack/template-app-vue-ts/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2020"],
+    "jsx": "preserve",
+    "target": "ES2020",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["rstack/types", "node"],
+    "jsxImportSource": "vue",
+    "useDefineForClassFields": true,
+
+    /* modules */
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+
+    /* type checking */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+}

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -57,6 +57,18 @@ test.each([
     sourceExtension: 'tsx',
     hasTypeScript: true,
   },
+  {
+    template: 'app-vue-js',
+    configExtension: 'js',
+    sourceExtension: 'js',
+    hasTypeScript: false,
+  },
+  {
+    template: 'app-vue-ts',
+    configExtension: 'ts',
+    sourceExtension: 'ts',
+    hasTypeScript: true,
+  },
 ])(
   'creates the $template template',
   async ({ template, configExtension, sourceExtension, hasTypeScript }) => {


### PR DESCRIPTION
create-rstack currently supports Vanilla and React web applications but does not provide a Vue starter.

This adds JavaScript and TypeScript Vue application templates based on create-rsbuild, including Vue plugin configuration, standard Rstack scripts, lint defaults, and Vue SFC type checking. The templates are exposed as `app-vue-js` and `app-vue-ts`.