### PR TITLE
feat(create-rstack): add Solid app templates

### DIFF
--- a/packages/create-rstack/README.md
+++ b/packages/create-rstack/README.md
@@ -27,6 +27,8 @@ npx create-rstack -d my-project -t app-vanilla-ts
 - `app-react-ts` - TypeScript React application
 - `app-vue-js` - JavaScript Vue application
 - `app-vue-ts` - TypeScript Vue application
+- `app-solid-js` - JavaScript Solid application
+- `app-solid-ts` - TypeScript Solid application
 - `lib-node-js` - JavaScript Node.js library
 - `lib-node-ts` - TypeScript Node.js library
 - `lib-react-js` - JavaScript React library

--- a/packages/create-rstack/src/index.ts
+++ b/packages/create-rstack/src/index.ts
@@ -46,6 +46,7 @@ const getTemplateName = async ({ template }: Argv): Promise<string> => {
               { value: 'vanilla', label: 'Vanilla' },
               { value: 'react', label: 'React' },
               { value: 'vue', label: 'Vue' },
+              { value: 'solid', label: 'Solid' },
             ]
           : [
               { value: 'node', label: 'Node.js' },
@@ -78,6 +79,8 @@ await create({
     'app-react-ts',
     'app-vue-js',
     'app-vue-ts',
+    'app-solid-js',
+    'app-solid-ts',
     'lib-node-js',
     'lib-node-ts',
     'lib-react-js',

--- a/packages/create-rstack/template-app-solid-js/AGENTS.md
+++ b/packages/create-rstack/template-app-solid-js/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Commands
+
+- `{{ packageManager }} run dev` - Start the development server
+- `{{ packageManager }} run build` - Build the app for production
+- `{{ packageManager }} run preview` - Preview the production build locally
+
+## Docs
+
+- Rsbuild: https://rsbuild.rs/llms.txt
+- Rspack: https://rspack.rs/llms.txt

--- a/packages/create-rstack/template-app-solid-js/package.json
+++ b/packages/create-rstack/template-app-solid-js/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "rstack-app-solid-js",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rs build",
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test"
+  },
+  "dependencies": {
+    "solid-js": "^1.9.14"
+  },
+  "devDependencies": {
+    "@rsbuild/plugin-babel": "^2.0.1",
+    "@rsbuild/plugin-solid": "^1.2.2",
+    "rstack": "^0.3.5"
+  }
+}

--- a/packages/create-rstack/template-app-solid-js/rstack.config.js
+++ b/packages/create-rstack/template-app-solid-js/rstack.config.js
@@ -1,0 +1,27 @@
+// @ts-check
+// Rstack configuration guide: https://rstack.rs/config
+import { define } from 'rstack';
+
+define.app(async () => {
+  const { pluginBabel } = await import('@rsbuild/plugin-babel');
+  const { pluginSolid } = await import('@rsbuild/plugin-solid');
+
+  return {
+    plugins: [
+      pluginBabel({
+        include: /\.(?:jsx|tsx)$/,
+      }),
+      pluginSolid(),
+    ],
+  };
+});
+
+define.test({
+  // Configure Rstest
+});
+
+define.lint(async () => {
+  const { js } = await import('rstack/lint');
+
+  return [js.configs.recommended];
+});

--- a/packages/create-rstack/template-app-solid-js/src/App.css
+++ b/packages/create-rstack/template-app-solid-js/src/App.css
@@ -1,0 +1,26 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}
+
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}

--- a/packages/create-rstack/template-app-solid-js/src/App.jsx
+++ b/packages/create-rstack/template-app-solid-js/src/App.jsx
@@ -1,0 +1,12 @@
+import './App.css';
+
+const App = () => {
+  return (
+    <div class="content">
+      <h1>Rstack with Solid</h1>
+      <p>Start building amazing things with Rstack.</p>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/create-rstack/template-app-solid-js/src/index.jsx
+++ b/packages/create-rstack/template-app-solid-js/src/index.jsx
@@ -1,0 +1,4 @@
+import { render } from 'solid-js/web';
+import App from './App';
+
+render(() => <App />, document.getElementById('root'));

--- a/packages/create-rstack/template-app-solid-ts/AGENTS.md
+++ b/packages/create-rstack/template-app-solid-ts/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Commands
+
+- `{{ packageManager }} run dev` - Start the development server
+- `{{ packageManager }} run build` - Build the app for production
+- `{{ packageManager }} run preview` - Preview the production build locally
+
+## Docs
+
+- Rsbuild: https://rsbuild.rs/llms.txt
+- Rspack: https://rspack.rs/llms.txt

--- a/packages/create-rstack/template-app-solid-ts/package.json
+++ b/packages/create-rstack/template-app-solid-ts/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "rstack-app-solid-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rs build",
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test"
+  },
+  "dependencies": {
+    "solid-js": "^1.9.14"
+  },
+  "devDependencies": {
+    "@rsbuild/plugin-babel": "^2.0.1",
+    "@rsbuild/plugin-solid": "^1.2.2",
+    "@types/node": "^24.13.3",
+    "rstack": "^0.3.5",
+    "typescript": "^7.0.2"
+  }
+}

--- a/packages/create-rstack/template-app-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-solid-ts/rstack.config.ts
@@ -1,0 +1,26 @@
+// Rstack configuration guide: https://rstack.rs/config
+import { define } from 'rstack';
+
+define.app(async () => {
+  const { pluginBabel } = await import('@rsbuild/plugin-babel');
+  const { pluginSolid } = await import('@rsbuild/plugin-solid');
+
+  return {
+    plugins: [
+      pluginBabel({
+        include: /\.(?:jsx|tsx)$/,
+      }),
+      pluginSolid(),
+    ],
+  };
+});
+
+define.test({
+  // Configure Rstest
+});
+
+define.lint(async () => {
+  const { js, ts } = await import('rstack/lint');
+
+  return [js.configs.recommended, ts.configs.recommended];
+});

--- a/packages/create-rstack/template-app-solid-ts/src/App.css
+++ b/packages/create-rstack/template-app-solid-ts/src/App.css
@@ -1,0 +1,26 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}
+
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}

--- a/packages/create-rstack/template-app-solid-ts/src/App.tsx
+++ b/packages/create-rstack/template-app-solid-ts/src/App.tsx
@@ -1,0 +1,12 @@
+import './App.css';
+
+const App = () => {
+  return (
+    <div class="content">
+      <h1>Rstack with Solid</h1>
+      <p>Start building amazing things with Rstack.</p>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/create-rstack/template-app-solid-ts/src/index.tsx
+++ b/packages/create-rstack/template-app-solid-ts/src/index.tsx
@@ -1,0 +1,7 @@
+import { render } from 'solid-js/web';
+import App from './App';
+
+const root = document.getElementById('root');
+if (root) {
+  render(() => <App />, root);
+}

--- a/packages/create-rstack/template-app-solid-ts/tsconfig.json
+++ b/packages/create-rstack/template-app-solid-ts/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2020"],
+    "jsx": "preserve",
+    "target": "ES2020",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["rstack/types", "node"],
+    "jsxImportSource": "solid-js",
+    "useDefineForClassFields": true,
+
+    /* modules */
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+
+    /* type checking */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src"]
+}

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -69,6 +69,18 @@ test.each([
     sourceExtension: 'ts',
     hasTypeScript: true,
   },
+  {
+    template: 'app-solid-js',
+    configExtension: 'js',
+    sourceExtension: 'jsx',
+    hasTypeScript: false,
+  },
+  {
+    template: 'app-solid-ts',
+    configExtension: 'ts',
+    sourceExtension: 'tsx',
+    hasTypeScript: true,
+  },
 ])(
   'creates the $template template',
   async ({ template, configExtension, sourceExtension, hasTypeScript }) => {


### PR DESCRIPTION
`create-rstack` does not currently provide a Solid application starter.

This adds JavaScript and TypeScript Solid templates with the required Babel and Solid plugins, standard Rstack scripts and lint defaults, and generator coverage.