### PR TITLE
feat(create-rstack): support --no-git

### DIFF
--- a/packages/create-rstack/README.md
+++ b/packages/create-rstack/README.md
@@ -17,6 +17,9 @@ npx create-rstack --dir my-project --template app-vanilla-ts
 
 # Using abbreviations
 npx create-rstack -d my-project -t app-vanilla-ts
+
+# Skip Git initialization
+npx create-rstack --dir my-project --template app-vanilla-ts --no-git
 ```
 
 ## Templates

--- a/packages/create-rstack/src/index.ts
+++ b/packages/create-rstack/src/index.ts
@@ -135,5 +135,6 @@ await create({
     'doc-i18n',
   ],
   builtinTools: [],
+  git: !process.argv.includes('--no-git'),
   getTemplateName,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ catalogs:
       specifier: 1.14.7
       version: 1.14.7
     '@rstackjs/create-toolkit':
-      specifier: 2.1.5
-      version: 2.1.5
+      specifier: 2.2.0
+      version: 2.2.0
     '@rstackjs/load-config':
       specifier: ^0.1.2
       version: 0.1.2
@@ -335,7 +335,7 @@ importers:
     dependencies:
       '@rstackjs/create-toolkit':
         specifier: 'catalog:'
-        version: 2.1.5
+        version: 2.2.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1434,8 +1434,8 @@ packages:
       '@rspress/core':
         optional: true
 
-  '@rstackjs/create-toolkit@2.1.5':
-    resolution: {integrity: sha512-55hmJqJJbyvdz9ET2NLXpQ+AF1+keb75duvLXMEU423sEPM1e8GdIE7aS3ODsXYKJ7CoYphDjVkcaDeB0TS5uw==}
+  '@rstackjs/create-toolkit@2.2.0':
+    resolution: {integrity: sha512-FYoJSxELw7E2qsq88GnkOSugG00KwczMVAtzG5qawwYIYdGgHa2ljW1Omm3xHbVfPshGzZJIKlfjcxlTxUVwMw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@rstackjs/load-config@0.1.2':
@@ -3843,7 +3843,7 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.19(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
-  '@rstackjs/create-toolkit@2.1.5': {}
+  '@rstackjs/create-toolkit@2.2.0': {}
 
   '@rstackjs/load-config@0.1.2': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ catalogs:
       specifier: ^20.11.1
       version: 20.11.1
     heading-case:
-      specifier: ^1.1.4
-      version: 1.1.4
+      specifier: ^1.1.5
+      version: 1.1.5
     ignore:
       specifier: 7.0.6
       version: 7.0.6
@@ -152,7 +152,7 @@ importers:
         version: 0.0.4
       heading-case:
         specifier: 'catalog:'
-        version: 1.1.4
+        version: 1.1.5
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -2121,8 +2121,8 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  heading-case@1.1.4:
-    resolution: {integrity: sha512-UwPg0xcqLrmd6kSW93kxjy4FMqcb0o97IoTUy+TMvjCF8mJvi6X0h733DEaJO/Ch9h9dOyv0I0ckGoSsuUp9KA==}
+  heading-case@1.1.5:
+    resolution: {integrity: sha512-dVZmEJLF5vK2IV3LLpEWgyy0wbe4W+vsUzuHy6KE440IClTXR5GIGDGwiawHqCqunsqos4nvOBpnLGUrUv3BUg==}
     hasBin: true
 
   hookable@6.1.1:
@@ -4490,7 +4490,7 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
-  heading-case@1.1.4: {}
+  heading-case@1.1.5: {}
 
   hookable@6.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,7 +39,7 @@ catalog:
   'cspell-ban-words': '^0.0.4'
   'fast-json-stable-stringify': '2.1.0'
   'happy-dom': '^20.11.1'
-  'heading-case': '^1.1.4'
+  'heading-case': '^1.1.5'
   ignore: 7.0.6
   'import-meta-resolve': '4.2.0'
   is-binary-path: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@rspress/plugin-client-redirects': '^2.0.19'
   '@rspress/plugin-sitemap': '^2.0.19'
   '@rstack-dev/doc-ui': '1.14.7'
-  '@rstackjs/create-toolkit': '2.1.5'
+  '@rstackjs/create-toolkit': '2.2.0'
   '@rstackjs/load-config': ^0.1.2
   '@rstackjs/test-utils': ^0.2.0
   '@rstest/adapter-rsbuild': '~0.11.5'


### PR DESCRIPTION
## Summary

This PR makes create-rstack initialize a Git repository by default while allowing users to opt out with `--no-git`.
It upgrades `@rstackjs/create-toolkit` to v2.2.0 and forwards the CLI preference through its `git` option.
It also upgrades `heading-case` to v1.1.5 so correctly capitalized product names such as Git pass heading validation.

## Related Links

- https://github.com/rstackjs/create-toolkit/releases/tag/v2.2.0
- https://github.com/rstackjs/heading-case/releases/tag/v1.1.5