### PR TITLE
feat(native): add internal binding loader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,9 +46,6 @@ jobs:
       - name: Build Native Binding
         run: pnpm --filter rstack build:native:release
 
-      - name: Test Native Binding
-        run: pnpm --filter rstack test:native
-
       - name: Check Generated Native Files
         run: git diff --exit-code -- packages/rstack/binding.cjs packages/rstack/binding.d.cts
 

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -56,6 +56,8 @@
   },
   "files": [
     "bin",
+    "binding.cjs",
+    "binding.d.cts",
     "dist",
     "types",
     "THIRD_PARTY_NOTICES.md"
@@ -65,8 +67,7 @@
     "build:native": "napi build --platform --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
     "build:native:release": "napi build --platform --release --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
     "dev": "rslib -w",
-    "test": "rs test",
-    "test:native": "node --test tests/native-smoke.cjs"
+    "test": "rs test"
   },
   "dependencies": {
     "@rsbuild/core": "catalog:",

--- a/packages/rstack/rslib.config.ts
+++ b/packages/rstack/rslib.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       lib: './src/lib.ts',
       lint: './src/lint.ts',
       test: './src/test.ts',
+      'native/index': './src/native/index.ts',
       fmtWorker: './src/fmt/worker.ts',
     },
     define: {

--- a/packages/rstack/src/native/index.ts
+++ b/packages/rstack/src/native/index.ts
@@ -1,0 +1,10 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+export type NativeBinding = typeof import('../../binding.cjs');
+
+const require = createRequire(import.meta.url);
+export const loadNativeBinding = (): NativeBinding => {
+  const packageJsonPath = require.resolve('rstack/package.json');
+  return require(path.join(path.dirname(packageJsonPath), 'binding.cjs')) as NativeBinding;
+};

--- a/packages/rstack/tests/native-smoke.cjs
+++ b/packages/rstack/tests/native-smoke.cjs
@@ -1,8 +1,0 @@
-const assert = require('node:assert/strict');
-const test = require('node:test');
-
-const { nativePing } = require('../binding.cjs');
-
-test('passes a string from JavaScript through Rust and back', () => {
-  assert.equal(nativePing('rstack'), 'pong:rstack');
-});

--- a/packages/rstack/tests/native/smoke.test.ts
+++ b/packages/rstack/tests/native/smoke.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'rstack/test';
+import { loadNativeBinding } from '../../dist/native/index.js';
+
+test('passes a string through the private loader and Rust', () => {
+  expect(loadNativeBinding().nativePing('rstack')).toBe('pong:rstack');
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -7,6 +7,7 @@ fnames
 huskyrc
 indentable
 llms
+napi
 noformat
 noprettier
 nosystem


### PR DESCRIPTION
This PR introduces an internal lazy loader for the NAPI-RS binding so `rstack` can start depending on Rust without exposing a public native API. The generated binding loader and declarations are included in the package, while the internal loader resolves the installed package before requiring them. The JavaScript-to-Rust smoke test now runs in the standard Rstest suite after CI builds the host native binding.