### PR TITLE
feat(create-rstack): add app template tests

### DIFF
--- a/packages/create-rstack/template-app-react-js/AGENTS.md
+++ b/packages/create-rstack/template-app-react-js/AGENTS.md
@@ -5,8 +5,11 @@
 - `{{ packageManager }} run dev` - Start the development server
 - `{{ packageManager }} run build` - Build the app for production
 - `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
 
 ## Docs
 
 - Rsbuild: https://rsbuild.rs/llms.txt
 - Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-react-js/package.json
+++ b/packages/create-rstack/template-app-react-js/package.json
@@ -9,7 +9,8 @@
     "format": "rs fmt",
     "lint": "rs lint",
     "preview": "rs preview",
-    "test": "rs test"
+    "test": "rs test",
+    "test:watch": "rs test --watch"
   },
   "dependencies": {
     "react": "^19.2.8",
@@ -17,6 +18,10 @@
   },
   "devDependencies": {
     "@rsbuild/plugin-react": "^2.1.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
+    "happy-dom": "^20.11.1",
     "rstack": "^0.3.5"
   }
 }

--- a/packages/create-rstack/template-app-react-js/rstack.config.js
+++ b/packages/create-rstack/template-app-react-js/rstack.config.js
@@ -11,7 +11,7 @@ define.app(async () => {
 });
 
 define.test({
-  // Configure Rstest
+  setupFiles: ['./tests/rstest.setup.js'],
 });
 
 define.lint(async () => {

--- a/packages/create-rstack/template-app-react-js/tests/index.test.jsx
+++ b/packages/create-rstack/template-app-react-js/tests/index.test.jsx
@@ -1,0 +1,8 @@
+import { expect, test } from 'rstack/test';
+import { render, screen } from '@testing-library/react';
+import App from '../src/App';
+
+test('renders the main page', () => {
+  render(<App />);
+  expect(screen.getByText('Rstack with React')).toBeInTheDocument();
+});

--- a/packages/create-rstack/template-app-react-js/tests/rstest.setup.js
+++ b/packages/create-rstack/template-app-react-js/tests/rstest.setup.js
@@ -1,0 +1,4 @@
+import { expect } from 'rstack/test';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);

--- a/packages/create-rstack/template-app-react-ts/AGENTS.md
+++ b/packages/create-rstack/template-app-react-ts/AGENTS.md
@@ -5,8 +5,11 @@
 - `{{ packageManager }} run dev` - Start the development server
 - `{{ packageManager }} run build` - Build the app for production
 - `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
 
 ## Docs
 
 - Rsbuild: https://rsbuild.rs/llms.txt
 - Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-react-ts/package.json
+++ b/packages/create-rstack/template-app-react-ts/package.json
@@ -9,7 +9,8 @@
     "format": "rs fmt",
     "lint": "rs lint",
     "preview": "rs preview",
-    "test": "rs test"
+    "test": "rs test",
+    "test:watch": "rs test --watch"
   },
   "dependencies": {
     "react": "^19.2.8",
@@ -17,9 +18,13 @@
   },
   "devDependencies": {
     "@rsbuild/plugin-react": "^2.1.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
+    "happy-dom": "^20.11.1",
     "rstack": "^0.3.5",
     "typescript": "^7.0.2"
   }

--- a/packages/create-rstack/template-app-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-react-ts/rstack.config.ts
@@ -10,7 +10,7 @@ define.app(async () => {
 });
 
 define.test({
-  // Configure Rstest
+  setupFiles: ['./tests/rstest.setup.ts'],
 });
 
 define.lint(async () => {

--- a/packages/create-rstack/template-app-react-ts/tests/index.test.tsx
+++ b/packages/create-rstack/template-app-react-ts/tests/index.test.tsx
@@ -1,0 +1,8 @@
+import { expect, test } from 'rstack/test';
+import { render, screen } from '@testing-library/react';
+import App from '../src/App';
+
+test('renders the main page', () => {
+  render(<App />);
+  expect(screen.getByText('Rstack with React')).toBeInTheDocument();
+});

--- a/packages/create-rstack/template-app-react-ts/tests/rstest.setup.ts
+++ b/packages/create-rstack/template-app-react-ts/tests/rstest.setup.ts
@@ -1,0 +1,4 @@
+import { expect } from 'rstack/test';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);

--- a/packages/create-rstack/template-app-react-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-app-react-ts/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["rstack/types", "node", "@testing-library/jest-dom"]
+  },
+  "include": ["./"]
+}

--- a/packages/create-rstack/template-app-solid-js/AGENTS.md
+++ b/packages/create-rstack/template-app-solid-js/AGENTS.md
@@ -5,8 +5,11 @@
 - `{{ packageManager }} run dev` - Start the development server
 - `{{ packageManager }} run build` - Build the app for production
 - `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
 
 ## Docs
 
 - Rsbuild: https://rsbuild.rs/llms.txt
 - Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-solid-js/package.json
+++ b/packages/create-rstack/template-app-solid-js/package.json
@@ -9,7 +9,8 @@
     "format": "rs fmt",
     "lint": "rs lint",
     "preview": "rs preview",
-    "test": "rs test"
+    "test": "rs test",
+    "test:watch": "rs test --watch"
   },
   "dependencies": {
     "solid-js": "^1.9.14"
@@ -17,6 +18,9 @@
   "devDependencies": {
     "@rsbuild/plugin-babel": "^2.0.1",
     "@rsbuild/plugin-solid": "^1.2.2",
+    "@solidjs/testing-library": "^0.8.10",
+    "@testing-library/jest-dom": "^7.0.0",
+    "happy-dom": "^20.11.1",
     "rstack": "^0.3.5"
   }
 }

--- a/packages/create-rstack/template-app-solid-js/rstack.config.js
+++ b/packages/create-rstack/template-app-solid-js/rstack.config.js
@@ -17,7 +17,7 @@ define.app(async () => {
 });
 
 define.test({
-  // Configure Rstest
+  setupFiles: ['./tests/rstest.setup.js'],
 });
 
 define.lint(async () => {

--- a/packages/create-rstack/template-app-solid-js/tests/index.test.jsx
+++ b/packages/create-rstack/template-app-solid-js/tests/index.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@solidjs/testing-library';
+import { expect, test } from 'rstack/test';
+import App from '../src/App';
+
+test('renders the main page', () => {
+  render(() => <App />);
+  expect(screen.getByText('Rstack with Solid')).toBeInTheDocument();
+});

--- a/packages/create-rstack/template-app-solid-js/tests/rstest.setup.js
+++ b/packages/create-rstack/template-app-solid-js/tests/rstest.setup.js
@@ -1,0 +1,4 @@
+import { expect } from 'rstack/test';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);

--- a/packages/create-rstack/template-app-solid-ts/AGENTS.md
+++ b/packages/create-rstack/template-app-solid-ts/AGENTS.md
@@ -5,8 +5,11 @@
 - `{{ packageManager }} run dev` - Start the development server
 - `{{ packageManager }} run build` - Build the app for production
 - `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
 
 ## Docs
 
 - Rsbuild: https://rsbuild.rs/llms.txt
 - Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-solid-ts/package.json
+++ b/packages/create-rstack/template-app-solid-ts/package.json
@@ -9,7 +9,8 @@
     "format": "rs fmt",
     "lint": "rs lint",
     "preview": "rs preview",
-    "test": "rs test"
+    "test": "rs test",
+    "test:watch": "rs test --watch"
   },
   "dependencies": {
     "solid-js": "^1.9.14"
@@ -17,7 +18,10 @@
   "devDependencies": {
     "@rsbuild/plugin-babel": "^2.0.1",
     "@rsbuild/plugin-solid": "^1.2.2",
+    "@solidjs/testing-library": "^0.8.10",
+    "@testing-library/jest-dom": "^7.0.0",
     "@types/node": "^24.13.3",
+    "happy-dom": "^20.11.1",
     "rstack": "^0.3.5",
     "typescript": "^7.0.2"
   }

--- a/packages/create-rstack/template-app-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-solid-ts/rstack.config.ts
@@ -16,7 +16,7 @@ define.app(async () => {
 });
 
 define.test({
-  // Configure Rstest
+  setupFiles: ['./tests/rstest.setup.ts'],
 });
 
 define.lint(async () => {

--- a/packages/create-rstack/template-app-solid-ts/tests/index.test.tsx
+++ b/packages/create-rstack/template-app-solid-ts/tests/index.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@solidjs/testing-library';
+import { expect, test } from 'rstack/test';
+import App from '../src/App';
+
+test('renders the main page', () => {
+  render(() => <App />);
+  expect(screen.getByText('Rstack with Solid')).toBeInTheDocument();
+});

--- a/packages/create-rstack/template-app-solid-ts/tests/rstest.setup.ts
+++ b/packages/create-rstack/template-app-solid-ts/tests/rstest.setup.ts
@@ -1,0 +1,4 @@
+import { expect } from 'rstack/test';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);

--- a/packages/create-rstack/template-app-solid-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-app-solid-ts/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["rstack/types", "node", "@testing-library/jest-dom"]
+  },
+  "include": ["./"]
+}

--- a/packages/create-rstack/template-app-vanilla-js/AGENTS.md
+++ b/packages/create-rstack/template-app-vanilla-js/AGENTS.md
@@ -5,8 +5,11 @@
 - `{{ packageManager }} run dev` - Start the development server
 - `{{ packageManager }} run build` - Build the app for production
 - `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
 
 ## Docs
 
 - Rsbuild: https://rsbuild.rs/llms.txt
 - Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-vanilla-js/package.json
+++ b/packages/create-rstack/template-app-vanilla-js/package.json
@@ -9,9 +9,13 @@
     "format": "rs fmt",
     "lint": "rs lint",
     "preview": "rs preview",
-    "test": "rs test"
+    "test": "rs test",
+    "test:watch": "rs test --watch"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^7.0.0",
+    "happy-dom": "^20.11.1",
     "rstack": "^0.3.5"
   }
 }

--- a/packages/create-rstack/template-app-vanilla-js/rstack.config.js
+++ b/packages/create-rstack/template-app-vanilla-js/rstack.config.js
@@ -7,7 +7,7 @@ define.app({
 });
 
 define.test({
-  // Configure Rstest
+  setupFiles: ['./tests/rstest.setup.js'],
 });
 
 define.lint(async () => {

--- a/packages/create-rstack/template-app-vanilla-js/tests/dom.test.js
+++ b/packages/create-rstack/template-app-vanilla-js/tests/dom.test.js
@@ -1,0 +1,12 @@
+import { expect, test } from 'rstack/test';
+import { screen } from '@testing-library/dom';
+
+test('test dom', () => {
+  document.body.innerHTML = `
+    <span data-testid="not-empty"><span data-testid="empty"></span></span>
+    <div data-testid="visible">Visible Example</div>
+  `;
+
+  expect(screen.queryByTestId('not-empty')).toBeInTheDocument();
+  expect(screen.getByText('Visible Example')).toBeVisible();
+});

--- a/packages/create-rstack/template-app-vanilla-js/tests/rstest.setup.js
+++ b/packages/create-rstack/template-app-vanilla-js/tests/rstest.setup.js
@@ -1,0 +1,4 @@
+import { expect } from 'rstack/test';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);

--- a/packages/create-rstack/template-app-vanilla-ts/AGENTS.md
+++ b/packages/create-rstack/template-app-vanilla-ts/AGENTS.md
@@ -5,8 +5,11 @@
 - `{{ packageManager }} run dev` - Start the development server
 - `{{ packageManager }} run build` - Build the app for production
 - `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
 
 ## Docs
 
 - Rsbuild: https://rsbuild.rs/llms.txt
 - Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-vanilla-ts/package.json
+++ b/packages/create-rstack/template-app-vanilla-ts/package.json
@@ -9,10 +9,14 @@
     "format": "rs fmt",
     "lint": "rs lint",
     "preview": "rs preview",
-    "test": "rs test"
+    "test": "rs test",
+    "test:watch": "rs test --watch"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^7.0.0",
     "@types/node": "^24.13.3",
+    "happy-dom": "^20.11.1",
     "rstack": "^0.3.5",
     "typescript": "^7.0.2"
   }

--- a/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
@@ -6,7 +6,7 @@ define.app({
 });
 
 define.test({
-  // Configure Rstest
+  setupFiles: ['./tests/rstest.setup.ts'],
 });
 
 define.lint(async () => {

--- a/packages/create-rstack/template-app-vanilla-ts/tests/dom.test.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/tests/dom.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'rstack/test';
+import { screen } from '@testing-library/dom';
+
+test('test dom', () => {
+  document.body.innerHTML = `
+    <span data-testid="not-empty"><span data-testid="empty"></span></span>
+    <div data-testid="visible">Visible Example</div>
+  `;
+
+  expect(screen.queryByTestId('not-empty')).toBeInTheDocument();
+  expect(screen.getByText('Visible Example')).toBeVisible();
+});

--- a/packages/create-rstack/template-app-vanilla-ts/tests/rstest.setup.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/tests/rstest.setup.ts
@@ -1,0 +1,4 @@
+import { expect } from 'rstack/test';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);

--- a/packages/create-rstack/template-app-vanilla-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-app-vanilla-ts/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["rstack/types", "node", "@testing-library/jest-dom"]
+  },
+  "include": ["./"]
+}

--- a/packages/create-rstack/template-app-vue-js/AGENTS.md
+++ b/packages/create-rstack/template-app-vue-js/AGENTS.md
@@ -5,8 +5,11 @@
 - `{{ packageManager }} run dev` - Start the development server
 - `{{ packageManager }} run build` - Build the app for production
 - `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
 
 ## Docs
 
 - Rsbuild: https://rsbuild.rs/llms.txt
 - Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-vue-js/package.json
+++ b/packages/create-rstack/template-app-vue-js/package.json
@@ -9,13 +9,18 @@
     "format": "rs fmt",
     "lint": "rs lint",
     "preview": "rs preview",
-    "test": "rs test"
+    "test": "rs test",
+    "test:watch": "rs test --watch"
   },
   "dependencies": {
     "vue": "^3.5.40"
   },
   "devDependencies": {
     "@rsbuild/plugin-vue": "^2.0.1",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/vue": "^8.1.0",
+    "@vue/test-utils": "^2.4.11",
+    "happy-dom": "^20.11.1",
     "rstack": "^0.3.5"
   }
 }

--- a/packages/create-rstack/template-app-vue-js/rstack.config.js
+++ b/packages/create-rstack/template-app-vue-js/rstack.config.js
@@ -11,7 +11,7 @@ define.app(async () => {
 });
 
 define.test({
-  // Configure Rstest
+  setupFiles: ['./tests/rstest.setup.js'],
 });
 
 define.lint(async () => {

--- a/packages/create-rstack/template-app-vue-js/tests/index.test.js
+++ b/packages/create-rstack/template-app-vue-js/tests/index.test.js
@@ -1,0 +1,8 @@
+import { expect, test } from 'rstack/test';
+import { render, screen } from '@testing-library/vue';
+import App from '../src/App.vue';
+
+test('renders the main page', () => {
+  render(App);
+  expect(screen.getByText('Rstack with Vue')).toBeInTheDocument();
+});

--- a/packages/create-rstack/template-app-vue-js/tests/rstest.setup.js
+++ b/packages/create-rstack/template-app-vue-js/tests/rstest.setup.js
@@ -1,0 +1,4 @@
+import { expect } from 'rstack/test';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);

--- a/packages/create-rstack/template-app-vue-ts/AGENTS.md
+++ b/packages/create-rstack/template-app-vue-ts/AGENTS.md
@@ -5,8 +5,11 @@
 - `{{ packageManager }} run dev` - Start the development server
 - `{{ packageManager }} run build` - Build the app for production
 - `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
 
 ## Docs
 
 - Rsbuild: https://rsbuild.rs/llms.txt
 - Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-vue-ts/package.json
+++ b/packages/create-rstack/template-app-vue-ts/package.json
@@ -9,14 +9,19 @@
     "format": "rs fmt",
     "lint": "rs lint",
     "preview": "rs preview",
-    "test": "rs test"
+    "test": "rs test",
+    "test:watch": "rs test --watch"
   },
   "dependencies": {
     "vue": "^3.5.40"
   },
   "devDependencies": {
     "@rsbuild/plugin-vue": "^2.0.1",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/vue": "^8.1.0",
     "@types/node": "^24.13.3",
+    "@vue/test-utils": "^2.4.11",
+    "happy-dom": "^20.11.1",
     "rstack": "^0.3.5",
     "typescript": "^6.0.3",
     "vue-tsc": "^3.3.9"

--- a/packages/create-rstack/template-app-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vue-ts/rstack.config.ts
@@ -10,7 +10,7 @@ define.app(async () => {
 });
 
 define.test({
-  // Configure Rstest
+  setupFiles: ['./tests/rstest.setup.ts'],
 });
 
 define.lint(async () => {

--- a/packages/create-rstack/template-app-vue-ts/tests/index.test.ts
+++ b/packages/create-rstack/template-app-vue-ts/tests/index.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'rstack/test';
+import { render, screen } from '@testing-library/vue';
+import App from '../src/App.vue';
+
+test('renders the main page', () => {
+  render(App);
+  expect(screen.getByText('Rstack with Vue')).toBeInTheDocument();
+});

--- a/packages/create-rstack/template-app-vue-ts/tests/rstest.setup.ts
+++ b/packages/create-rstack/template-app-vue-ts/tests/rstest.setup.ts
@@ -1,0 +1,4 @@
+import { expect } from 'rstack/test';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);

--- a/packages/create-rstack/template-app-vue-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-app-vue-ts/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["rstack/types", "node", "@testing-library/jest-dom"]
+  },
+  "include": ["./"]
+}

--- a/packages/create-rstack/template-lib-solid-js/package.json
+++ b/packages/create-rstack/template-lib-solid-js/package.json
@@ -24,7 +24,6 @@
     "@rsbuild/plugin-babel": "^2.0.1",
     "@rsbuild/plugin-solid": "^1.2.2",
     "@solidjs/testing-library": "^0.8.10",
-    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
     "happy-dom": "^20.11.1",
     "rstack": "^0.3.5",

--- a/packages/create-rstack/template-lib-solid-ts/package.json
+++ b/packages/create-rstack/template-lib-solid-ts/package.json
@@ -26,7 +26,6 @@
     "@rsbuild/plugin-babel": "^2.0.1",
     "@rsbuild/plugin-solid": "^1.2.2",
     "@solidjs/testing-library": "^0.8.10",
-    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.1",

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -37,53 +37,61 @@ test.each([
     template: 'app-vanilla-js',
     configExtension: 'js',
     sourceExtension: 'js',
+    testFile: 'dom.test.js',
     hasTypeScript: false,
   },
   {
     template: 'app-vanilla-ts',
     configExtension: 'ts',
     sourceExtension: 'ts',
+    testFile: 'dom.test.ts',
     hasTypeScript: true,
   },
   {
     template: 'app-react-js',
     configExtension: 'js',
     sourceExtension: 'jsx',
+    testFile: 'index.test.jsx',
     hasTypeScript: false,
   },
   {
     template: 'app-react-ts',
     configExtension: 'ts',
     sourceExtension: 'tsx',
+    testFile: 'index.test.tsx',
     hasTypeScript: true,
   },
   {
     template: 'app-vue-js',
     configExtension: 'js',
     sourceExtension: 'js',
+    testFile: 'index.test.js',
     hasTypeScript: false,
   },
   {
     template: 'app-vue-ts',
     configExtension: 'ts',
     sourceExtension: 'ts',
+    testFile: 'index.test.ts',
     hasTypeScript: true,
   },
   {
     template: 'app-solid-js',
     configExtension: 'js',
     sourceExtension: 'jsx',
+    testFile: 'index.test.jsx',
     hasTypeScript: false,
   },
   {
     template: 'app-solid-ts',
     configExtension: 'ts',
     sourceExtension: 'tsx',
+    testFile: 'index.test.tsx',
     hasTypeScript: true,
   },
 ])(
   'creates the $template template',
-  async ({ template, configExtension, sourceExtension, hasTypeScript }) => {
+  async ({ template, configExtension, sourceExtension, testFile, hasTypeScript }) => {
     const projectDirectory = await createProject(template);
     const packageJson = JSON.parse(
       await readFile(path.join(projectDirectory, 'package.json'), 'utf8'),
@@ -99,6 +107,7 @@ test.each([
     await expect(
       access(path.join(projectDirectory, `src/index.${sourceExtension}`)),
     ).resolves.toBeUndefined();
+    await expect(access(path.join(projectDirectory, 'tests', testFile))).resolves.toBeUndefined();
 
     const tsconfigPath = path.join(projectDirectory, 'tsconfig.json');
     if (hasTypeScript) {


### PR DESCRIPTION
`create-rstack` exposed test scripts for application templates but generated no default tests or supporting test dependencies. This adds basic Vanilla, React, Vue, and Solid app tests in JavaScript and TypeScript, wires their setup into Rstack, and removes redundant direct DOM Testing Library dependencies from Solid templates.