### PR TITLE
fix(create-rstack): format Svelte templates

### DIFF
--- a/packages/create-rstack/template-app-svelte-js/package.json
+++ b/packages/create-rstack/template-app-svelte-js/package.json
@@ -20,6 +20,7 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/svelte": "^5.4.2",
     "happy-dom": "^20.11.1",
+    "prettier-plugin-svelte": "^4.1.1",
     "rstack": "^0.3.5"
   }
 }

--- a/packages/create-rstack/template-app-svelte-js/rstack.config.js
+++ b/packages/create-rstack/template-app-svelte-js/rstack.config.js
@@ -19,3 +19,7 @@ define.lint(async () => {
 
   return [js.configs.recommended];
 });
+
+define.fmt({
+  plugins: ['prettier-plugin-svelte'],
+});

--- a/packages/create-rstack/template-app-svelte-js/src/App.svelte
+++ b/packages/create-rstack/template-app-svelte-js/src/App.svelte
@@ -6,23 +6,23 @@
 </main>
 
 <style>
-.content {
-  display: flex;
-  min-height: 100vh;
-  line-height: 1.1;
-  text-align: center;
-  flex-direction: column;
-  justify-content: center;
-}
+  .content {
+    display: flex;
+    min-height: 100vh;
+    line-height: 1.1;
+    text-align: center;
+    flex-direction: column;
+    justify-content: center;
+  }
 
-.content h1 {
-  font-size: 3.6rem;
-  font-weight: 700;
-}
+  .content h1 {
+    font-size: 3.6rem;
+    font-weight: 700;
+  }
 
-.content p {
-  font-size: 1.2rem;
-  font-weight: 400;
-  opacity: 0.5;
-}
+  .content p {
+    font-size: 1.2rem;
+    font-weight: 400;
+    opacity: 0.5;
+  }
 </style>

--- a/packages/create-rstack/template-app-svelte-ts/package.json
+++ b/packages/create-rstack/template-app-svelte-ts/package.json
@@ -21,6 +21,7 @@
     "@testing-library/svelte": "^5.4.2",
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.1",
+    "prettier-plugin-svelte": "^4.1.1",
     "rstack": "^0.3.5",
     "svelte-check": "^4.7.4",
     "typescript": "^6.0.3"

--- a/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
@@ -18,3 +18,7 @@ define.lint(async () => {
 
   return [js.configs.recommended, ts.configs.recommended];
 });
+
+define.fmt({
+  plugins: ['prettier-plugin-svelte'],
+});

--- a/packages/create-rstack/template-app-svelte-ts/src/App.svelte
+++ b/packages/create-rstack/template-app-svelte-ts/src/App.svelte
@@ -15,23 +15,23 @@
 </main>
 
 <style>
-.content {
-  display: flex;
-  min-height: 100vh;
-  line-height: 1.1;
-  text-align: center;
-  flex-direction: column;
-  justify-content: center;
-}
+  .content {
+    display: flex;
+    min-height: 100vh;
+    line-height: 1.1;
+    text-align: center;
+    flex-direction: column;
+    justify-content: center;
+  }
 
-.content h1 {
-  font-size: 3.6rem;
-  font-weight: 700;
-}
+  .content h1 {
+    font-size: 3.6rem;
+    font-weight: 700;
+  }
 
-.content p {
-  font-size: 1.2rem;
-  font-weight: 400;
-  opacity: 0.5;
-}
+  .content p {
+    font-size: 1.2rem;
+    font-weight: 400;
+    opacity: 0.5;
+  }
 </style>


### PR DESCRIPTION
The Svelte templates were silently skipped by `rs fmt`, leaving generated `.svelte` files outside the default formatting workflow.

This PR adds `prettier-plugin-svelte` to both Svelte app templates and configures it through `define.fmt`.