### PR TITLE
feat(create-rstack): add staged file checks to templates

### DIFF
--- a/packages/create-rstack/template-app-lit-js/package.json
+++ b/packages/create-rstack/template-app-lit-js/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-lit-js/rstack.config.js
+++ b/packages/create-rstack/template-app-lit-js/rstack.config.js
@@ -26,3 +26,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-lit-ts/package.json
+++ b/packages/create-rstack/template-app-lit-ts/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-lit-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-lit-ts/rstack.config.ts
@@ -25,3 +25,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-preact-js/package.json
+++ b/packages/create-rstack/template-app-preact-js/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-preact-js/rstack.config.js
+++ b/packages/create-rstack/template-app-preact-js/rstack.config.js
@@ -27,3 +27,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-preact-ts/package.json
+++ b/packages/create-rstack/template-app-preact-ts/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-preact-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-preact-ts/rstack.config.ts
@@ -27,3 +27,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-react-js/package.json
+++ b/packages/create-rstack/template-app-react-js/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-react-js/rstack.config.js
+++ b/packages/create-rstack/template-app-react-js/rstack.config.js
@@ -27,3 +27,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-react-ts/package.json
+++ b/packages/create-rstack/template-app-react-ts/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-react-ts/rstack.config.ts
@@ -27,3 +27,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-solid-js/package.json
+++ b/packages/create-rstack/template-app-solid-js/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-solid-js/rstack.config.js
+++ b/packages/create-rstack/template-app-solid-js/rstack.config.js
@@ -29,3 +29,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-solid-ts/package.json
+++ b/packages/create-rstack/template-app-solid-ts/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-solid-ts/rstack.config.ts
@@ -28,3 +28,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-svelte-js/package.json
+++ b/packages/create-rstack/template-app-svelte-js/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-svelte-js/rstack.config.js
+++ b/packages/create-rstack/template-app-svelte-js/rstack.config.js
@@ -24,3 +24,8 @@ define.fmt({
   plugins: ['prettier-plugin-svelte'],
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml,svelte}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-svelte-ts/package.json
+++ b/packages/create-rstack/template-app-svelte-ts/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
@@ -23,3 +23,8 @@ define.fmt({
   plugins: ['prettier-plugin-svelte'],
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml,svelte}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-vanilla-js/package.json
+++ b/packages/create-rstack/template-app-vanilla-js/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-vanilla-js/rstack.config.js
+++ b/packages/create-rstack/template-app-vanilla-js/rstack.config.js
@@ -19,3 +19,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-vanilla-ts/package.json
+++ b/packages/create-rstack/template-app-vanilla-ts/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
@@ -18,3 +18,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-vue-js/package.json
+++ b/packages/create-rstack/template-app-vue-js/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-vue-js/rstack.config.js
+++ b/packages/create-rstack/template-app-vue-js/rstack.config.js
@@ -23,3 +23,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml,vue}': 'rs fmt',
+});

--- a/packages/create-rstack/template-app-vue-ts/package.json
+++ b/packages/create-rstack/template-app-vue-ts/package.json
@@ -9,6 +9,7 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vue-ts/rstack.config.ts
@@ -22,3 +22,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml,vue}': 'rs fmt',
+});

--- a/packages/create-rstack/template-common/.rstack/hooks/pre-commit
+++ b/packages/create-rstack/template-common/.rstack/hooks/pre-commit
@@ -1,0 +1,1 @@
+rs staged

--- a/packages/create-rstack/template-doc-basic/package.json
+++ b/packages/create-rstack/template-doc-basic/package.json
@@ -9,6 +9,7 @@
     "dev": "rs doc",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs doc preview"
   },
   "devDependencies": {

--- a/packages/create-rstack/template-doc-basic/rstack.config.ts
+++ b/packages/create-rstack/template-doc-basic/rstack.config.ts
@@ -21,3 +21,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-doc-i18n/package.json
+++ b/packages/create-rstack/template-doc-i18n/package.json
@@ -9,6 +9,7 @@
     "dev": "rs doc",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "preview": "rs doc preview"
   },
   "devDependencies": {

--- a/packages/create-rstack/template-doc-i18n/rstack.config.ts
+++ b/packages/create-rstack/template-doc-i18n/rstack.config.ts
@@ -37,3 +37,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-lib-node-js/package.json
+++ b/packages/create-rstack/template-lib-node-js/package.json
@@ -18,6 +18,7 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-node-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-node-js/rstack.config.js
@@ -19,3 +19,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-lib-node-ts/package.json
+++ b/packages/create-rstack/template-lib-node-ts/package.json
@@ -20,6 +20,7 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-node-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-node-ts/rstack.config.ts
@@ -19,3 +19,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-lib-react-js/package.json
+++ b/packages/create-rstack/template-lib-react-js/package.json
@@ -17,6 +17,7 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-react-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-react-js/rstack.config.js
@@ -36,3 +36,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-lib-react-ts/package.json
+++ b/packages/create-rstack/template-lib-react-ts/package.json
@@ -19,6 +19,7 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-react-ts/rstack.config.ts
@@ -37,3 +37,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-lib-solid-js/package.json
+++ b/packages/create-rstack/template-lib-solid-js/package.json
@@ -18,6 +18,7 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-solid-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-solid-js/rstack.config.js
@@ -84,3 +84,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-lib-solid-ts/package.json
+++ b/packages/create-rstack/template-lib-solid-ts/package.json
@@ -20,6 +20,7 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
@@ -84,3 +84,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
+});

--- a/packages/create-rstack/template-lib-svelte-js/package.json
+++ b/packages/create-rstack/template-lib-svelte-js/package.json
@@ -17,6 +17,7 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-svelte-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-svelte-js/rstack.config.js
@@ -33,3 +33,8 @@ define.fmt({
   plugins: ['prettier-plugin-svelte'],
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml,svelte}': 'rs fmt',
+});

--- a/packages/create-rstack/template-lib-svelte-ts/package.json
+++ b/packages/create-rstack/template-lib-svelte-ts/package.json
@@ -19,6 +19,7 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
@@ -33,3 +33,8 @@ define.fmt({
   plugins: ['prettier-plugin-svelte'],
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml,svelte}': 'rs fmt',
+});

--- a/packages/create-rstack/template-lib-vue-js/package.json
+++ b/packages/create-rstack/template-lib-vue-js/package.json
@@ -17,6 +17,7 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-vue-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-vue-js/rstack.config.js
@@ -32,3 +32,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml,vue}': 'rs fmt',
+});

--- a/packages/create-rstack/template-lib-vue-ts/package.json
+++ b/packages/create-rstack/template-lib-vue-ts/package.json
@@ -19,6 +19,7 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
@@ -31,3 +31,8 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
+
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
+  '*.{json,jsonc,md,mdx,css,html,yml,yaml,vue}': 'rs fmt',
+});

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -21,6 +21,20 @@ const templatesWithoutTypeCheck = new Set([
 const getCheckScript = (template: string, hasTypeScript: boolean): string =>
   hasTypeScript && !templatesWithoutTypeCheck.has(template) ? tsCheckScript : jsCheckScript;
 
+const expectStagedSetup = async (
+  projectDirectory: string,
+  configExtension: string,
+  scripts: Record<string, string>,
+): Promise<void> => {
+  expect(scripts.prepare).toBe('rs setup');
+  expect(
+    await readFile(path.join(projectDirectory, '.rstack', 'hooks', 'pre-commit'), 'utf8'),
+  ).toBe('rs staged\n');
+  expect(
+    await readFile(path.join(projectDirectory, `rstack.config.${configExtension}`), 'utf8'),
+  ).toContain('define.staged({');
+};
+
 afterEach(async () => {
   await Promise.all(
     tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
@@ -152,6 +166,7 @@ test.each([
 
     expect(packageJson.name).toBe('my-app');
     expect(packageJson.scripts.check).toBe(getCheckScript(template, hasTypeScript));
+    await expectStagedSetup(projectDirectory, configExtension, packageJson.scripts);
 
     await expect(access(path.join(projectDirectory, 'README.md'))).resolves.toBeUndefined();
     await expect(access(path.join(projectDirectory, '.gitignore'))).resolves.toBeUndefined();
@@ -180,6 +195,7 @@ test('creates the doc-basic template', async () => {
 
   expect(packageJson.name).toBe('my-app');
   expect(packageJson.scripts.check).toBe(tsCheckScript);
+  await expectStagedSetup(projectDirectory, 'ts', packageJson.scripts);
 
   await expect(access(path.join(projectDirectory, 'README.md'))).resolves.toBeUndefined();
   await expect(access(path.join(projectDirectory, '.gitignore'))).resolves.toBeUndefined();
@@ -199,6 +215,7 @@ test('creates the doc-i18n template', async () => {
 
   expect(packageJson.name).toBe('my-app');
   expect(packageJson.scripts.check).toBe(tsCheckScript);
+  await expectStagedSetup(projectDirectory, 'ts', packageJson.scripts);
 
   await expect(access(path.join(projectDirectory, 'rstack.config.ts'))).resolves.toBeUndefined();
   await expect(
@@ -280,6 +297,7 @@ test.each([
 
     expect(packageJson.name).toBe('my-app');
     expect(packageJson.scripts.check).toBe(getCheckScript(template, hasTypeScript));
+    await expectStagedSetup(projectDirectory, configExtension, packageJson.scripts);
 
     await expect(
       access(path.join(projectDirectory, `rstack.config.${configExtension}`)),


### PR DESCRIPTION
This PR gives generated projects a ready-to-use pre-commit workflow so staged files are linted and formatted consistently.

Every create-rstack template now configures `define.staged`, runs `rs setup` from `prepare`, and receives a shared `pre-commit` hook that invokes `rs staged`. Vue and Svelte templates include their component extensions in formatting tasks.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/263