### PR TITLE
feat(create-rstack): add check scripts to templates

### DIFF
--- a/packages/create-rstack/template-app-lit-js/package.json
+++ b/packages/create-rstack/template-app-lit-js/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-lit-js/rstack.config.js
+++ b/packages/create-rstack/template-app-lit-js/rstack.config.js
@@ -22,3 +22,7 @@ define.lint(async () => {
 
   return [js.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-app-lit-ts/package.json
+++ b/packages/create-rstack/template-app-lit-ts/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
+    "check": "rs lint --type-check && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-lit-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-lit-ts/rstack.config.ts
@@ -21,3 +21,7 @@ define.lint(async () => {
 
   return [js.configs.recommended, ts.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-app-preact-js/package.json
+++ b/packages/create-rstack/template-app-preact-js/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-preact-js/rstack.config.js
+++ b/packages/create-rstack/template-app-preact-js/rstack.config.js
@@ -23,3 +23,7 @@ define.lint(async () => {
     reactHooksPlugin.configs.recommended,
   ];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-app-preact-ts/package.json
+++ b/packages/create-rstack/template-app-preact-ts/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
+    "check": "rs lint --type-check && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-preact-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-preact-ts/rstack.config.ts
@@ -23,3 +23,7 @@ define.lint(async () => {
     reactHooksPlugin.configs.recommended,
   ];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-app-react-js/package.json
+++ b/packages/create-rstack/template-app-react-js/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-react-js/rstack.config.js
+++ b/packages/create-rstack/template-app-react-js/rstack.config.js
@@ -23,3 +23,7 @@ define.lint(async () => {
     reactHooksPlugin.configs.recommended,
   ];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-app-react-ts/package.json
+++ b/packages/create-rstack/template-app-react-ts/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
+    "check": "rs lint --type-check && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-react-ts/rstack.config.ts
@@ -23,3 +23,7 @@ define.lint(async () => {
     reactHooksPlugin.configs.recommended,
   ];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-app-solid-js/package.json
+++ b/packages/create-rstack/template-app-solid-js/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-solid-js/rstack.config.js
+++ b/packages/create-rstack/template-app-solid-js/rstack.config.js
@@ -25,3 +25,7 @@ define.lint(async () => {
 
   return [js.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-app-solid-ts/package.json
+++ b/packages/create-rstack/template-app-solid-ts/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
+    "check": "rs lint --type-check && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-solid-ts/rstack.config.ts
@@ -24,3 +24,7 @@ define.lint(async () => {
 
   return [js.configs.recommended, ts.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-app-svelte-js/package.json
+++ b/packages/create-rstack/template-app-svelte-js/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-svelte-js/rstack.config.js
+++ b/packages/create-rstack/template-app-svelte-js/rstack.config.js
@@ -22,4 +22,5 @@ define.lint(async () => {
 
 define.fmt({
   plugins: ['prettier-plugin-svelte'],
+  singleQuote: true,
 });

--- a/packages/create-rstack/template-app-svelte-ts/package.json
+++ b/packages/create-rstack/template-app-svelte-ts/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "svelte-check && rs build",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
@@ -21,4 +21,5 @@ define.lint(async () => {
 
 define.fmt({
   plugins: ['prettier-plugin-svelte'],
+  singleQuote: true,
 });

--- a/packages/create-rstack/template-app-vanilla-js/package.json
+++ b/packages/create-rstack/template-app-vanilla-js/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-vanilla-js/rstack.config.js
+++ b/packages/create-rstack/template-app-vanilla-js/rstack.config.js
@@ -15,3 +15,7 @@ define.lint(async () => {
 
   return [js.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-app-vanilla-ts/package.json
+++ b/packages/create-rstack/template-app-vanilla-ts/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
+    "check": "rs lint --type-check && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
@@ -14,3 +14,7 @@ define.lint(async () => {
 
   return [js.configs.recommended, ts.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-app-vue-js/package.json
+++ b/packages/create-rstack/template-app-vue-js/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-vue-js/rstack.config.js
+++ b/packages/create-rstack/template-app-vue-js/rstack.config.js
@@ -19,3 +19,7 @@ define.lint(async () => {
 
   return [js.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-app-vue-ts/package.json
+++ b/packages/create-rstack/template-app-vue-ts/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vue-tsc && rs build",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vue-ts/rstack.config.ts
@@ -18,3 +18,7 @@ define.lint(async () => {
 
   return [js.configs.recommended, ts.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-doc-basic/package.json
+++ b/packages/create-rstack/template-doc-basic/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs doc build",
+    "check": "rs lint --type-check && rs fmt --check",
     "dev": "rs doc",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-doc-basic/rstack.config.ts
+++ b/packages/create-rstack/template-doc-basic/rstack.config.ts
@@ -17,3 +17,7 @@ define.lint(async () => {
     reactHooksPlugin.configs.recommended,
   ];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-doc-i18n/package.json
+++ b/packages/create-rstack/template-doc-i18n/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs doc build",
+    "check": "rs lint --type-check && rs fmt --check",
     "dev": "rs doc",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-doc-i18n/rstack.config.ts
+++ b/packages/create-rstack/template-doc-i18n/rstack.config.ts
@@ -33,3 +33,7 @@ define.lint(async () => {
     reactHooksPlugin.configs.recommended,
   ];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-lib-node-js/package.json
+++ b/packages/create-rstack/template-lib-node-js/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "rs lib",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-node-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-node-js/rstack.config.js
@@ -15,3 +15,7 @@ define.lint(async () => {
 
   return [js.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-lib-node-ts/package.json
+++ b/packages/create-rstack/template-lib-node-ts/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "rs lib",
+    "check": "rs lint --type-check && rs fmt --check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-node-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-node-ts/rstack.config.ts
@@ -15,3 +15,7 @@ define.lint(async () => {
 
   return [js.configs.recommended, ts.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-lib-react-js/package.json
+++ b/packages/create-rstack/template-lib-react-js/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "rs lib",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-react-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-react-js/rstack.config.js
@@ -32,3 +32,7 @@ define.lint(async () => {
     reactHooksPlugin.configs.recommended,
   ];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-lib-react-js/src/Button.jsx
+++ b/packages/create-rstack/template-lib-react-js/src/Button.jsx
@@ -1,6 +1,12 @@
 import './button.css';
 
-export const Button = ({ primary = false, size = 'medium', backgroundColor, label, ...props }) => {
+export const Button = ({
+  primary = false,
+  size = 'medium',
+  backgroundColor,
+  label,
+  ...props
+}) => {
   const mode = primary ? 'demo-button--primary' : 'demo-button--secondary';
   return (
     <button

--- a/packages/create-rstack/template-lib-react-ts/package.json
+++ b/packages/create-rstack/template-lib-react-ts/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "rs lib",
+    "check": "rs lint --type-check && rs fmt --check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-react-ts/rstack.config.ts
@@ -33,3 +33,7 @@ define.lint(async () => {
     reactHooksPlugin.configs.recommended,
   ];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-lib-solid-js/package.json
+++ b/packages/create-rstack/template-lib-solid-js/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "rs lib",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-solid-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-solid-js/rstack.config.js
@@ -80,3 +80,7 @@ define.lint(async () => {
 
   return [js.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-lib-solid-js/src/Button.jsx
+++ b/packages/create-rstack/template-lib-solid-js/src/Button.jsx
@@ -1,7 +1,8 @@
 import './button.css';
 
 export function Button(props) {
-  const mode = () => (props.primary ? 'demo-button--primary' : 'demo-button--secondary');
+  const mode = () =>
+    props.primary ? 'demo-button--primary' : 'demo-button--secondary';
   const size = () => props.size ?? 'medium';
 
   return (

--- a/packages/create-rstack/template-lib-solid-ts/package.json
+++ b/packages/create-rstack/template-lib-solid-ts/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "rs lib",
+    "check": "rs lint --type-check && rs fmt --check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
@@ -80,3 +80,7 @@ define.lint(async () => {
 
   return [js.configs.recommended, ts.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-lib-solid-ts/src/Button.tsx
+++ b/packages/create-rstack/template-lib-solid-ts/src/Button.tsx
@@ -26,7 +26,8 @@ export interface ButtonProps {
 }
 
 export function Button(props: ButtonProps) {
-  const mode = () => (props.primary ? 'demo-button--primary' : 'demo-button--secondary');
+  const mode = () =>
+    props.primary ? 'demo-button--primary' : 'demo-button--secondary';
   const size = () => props.size ?? 'medium';
 
   return (

--- a/packages/create-rstack/template-lib-svelte-js/package.json
+++ b/packages/create-rstack/template-lib-svelte-js/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "rs lib",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-svelte-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-svelte-js/rstack.config.js
@@ -31,4 +31,5 @@ define.lint(async () => {
 
 define.fmt({
   plugins: ['prettier-plugin-svelte'],
+  singleQuote: true,
 });

--- a/packages/create-rstack/template-lib-svelte-ts/package.json
+++ b/packages/create-rstack/template-lib-svelte-ts/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "svelte-check && rs lib",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
@@ -31,4 +31,5 @@ define.lint(async () => {
 
 define.fmt({
   plugins: ['prettier-plugin-svelte'],
+  singleQuote: true,
 });

--- a/packages/create-rstack/template-lib-svelte-ts/scripts/rslib-plugin-svelte-dts.ts
+++ b/packages/create-rstack/template-lib-svelte-ts/scripts/rslib-plugin-svelte-dts.ts
@@ -5,9 +5,12 @@ import { emitDts, type EmitDtsConfig } from 'svelte2tsx';
 
 type SvelteDtsPluginOptions = Partial<EmitDtsConfig>;
 
-const resolveProjectPath = (rootPath: string, path: string): string => resolve(rootPath, path);
+const resolveProjectPath = (rootPath: string, path: string): string =>
+  resolve(rootPath, path);
 
-export function svelteDtsPlugin(options: SvelteDtsPluginOptions = {}): RsbuildPlugin {
+export function svelteDtsPlugin(
+  options: SvelteDtsPluginOptions = {},
+): RsbuildPlugin {
   return {
     name: 'rslib-plugin-svelte-dts',
     setup(api) {
@@ -16,15 +19,23 @@ export function svelteDtsPlugin(options: SvelteDtsPluginOptions = {}): RsbuildPl
           api.logger.start('generating declaration files...');
         }
 
-        const { declarationDir = './dist', libRoot = './src', tsconfig } = options;
+        const {
+          declarationDir = './dist',
+          libRoot = './src',
+          tsconfig,
+        } = options;
         const rootPath = api.context.rootPath;
         const tsconfigPath = resolveProjectPath(
           rootPath,
-          tsconfig ?? api.getNormalizedConfig().source.tsconfigPath ?? './tsconfig.json',
+          tsconfig ??
+            api.getNormalizedConfig().source.tsconfigPath ??
+            './tsconfig.json',
         );
         const svelteShimsPath = options.svelteShimsPath
           ? resolveProjectPath(rootPath, options.svelteShimsPath)
-          : fileURLToPath(import.meta.resolve('svelte2tsx/svelte-shims-v4.d.ts'));
+          : fileURLToPath(
+              import.meta.resolve('svelte2tsx/svelte-shims-v4.d.ts'),
+            );
 
         try {
           await emitDts({
@@ -36,7 +47,9 @@ export function svelteDtsPlugin(options: SvelteDtsPluginOptions = {}): RsbuildPl
 
           api.logger.ready('declaration files generated with svelte2tsx.');
         } catch (error) {
-          api.logger.error('Failed to generate declaration files with svelte2tsx.');
+          api.logger.error(
+            'Failed to generate declaration files with svelte2tsx.',
+          );
           api.logger.error(error);
           throw error;
         }

--- a/packages/create-rstack/template-lib-vue-js/package.json
+++ b/packages/create-rstack/template-lib-vue-js/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "rs lib",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-vue-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-vue-js/rstack.config.js
@@ -28,3 +28,7 @@ define.lint(async () => {
 
   return [js.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-lib-vue-js/src/Button.vue
+++ b/packages/create-rstack/template-lib-vue-js/src/Button.vue
@@ -26,7 +26,9 @@ const {
   },
 });
 
-const mode = computed(() => (primary ? 'demo-button--primary' : 'demo-button--secondary'));
+const mode = computed(() =>
+  primary ? 'demo-button--primary' : 'demo-button--secondary',
+);
 </script>
 
 <template>

--- a/packages/create-rstack/template-lib-vue-ts/package.json
+++ b/packages/create-rstack/template-lib-vue-ts/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "rs lib && vue-tsc",
+    "check": "rs lint && rs fmt --check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
@@ -27,3 +27,7 @@ define.lint(async () => {
 
   return [js.configs.recommended, ts.configs.recommended];
 });
+
+define.fmt({
+  singleQuote: true,
+});

--- a/packages/create-rstack/template-lib-vue-ts/src/Button.vue
+++ b/packages/create-rstack/template-lib-vue-ts/src/Button.vue
@@ -18,7 +18,9 @@ const {
   onClick = undefined,
 } = defineProps<Props>();
 
-const mode = computed(() => (primary ? 'demo-button--primary' : 'demo-button--secondary'));
+const mode = computed(() =>
+  primary ? 'demo-button--primary' : 'demo-button--secondary',
+);
 </script>
 
 <template>

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -9,6 +9,17 @@ const execFileAsync = promisify(execFile);
 const packageRoot = path.resolve(import.meta.dirname, '..');
 const binPath = path.join(packageRoot, 'bin.js');
 const tempDirectories: string[] = [];
+const jsCheckScript = 'rs lint && rs fmt --check';
+const tsCheckScript = 'rs lint --type-check && rs fmt --check';
+const templatesWithoutTypeCheck = new Set([
+  'app-svelte-ts',
+  'app-vue-ts',
+  'lib-svelte-ts',
+  'lib-vue-ts',
+]);
+
+const getCheckScript = (template: string, hasTypeScript: boolean): string =>
+  hasTypeScript && !templatesWithoutTypeCheck.has(template) ? tsCheckScript : jsCheckScript;
 
 afterEach(async () => {
   await Promise.all(
@@ -140,6 +151,7 @@ test.each([
     );
 
     expect(packageJson.name).toBe('my-app');
+    expect(packageJson.scripts.check).toBe(getCheckScript(template, hasTypeScript));
 
     await expect(access(path.join(projectDirectory, 'README.md'))).resolves.toBeUndefined();
     await expect(access(path.join(projectDirectory, '.gitignore'))).resolves.toBeUndefined();
@@ -167,6 +179,7 @@ test('creates the doc-basic template', async () => {
   );
 
   expect(packageJson.name).toBe('my-app');
+  expect(packageJson.scripts.check).toBe(tsCheckScript);
 
   await expect(access(path.join(projectDirectory, 'README.md'))).resolves.toBeUndefined();
   await expect(access(path.join(projectDirectory, '.gitignore'))).resolves.toBeUndefined();
@@ -185,6 +198,7 @@ test('creates the doc-i18n template', async () => {
   );
 
   expect(packageJson.name).toBe('my-app');
+  expect(packageJson.scripts.check).toBe(tsCheckScript);
 
   await expect(access(path.join(projectDirectory, 'rstack.config.ts'))).resolves.toBeUndefined();
   await expect(
@@ -265,6 +279,7 @@ test.each([
     );
 
     expect(packageJson.name).toBe('my-app');
+    expect(packageJson.scripts.check).toBe(getCheckScript(template, hasTypeScript));
 
     await expect(
       access(path.join(projectDirectory, `rstack.config.${configExtension}`)),

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -41,6 +41,14 @@ define.lint(async () => {
 
 define.fmt({
   ignorePatterns: ['packages/rstack/binding.cjs', 'packages/rstack/binding.d.cts'],
+  overrides: [
+    {
+      files: 'packages/create-rstack/template-*/**/*',
+      options: {
+        printWidth: 80,
+      },
+    },
+  ],
   printWidth: 100,
   singleQuote: true,
   sortPackageJson: true,


### PR DESCRIPTION
This PR adds a default `check` script to every create-rstack template so generated projects can lint and verify formatting with one command.

TypeScript templates enable lint type checking where supported, while Vue and Svelte retain syntax-only linting. Template formatting configs now set only `singleQuote`, and the repository formatter uses an override to keep template files at Prettier's default print width.