### PR TITLE
refactor(create-rstack): use Vue Test Utils in templates

### DIFF
--- a/packages/create-rstack/template-app-vue-js/package.json
+++ b/packages/create-rstack/template-app-vue-js/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "@rsbuild/plugin-vue": "^2.0.1",
     "@testing-library/jest-dom": "^7.0.0",
-    "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.1",
     "rstack": "^0.3.5"

--- a/packages/create-rstack/template-app-vue-js/tests/index.test.js
+++ b/packages/create-rstack/template-app-vue-js/tests/index.test.js
@@ -1,8 +1,8 @@
 import { expect, test } from 'rstack/test';
-import { render, screen } from '@testing-library/vue';
+import { mount } from '@vue/test-utils';
 import App from '../src/App.vue';
 
 test('renders the main page', () => {
-  render(App);
-  expect(screen.getByText('Rstack with Vue')).toBeInTheDocument();
+  const wrapper = mount(App);
+  expect(wrapper.element).toHaveTextContent('Rstack with Vue');
 });

--- a/packages/create-rstack/template-app-vue-ts/package.json
+++ b/packages/create-rstack/template-app-vue-ts/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "@rsbuild/plugin-vue": "^2.0.1",
     "@testing-library/jest-dom": "^7.0.0",
-    "@testing-library/vue": "^8.1.0",
     "@types/node": "^24.13.3",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.1",

--- a/packages/create-rstack/template-app-vue-ts/tests/index.test.ts
+++ b/packages/create-rstack/template-app-vue-ts/tests/index.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from 'rstack/test';
-import { render, screen } from '@testing-library/vue';
+import { mount } from '@vue/test-utils';
 import App from '../src/App.vue';
 
 test('renders the main page', () => {
-  render(App);
-  expect(screen.getByText('Rstack with Vue')).toBeInTheDocument();
+  const wrapper = mount(App);
+  expect(wrapper.element).toHaveTextContent('Rstack with Vue');
 });

--- a/packages/create-rstack/template-lib-vue-js/package.json
+++ b/packages/create-rstack/template-lib-vue-js/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "@rsbuild/plugin-vue": "^2.0.1",
     "@testing-library/jest-dom": "^7.0.0",
-    "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.1",
     "rstack": "^0.3.5",

--- a/packages/create-rstack/template-lib-vue-js/tests/index.test.js
+++ b/packages/create-rstack/template-lib-vue-js/tests/index.test.js
@@ -1,16 +1,17 @@
 import { expect, test } from 'rstack/test';
-import { render, screen } from '@testing-library/vue';
+import { mount } from '@vue/test-utils';
 import Button from '../src/Button.vue';
 
-test('The button should have correct background color', async () => {
-  render(Button, {
+test('The button should have correct background color', () => {
+  const wrapper = mount(Button, {
+    attachTo: document.body,
     props: {
       backgroundColor: '#ccc',
       label: 'Demo Button',
     },
   });
-  const button = screen.getByText('Demo Button');
-  expect(button).toHaveStyle({
+  expect(wrapper.get('button').element).toHaveStyle({
     backgroundColor: '#ccc',
   });
+  wrapper.unmount();
 });

--- a/packages/create-rstack/template-lib-vue-ts/package.json
+++ b/packages/create-rstack/template-lib-vue-ts/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@rsbuild/plugin-vue": "^2.0.1",
     "@testing-library/jest-dom": "^7.0.0",
-    "@testing-library/vue": "^8.1.0",
     "@types/node": "^24.13.3",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.1",

--- a/packages/create-rstack/template-lib-vue-ts/tests/index.test.ts
+++ b/packages/create-rstack/template-lib-vue-ts/tests/index.test.ts
@@ -1,16 +1,17 @@
 import { expect, test } from 'rstack/test';
-import { render, screen } from '@testing-library/vue';
+import { mount } from '@vue/test-utils';
 import Button from '../src/Button.vue';
 
-test('The button should have correct background color', async () => {
-  render(Button, {
+test('The button should have correct background color', () => {
+  const wrapper = mount(Button, {
+    attachTo: document.body,
     props: {
       backgroundColor: '#ccc',
       label: 'Demo Button',
     },
   });
-  const button = screen.getByText('Demo Button');
-  expect(button).toHaveStyle({
+  expect(wrapper.get('button').element).toHaveStyle({
     backgroundColor: '#ccc',
   });
+  wrapper.unmount();
 });


### PR DESCRIPTION
## Summary

`@testing-library/vue` has seen limited maintenance and receives substantially fewer weekly npm downloads than Vue Test Utils, the official Vue component testing utility. This PR removes `@testing-library/vue` from all Vue app and library templates and updates their default tests to use `@vue/test-utils` directly.

## Related Links

- https://www.npmjs.com/package/@testing-library/vue
- https://www.npmjs.com/package/@vue/test-utils