### PR TITLE
feat(create-rstack): add Preact app templates

### DIFF
--- a/packages/create-rstack/README.md
+++ b/packages/create-rstack/README.md
@@ -25,6 +25,8 @@ npx create-rstack -d my-project -t app-vanilla-ts
 - `app-vanilla-ts` - TypeScript Vanilla application
 - `app-react-js` - JavaScript React application
 - `app-react-ts` - TypeScript React application
+- `app-preact-js` - JavaScript Preact application
+- `app-preact-ts` - TypeScript Preact application
 - `app-vue-js` - JavaScript Vue application
 - `app-vue-ts` - TypeScript Vue application
 - `app-svelte-js` - JavaScript Svelte application

--- a/packages/create-rstack/src/index.ts
+++ b/packages/create-rstack/src/index.ts
@@ -74,6 +74,7 @@ const getTemplateName = async ({ template }: Argv): Promise<string> => {
           ? [
               { value: 'vanilla', label: 'Vanilla' },
               { value: 'react', label: 'React' },
+              { value: 'preact', label: 'Preact' },
               { value: 'vue', label: 'Vue' },
               { value: 'svelte', label: 'Svelte' },
               { value: 'solid', label: 'Solid' },
@@ -108,6 +109,8 @@ await create({
     'app-vanilla-ts',
     'app-react-js',
     'app-react-ts',
+    'app-preact-js',
+    'app-preact-ts',
     'app-vue-js',
     'app-vue-ts',
     'app-svelte-js',

--- a/packages/create-rstack/template-app-preact-js/AGENTS.md
+++ b/packages/create-rstack/template-app-preact-js/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Commands
+
+- `{{ packageManager }} run dev` - Start the development server
+- `{{ packageManager }} run build` - Build the app for production
+- `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
+
+## Docs
+
+- Rsbuild: https://rsbuild.rs/llms.txt
+- Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-preact-js/package.json
+++ b/packages/create-rstack/template-app-preact-js/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "rstack-app-preact-js",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rs build",
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test",
+    "test:watch": "rs test --watch"
+  },
+  "dependencies": {
+    "preact": "^10.29.8"
+  },
+  "devDependencies": {
+    "@rsbuild/plugin-preact": "^2.0.0",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/preact": "^3.2.4",
+    "happy-dom": "^20.11.1",
+    "rstack": "^0.3.5"
+  }
+}

--- a/packages/create-rstack/template-app-preact-js/rstack.config.js
+++ b/packages/create-rstack/template-app-preact-js/rstack.config.js
@@ -1,0 +1,25 @@
+// @ts-check
+// Rstack configuration guide: https://rstack.rs/config
+import { define } from 'rstack';
+
+define.app(async () => {
+  const { pluginPreact } = await import('@rsbuild/plugin-preact');
+
+  return {
+    plugins: [pluginPreact()],
+  };
+});
+
+define.test({
+  setupFiles: ['./tests/rstest.setup.js'],
+});
+
+define.lint(async () => {
+  const { js, reactHooksPlugin, reactPlugin } = await import('rstack/lint');
+
+  return [
+    js.configs.recommended,
+    reactPlugin.configs.recommended,
+    reactHooksPlugin.configs.recommended,
+  ];
+});

--- a/packages/create-rstack/template-app-preact-js/src/App.css
+++ b/packages/create-rstack/template-app-preact-js/src/App.css
@@ -1,0 +1,26 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}
+
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}

--- a/packages/create-rstack/template-app-preact-js/src/App.jsx
+++ b/packages/create-rstack/template-app-preact-js/src/App.jsx
@@ -1,0 +1,12 @@
+import './App.css';
+
+const App = () => {
+  return (
+    <div className="content">
+      <h1>Rstack with Preact</h1>
+      <p>Start building amazing things with Rstack.</p>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/create-rstack/template-app-preact-js/src/index.jsx
+++ b/packages/create-rstack/template-app-preact-js/src/index.jsx
@@ -1,0 +1,4 @@
+import { render } from 'preact';
+import App from './App';
+
+render(<App />, document.getElementById('root'));

--- a/packages/create-rstack/template-app-preact-js/tests/index.test.jsx
+++ b/packages/create-rstack/template-app-preact-js/tests/index.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/preact';
+import { expect, test } from 'rstack/test';
+import App from '../src/App';
+
+test('renders the main page', () => {
+  render(<App />);
+  expect(screen.getByText('Rstack with Preact')).toBeInTheDocument();
+});

--- a/packages/create-rstack/template-app-preact-js/tests/rstest.setup.js
+++ b/packages/create-rstack/template-app-preact-js/tests/rstest.setup.js
@@ -1,0 +1,4 @@
+import { expect } from 'rstack/test';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);

--- a/packages/create-rstack/template-app-preact-ts/AGENTS.md
+++ b/packages/create-rstack/template-app-preact-ts/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Commands
+
+- `{{ packageManager }} run dev` - Start the development server
+- `{{ packageManager }} run build` - Build the app for production
+- `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
+
+## Docs
+
+- Rsbuild: https://rsbuild.rs/llms.txt
+- Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-preact-ts/package.json
+++ b/packages/create-rstack/template-app-preact-ts/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "rstack-app-preact-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rs build",
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test",
+    "test:watch": "rs test --watch"
+  },
+  "dependencies": {
+    "preact": "^10.29.8"
+  },
+  "devDependencies": {
+    "@rsbuild/plugin-preact": "^2.0.0",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/preact": "^3.2.4",
+    "@types/node": "^24.13.3",
+    "happy-dom": "^20.11.1",
+    "rstack": "^0.3.5",
+    "typescript": "^7.0.2"
+  }
+}

--- a/packages/create-rstack/template-app-preact-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-preact-ts/rstack.config.ts
@@ -1,0 +1,25 @@
+// Rstack configuration guide: https://rstack.rs/config
+import { define } from 'rstack';
+
+define.app(async () => {
+  const { pluginPreact } = await import('@rsbuild/plugin-preact');
+
+  return {
+    plugins: [pluginPreact()],
+  };
+});
+
+define.test({
+  setupFiles: ['./tests/rstest.setup.ts'],
+});
+
+define.lint(async () => {
+  const { js, ts, reactHooksPlugin, reactPlugin } = await import('rstack/lint');
+
+  return [
+    js.configs.recommended,
+    ts.configs.recommended,
+    reactPlugin.configs.recommended,
+    reactHooksPlugin.configs.recommended,
+  ];
+});

--- a/packages/create-rstack/template-app-preact-ts/src/App.css
+++ b/packages/create-rstack/template-app-preact-ts/src/App.css
@@ -1,0 +1,26 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}
+
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}

--- a/packages/create-rstack/template-app-preact-ts/src/App.tsx
+++ b/packages/create-rstack/template-app-preact-ts/src/App.tsx
@@ -1,0 +1,12 @@
+import './App.css';
+
+const App = () => {
+  return (
+    <div className="content">
+      <h1>Rstack with Preact</h1>
+      <p>Start building amazing things with Rstack.</p>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/create-rstack/template-app-preact-ts/src/index.tsx
+++ b/packages/create-rstack/template-app-preact-ts/src/index.tsx
@@ -1,0 +1,7 @@
+import { render } from 'preact';
+import App from './App';
+
+const root = document.getElementById('root');
+if (root) {
+  render(<App />, root);
+}

--- a/packages/create-rstack/template-app-preact-ts/tests/index.test.tsx
+++ b/packages/create-rstack/template-app-preact-ts/tests/index.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/preact';
+import { expect, test } from 'rstack/test';
+import App from '../src/App';
+
+test('renders the main page', () => {
+  render(<App />);
+  expect(screen.getByText('Rstack with Preact')).toBeInTheDocument();
+});

--- a/packages/create-rstack/template-app-preact-ts/tests/rstest.setup.ts
+++ b/packages/create-rstack/template-app-preact-ts/tests/rstest.setup.ts
@@ -1,0 +1,4 @@
+import { expect } from 'rstack/test';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(jestDomMatchers);

--- a/packages/create-rstack/template-app-preact-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-app-preact-ts/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["rstack/types", "node", "@testing-library/jest-dom"]
+  },
+  "include": ["./"]
+}

--- a/packages/create-rstack/template-app-preact-ts/tsconfig.json
+++ b/packages/create-rstack/template-app-preact-ts/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2020"],
+    "jsx": "react-jsx",
+    "target": "ES2020",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["rstack/types", "node"],
+    "jsxImportSource": "preact",
+    "useDefineForClassFields": true,
+
+    /* modules */
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "paths": {
+      "react": ["./node_modules/preact/compat/"],
+      "react-dom": ["./node_modules/preact/compat/"]
+    },
+
+    /* type checking */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src"]
+}

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -62,6 +62,20 @@ test.each([
     hasTypeScript: true,
   },
   {
+    template: 'app-preact-js',
+    configExtension: 'js',
+    sourceExtension: 'jsx',
+    testFile: 'index.test.jsx',
+    hasTypeScript: false,
+  },
+  {
+    template: 'app-preact-ts',
+    configExtension: 'ts',
+    sourceExtension: 'tsx',
+    testFile: 'index.test.tsx',
+    hasTypeScript: true,
+  },
+  {
     template: 'app-vue-js',
     configExtension: 'js',
     sourceExtension: 'js',


### PR DESCRIPTION
`create-rstack` does not currently offer Preact when creating a web application.

This PR adds JavaScript and TypeScript Preact templates with the standard build, test, lint, and format setup, and exposes Preact in both the interactive prompt and `--template` flow.