### PR TITLE
ci(release): pin release workflow to dispatched commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,6 @@ on:
           - rc
           - canary
           - latest
-      branch:
-        description: 'Release Branch (confirm release branch)'
-        required: true
-        default: 'main'
-
 permissions: {}
 
 jobs:
@@ -65,7 +60,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
-          ref: ${{ github.event.inputs.branch }}
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
This PR ensures manual releases use the commit selected when the workflow is dispatched, even if the selected branch advances before the release job starts. It removes the redundant branch confirmation input and lets `actions/checkout` use the workflow event commit instead of resolving a mutable branch name.