### PR TITLE
feat(create-rstack): add Svelte app templates

### DIFF
--- a/packages/create-rstack/README.md
+++ b/packages/create-rstack/README.md
@@ -27,6 +27,8 @@ npx create-rstack -d my-project -t app-vanilla-ts
 - `app-react-ts` - TypeScript React application
 - `app-vue-js` - JavaScript Vue application
 - `app-vue-ts` - TypeScript Vue application
+- `app-svelte-js` - JavaScript Svelte application
+- `app-svelte-ts` - TypeScript Svelte application
 - `app-solid-js` - JavaScript Solid application
 - `app-solid-ts` - TypeScript Solid application
 - `lib-node-js` - JavaScript Node.js library

--- a/packages/create-rstack/src/index.ts
+++ b/packages/create-rstack/src/index.ts
@@ -75,6 +75,7 @@ const getTemplateName = async ({ template }: Argv): Promise<string> => {
               { value: 'vanilla', label: 'Vanilla' },
               { value: 'react', label: 'React' },
               { value: 'vue', label: 'Vue' },
+              { value: 'svelte', label: 'Svelte' },
               { value: 'solid', label: 'Solid' },
             ]
           : [
@@ -109,6 +110,8 @@ await create({
     'app-react-ts',
     'app-vue-js',
     'app-vue-ts',
+    'app-svelte-js',
+    'app-svelte-ts',
     'app-solid-js',
     'app-solid-ts',
     'lib-node-js',

--- a/packages/create-rstack/template-app-svelte-js/AGENTS.md
+++ b/packages/create-rstack/template-app-svelte-js/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Commands
+
+- `{{ packageManager }} run dev` - Start the development server
+- `{{ packageManager }} run build` - Build the app for production
+- `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
+
+## Docs
+
+- Rsbuild: https://rsbuild.rs/llms.txt
+- Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-svelte-js/package.json
+++ b/packages/create-rstack/template-app-svelte-js/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "rstack-app-svelte-js",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rs build",
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test",
+    "test:watch": "rs test --watch"
+  },
+  "dependencies": {
+    "svelte": "^5.56.8"
+  },
+  "devDependencies": {
+    "@rsbuild/plugin-svelte": "^2.0.1",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/svelte": "^5.4.2",
+    "happy-dom": "^20.11.1",
+    "rstack": "^0.3.5"
+  }
+}

--- a/packages/create-rstack/template-app-svelte-js/pnpm-workspace.yaml
+++ b/packages/create-rstack/template-app-svelte-js/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  svelte-preprocess: false

--- a/packages/create-rstack/template-app-svelte-js/rstack.config.js
+++ b/packages/create-rstack/template-app-svelte-js/rstack.config.js
@@ -1,0 +1,21 @@
+// @ts-check
+// Rstack configuration guide: https://rstack.rs/config
+import { define } from 'rstack';
+
+define.app(async () => {
+  const { pluginSvelte } = await import('@rsbuild/plugin-svelte');
+
+  return {
+    plugins: [pluginSvelte()],
+  };
+});
+
+define.test({
+  setupFiles: ['./tests/rstest.setup.js'],
+});
+
+define.lint(async () => {
+  const { js } = await import('rstack/lint');
+
+  return [js.configs.recommended];
+});

--- a/packages/create-rstack/template-app-svelte-js/src/App.svelte
+++ b/packages/create-rstack/template-app-svelte-js/src/App.svelte
@@ -1,0 +1,28 @@
+<main>
+  <div class="content">
+    <h1>Rstack with Svelte</h1>
+    <p>Start building amazing things with Rstack.</p>
+  </div>
+</main>
+
+<style>
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}
+</style>

--- a/packages/create-rstack/template-app-svelte-js/src/index.css
+++ b/packages/create-rstack/template-app-svelte-js/src/index.css
@@ -1,0 +1,6 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}

--- a/packages/create-rstack/template-app-svelte-js/src/index.js
+++ b/packages/create-rstack/template-app-svelte-js/src/index.js
@@ -1,0 +1,8 @@
+import { mount } from 'svelte';
+import App from './App.svelte';
+import './index.css';
+
+const root = document.getElementById('root');
+if (root) {
+  mount(App, { target: root });
+}

--- a/packages/create-rstack/template-app-svelte-js/tests/index.test.js
+++ b/packages/create-rstack/template-app-svelte-js/tests/index.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'rstack/test';
+import App from '../src/App.svelte';
+
+test('renders the main page', () => {
+  render(App);
+  expect(screen.getByText('Rstack with Svelte')).toBeInTheDocument();
+});

--- a/packages/create-rstack/template-app-svelte-js/tests/rstest.setup.js
+++ b/packages/create-rstack/template-app-svelte-js/tests/rstest.setup.js
@@ -1,0 +1,4 @@
+import { expect } from 'rstack/test';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);

--- a/packages/create-rstack/template-app-svelte-ts/AGENTS.md
+++ b/packages/create-rstack/template-app-svelte-ts/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Commands
+
+- `{{ packageManager }} run dev` - Start the development server
+- `{{ packageManager }} run build` - Build the app for production
+- `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
+
+## Docs
+
+- Rsbuild: https://rsbuild.rs/llms.txt
+- Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-svelte-ts/package.json
+++ b/packages/create-rstack/template-app-svelte-ts/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "rstack-app-svelte-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "svelte-check && rs build",
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test",
+    "test:watch": "rs test --watch"
+  },
+  "dependencies": {
+    "svelte": "^5.56.8"
+  },
+  "devDependencies": {
+    "@rsbuild/plugin-svelte": "^2.0.1",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/svelte": "^5.4.2",
+    "@types/node": "^24.13.3",
+    "happy-dom": "^20.11.1",
+    "rstack": "^0.3.5",
+    "svelte-check": "^4.7.4",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/create-rstack/template-app-svelte-ts/pnpm-workspace.yaml
+++ b/packages/create-rstack/template-app-svelte-ts/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  svelte-preprocess: false

--- a/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
@@ -1,0 +1,20 @@
+// Rstack configuration guide: https://rstack.rs/config
+import { define } from 'rstack';
+
+define.app(async () => {
+  const { pluginSvelte } = await import('@rsbuild/plugin-svelte');
+
+  return {
+    plugins: [pluginSvelte()],
+  };
+});
+
+define.test({
+  setupFiles: ['./tests/rstest.setup.ts'],
+});
+
+define.lint(async () => {
+  const { js, ts } = await import('rstack/lint');
+
+  return [js.configs.recommended, ts.configs.recommended];
+});

--- a/packages/create-rstack/template-app-svelte-ts/src/App.svelte
+++ b/packages/create-rstack/template-app-svelte-ts/src/App.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  type Props = {
+    tool: string;
+    framework: string;
+  };
+
+  let { tool, framework }: Props = $props();
+</script>
+
+<main>
+  <div class="content">
+    <h1>{tool} with {framework}</h1>
+    <p>Start building amazing things with Rstack.</p>
+  </div>
+</main>
+
+<style>
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}
+</style>

--- a/packages/create-rstack/template-app-svelte-ts/src/index.css
+++ b/packages/create-rstack/template-app-svelte-ts/src/index.css
@@ -1,0 +1,6 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}

--- a/packages/create-rstack/template-app-svelte-ts/src/index.ts
+++ b/packages/create-rstack/template-app-svelte-ts/src/index.ts
@@ -1,0 +1,14 @@
+import { mount } from 'svelte';
+import App from './App.svelte';
+import './index.css';
+
+const root = document.getElementById('root');
+if (root) {
+  mount(App, {
+    target: root,
+    props: {
+      tool: 'Rstack',
+      framework: 'Svelte',
+    },
+  });
+}

--- a/packages/create-rstack/template-app-svelte-ts/tests/index.test.ts
+++ b/packages/create-rstack/template-app-svelte-ts/tests/index.test.ts
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'rstack/test';
+import App from '../src/App.svelte';
+
+test('renders the main page', () => {
+  render(App, {
+    tool: 'Rstack',
+    framework: 'Svelte',
+  });
+  expect(screen.getByText('Rstack with Svelte')).toBeInTheDocument();
+});

--- a/packages/create-rstack/template-app-svelte-ts/tests/rstest.setup.ts
+++ b/packages/create-rstack/template-app-svelte-ts/tests/rstest.setup.ts
@@ -1,0 +1,4 @@
+import { expect } from 'rstack/test';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);

--- a/packages/create-rstack/template-app-svelte-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-app-svelte-ts/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["rstack/types", "node", "@testing-library/jest-dom"]
+  },
+  "include": ["./"]
+}

--- a/packages/create-rstack/template-app-svelte-ts/tsconfig.json
+++ b/packages/create-rstack/template-app-svelte-ts/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2020"],
+    "target": "ES2020",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["rstack/types", "node", "svelte"],
+    "useDefineForClassFields": true,
+
+    /* modules */
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+
+    /* type checking */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte"]
+}

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -76,6 +76,20 @@ test.each([
     hasTypeScript: true,
   },
   {
+    template: 'app-svelte-js',
+    configExtension: 'js',
+    sourceExtension: 'js',
+    testFile: 'index.test.js',
+    hasTypeScript: false,
+  },
+  {
+    template: 'app-svelte-ts',
+    configExtension: 'ts',
+    sourceExtension: 'ts',
+    testFile: 'index.test.ts',
+    hasTypeScript: true,
+  },
+  {
     template: 'app-solid-js',
     configExtension: 'js',
     sourceExtension: 'jsx',


### PR DESCRIPTION
This PR adds Svelte application starters so create-rstack users can choose Svelte with either JavaScript or TypeScript.

Both templates include Rsbuild integration, component tests, lint and format scripts, and TypeScript checking where applicable. They also explicitly deny the informational `svelte-preprocess` install script for pnpm 11 compatibility.