### PR TITLE
ci(native): support Linux x64 glibc

### DIFF
--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -81,9 +81,6 @@ jobs:
           --js binding.cjs
           --dts binding.d.cts
 
-      - name: Check generated native files
-        run: git diff --exit-code -- packages/rstack/binding.cjs packages/rstack/binding.d.cts
-
       - name: Upload native binding
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -1,0 +1,93 @@
+name: Reusable Native Build
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        description: Rust target triple to build
+        required: true
+        type: string
+      runner:
+        description: GitHub-hosted runner label
+        required: true
+        type: string
+      filename:
+        description: Expected NAPI-RS binary filename
+        required: true
+        type: string
+      use_napi_cross:
+        description: Build with the NAPI-RS cross toolchain
+        default: false
+        required: false
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  build:
+    name: Build ${{ inputs.target }}
+    runs-on: ${{ inputs.runner }}
+    env:
+      RUST_TARGET: ${{ inputs.target }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.18.0
+          package-manager-cache: false
+
+      - name: Install Pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          run_install: true
+
+      - name: Install Rust target
+        shell: bash
+        run: rustup target add "$RUST_TARGET"
+
+      - name: Build native binding with NAPI-RS cross toolchain
+        if: inputs.use_napi_cross
+        shell: bash
+        working-directory: packages/rstack
+        run: >-
+          pnpm exec napi build --platform --release
+          --target "$RUST_TARGET"
+          --manifest-path ../../Cargo.toml
+          --package rstack-binding
+          --package-json-path package.json
+          --output-dir .
+          --js binding.cjs
+          --dts binding.d.cts
+          --use-napi-cross
+
+      - name: Build native binding
+        if: ${{ !inputs.use_napi_cross }}
+        shell: bash
+        working-directory: packages/rstack
+        run: >-
+          pnpm exec napi build --platform --release
+          --target "$RUST_TARGET"
+          --manifest-path ../../Cargo.toml
+          --package rstack-binding
+          --package-json-path package.json
+          --output-dir .
+          --js binding.cjs
+          --dts binding.d.cts
+
+      - name: Check generated native files
+        run: git diff --exit-code -- packages/rstack/binding.cjs packages/rstack/binding.d.cts
+
+      - name: Upload native binding
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: native-${{ inputs.target }}
+          path: packages/rstack/${{ inputs.filename }}
+          if-no-files-found: error
+          retention-days: 1

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -116,6 +116,8 @@
   "napi": {
     "binaryName": "rstack",
     "packageName": "@rstackjs/binding",
-    "targets": []
+    "targets": [
+      "x86_64-unknown-linux-gnu"
+    ]
   }
 }


### PR DESCRIPTION
This PR starts the platform-specific native build rollout with the Tier 1 `x86_64-unknown-linux-gnu` target.

It adds a reusable single-target workflow that supports the NAPI-RS cross toolchain and uploads the exact binary for later callers. The workflow is intentionally not wired into pull request or release flows yet.