### PR TITLE
feat(create-rstack): add Lit app templates

### DIFF
--- a/packages/create-rstack/README.md
+++ b/packages/create-rstack/README.md
@@ -29,6 +29,8 @@ npx create-rstack -d my-project -t app-vanilla-ts
 - `app-preact-ts` - TypeScript Preact application
 - `app-vue-js` - JavaScript Vue application
 - `app-vue-ts` - TypeScript Vue application
+- `app-lit-js` - JavaScript Lit application
+- `app-lit-ts` - TypeScript Lit application
 - `app-svelte-js` - JavaScript Svelte application
 - `app-svelte-ts` - TypeScript Svelte application
 - `app-solid-js` - JavaScript Solid application

--- a/packages/create-rstack/src/index.ts
+++ b/packages/create-rstack/src/index.ts
@@ -76,6 +76,7 @@ const getTemplateName = async ({ template }: Argv): Promise<string> => {
               { value: 'react', label: 'React' },
               { value: 'preact', label: 'Preact' },
               { value: 'vue', label: 'Vue' },
+              { value: 'lit', label: 'Lit' },
               { value: 'svelte', label: 'Svelte' },
               { value: 'solid', label: 'Solid' },
             ]
@@ -113,6 +114,8 @@ await create({
     'app-preact-ts',
     'app-vue-js',
     'app-vue-ts',
+    'app-lit-js',
+    'app-lit-ts',
     'app-svelte-js',
     'app-svelte-ts',
     'app-solid-js',

--- a/packages/create-rstack/template-app-lit-js/AGENTS.md
+++ b/packages/create-rstack/template-app-lit-js/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Commands
+
+- `{{ packageManager }} run dev` - Start the development server
+- `{{ packageManager }} run build` - Build the app for production
+- `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
+
+## Docs
+
+- Rsbuild: https://rsbuild.rs/llms.txt
+- Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-lit-js/package.json
+++ b/packages/create-rstack/template-app-lit-js/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "rstack-app-lit-js",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rs build",
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test",
+    "test:watch": "rs test --watch"
+  },
+  "dependencies": {
+    "lit": "^3.3.3"
+  },
+  "devDependencies": {
+    "happy-dom": "^20.11.1",
+    "rstack": "^0.3.5"
+  }
+}

--- a/packages/create-rstack/template-app-lit-js/rstack.config.js
+++ b/packages/create-rstack/template-app-lit-js/rstack.config.js
@@ -1,0 +1,24 @@
+// @ts-check
+// Rstack configuration guide: https://rstack.rs/config
+import { define } from 'rstack';
+
+define.app({
+  html: {
+    template: './src/index.html',
+  },
+  source: {
+    decorators: {
+      version: 'legacy',
+    },
+  },
+});
+
+define.test({
+  testEnvironment: 'happy-dom',
+});
+
+define.lint(async () => {
+  const { js } = await import('rstack/lint');
+
+  return [js.configs.recommended];
+});

--- a/packages/create-rstack/template-app-lit-js/src/index.css
+++ b/packages/create-rstack/template-app-lit-js/src/index.css
@@ -1,0 +1,6 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}

--- a/packages/create-rstack/template-app-lit-js/src/index.html
+++ b/packages/create-rstack/template-app-lit-js/src/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <head></head>
+  <body>
+    <my-element></my-element>
+  </body>
+</html>

--- a/packages/create-rstack/template-app-lit-js/src/index.js
+++ b/packages/create-rstack/template-app-lit-js/src/index.js
@@ -1,0 +1,4 @@
+import './index.css';
+import { MyElement } from './my-element';
+
+customElements.define('my-element', MyElement);

--- a/packages/create-rstack/template-app-lit-js/src/my-element.js
+++ b/packages/create-rstack/template-app-lit-js/src/my-element.js
@@ -1,0 +1,34 @@
+import { html, css, LitElement } from 'lit';
+
+export class MyElement extends LitElement {
+  static styles = css`
+    .content {
+      display: flex;
+      min-height: 100vh;
+      line-height: 1.1;
+      text-align: center;
+      flex-direction: column;
+      justify-content: center;
+    }
+
+    .content h1 {
+      font-size: 3.6rem;
+      font-weight: 700;
+    }
+
+    .content p {
+      font-size: 1.2rem;
+      font-weight: 400;
+      opacity: 0.5;
+    }
+  `;
+
+  render() {
+    return html`
+      <div class="content">
+        <h1>Rstack with Lit</h1>
+        <p>Start building amazing things with Rstack.</p>
+      </div>
+    `;
+  }
+}

--- a/packages/create-rstack/template-app-lit-js/tests/index.test.js
+++ b/packages/create-rstack/template-app-lit-js/tests/index.test.js
@@ -1,0 +1,12 @@
+import { expect, test } from 'rstack/test';
+import { MyElement } from '../src/my-element';
+
+test('renders the main page', async () => {
+  customElements.define('my-element', MyElement);
+  const element = document.createElement('my-element');
+  document.body.append(element);
+
+  await element.updateComplete;
+
+  expect(element.shadowRoot?.textContent).toContain('Rstack with Lit');
+});

--- a/packages/create-rstack/template-app-lit-ts/AGENTS.md
+++ b/packages/create-rstack/template-app-lit-ts/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Commands
+
+- `{{ packageManager }} run dev` - Start the development server
+- `{{ packageManager }} run build` - Build the app for production
+- `{{ packageManager }} run preview` - Preview the production build locally
+- `{{ packageManager }} run test` - Run tests
+- `{{ packageManager }} run test:watch` - Run tests in watch mode
+
+## Docs
+
+- Rsbuild: https://rsbuild.rs/llms.txt
+- Rspack: https://rspack.rs/llms.txt
+- Rstest: https://rstest.rs/llms.txt

--- a/packages/create-rstack/template-app-lit-ts/package.json
+++ b/packages/create-rstack/template-app-lit-ts/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "rstack-app-lit-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rs build",
+    "dev": "rs dev",
+    "format": "rs fmt",
+    "lint": "rs lint",
+    "preview": "rs preview",
+    "test": "rs test",
+    "test:watch": "rs test --watch"
+  },
+  "dependencies": {
+    "lit": "^3.3.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.13.3",
+    "happy-dom": "^20.11.1",
+    "rstack": "^0.3.5",
+    "typescript": "^7.0.2"
+  }
+}

--- a/packages/create-rstack/template-app-lit-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-lit-ts/rstack.config.ts
@@ -1,0 +1,23 @@
+// Rstack configuration guide: https://rstack.rs/config
+import { define } from 'rstack';
+
+define.app({
+  html: {
+    template: './src/index.html',
+  },
+  source: {
+    decorators: {
+      version: 'legacy',
+    },
+  },
+});
+
+define.test({
+  testEnvironment: 'happy-dom',
+});
+
+define.lint(async () => {
+  const { js, ts } = await import('rstack/lint');
+
+  return [js.configs.recommended, ts.configs.recommended];
+});

--- a/packages/create-rstack/template-app-lit-ts/src/index.css
+++ b/packages/create-rstack/template-app-lit-ts/src/index.css
@@ -1,0 +1,6 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}

--- a/packages/create-rstack/template-app-lit-ts/src/index.html
+++ b/packages/create-rstack/template-app-lit-ts/src/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <head></head>
+  <body>
+    <my-element></my-element>
+  </body>
+</html>

--- a/packages/create-rstack/template-app-lit-ts/src/index.ts
+++ b/packages/create-rstack/template-app-lit-ts/src/index.ts
@@ -1,0 +1,4 @@
+import './index.css';
+import { MyElement } from './my-element';
+
+customElements.define('my-element', MyElement);

--- a/packages/create-rstack/template-app-lit-ts/src/my-element.ts
+++ b/packages/create-rstack/template-app-lit-ts/src/my-element.ts
@@ -1,0 +1,34 @@
+import { html, css, LitElement } from 'lit';
+
+export class MyElement extends LitElement {
+  static styles = css`
+    .content {
+      display: flex;
+      min-height: 100vh;
+      line-height: 1.1;
+      text-align: center;
+      flex-direction: column;
+      justify-content: center;
+    }
+
+    .content h1 {
+      font-size: 3.6rem;
+      font-weight: 700;
+    }
+
+    .content p {
+      font-size: 1.2rem;
+      font-weight: 400;
+      opacity: 0.5;
+    }
+  `;
+
+  render() {
+    return html`
+      <div class="content">
+        <h1>Rstack with Lit</h1>
+        <p>Start building amazing things with Rstack.</p>
+      </div>
+    `;
+  }
+}

--- a/packages/create-rstack/template-app-lit-ts/tests/index.test.ts
+++ b/packages/create-rstack/template-app-lit-ts/tests/index.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'rstack/test';
+import { MyElement } from '../src/my-element';
+
+test('renders the main page', async () => {
+  customElements.define('my-element', MyElement);
+  const element = document.createElement('my-element') as MyElement;
+  document.body.append(element);
+
+  await element.updateComplete;
+
+  expect(element.shadowRoot?.textContent).toContain('Rstack with Lit');
+});

--- a/packages/create-rstack/template-app-lit-ts/tsconfig.json
+++ b/packages/create-rstack/template-app-lit-ts/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2020"],
+    "target": "ES2020",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["rstack/types", "node"],
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+
+    /* modules */
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+
+    /* type checking */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src"]
+}

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -90,6 +90,20 @@ test.each([
     hasTypeScript: true,
   },
   {
+    template: 'app-lit-js',
+    configExtension: 'js',
+    sourceExtension: 'js',
+    testFile: 'index.test.js',
+    hasTypeScript: false,
+  },
+  {
+    template: 'app-lit-ts',
+    configExtension: 'ts',
+    sourceExtension: 'ts',
+    testFile: 'index.test.ts',
+    hasTypeScript: true,
+  },
+  {
     template: 'app-svelte-js',
     configExtension: 'js',
     sourceExtension: 'js',


### PR DESCRIPTION
create-rstack currently lacks a Lit starter for users building web components. This PR adds JavaScript and TypeScript Lit application templates, exposes them in the framework prompt and CLI template list, and covers generation in tests. The templates include the repository's default build, test, lint, and format setup.