### PR TITLE
fix(create-rstack): auto unmount Vue wrappers in templates

### DIFF
--- a/packages/create-rstack/template-app-vue-js/tests/rstest.setup.js
+++ b/packages/create-rstack/template-app-vue-js/tests/rstest.setup.js
@@ -1,4 +1,6 @@
-import { expect } from 'rstack/test';
+import { afterEach, expect } from 'rstack/test';
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+import { enableAutoUnmount } from '@vue/test-utils';
 
 expect.extend(jestDomMatchers);
+enableAutoUnmount(afterEach);

--- a/packages/create-rstack/template-app-vue-ts/tests/rstest.setup.ts
+++ b/packages/create-rstack/template-app-vue-ts/tests/rstest.setup.ts
@@ -1,4 +1,6 @@
-import { expect } from 'rstack/test';
+import { afterEach, expect } from 'rstack/test';
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+import { enableAutoUnmount } from '@vue/test-utils';
 
 expect.extend(jestDomMatchers);
+enableAutoUnmount(afterEach);

--- a/packages/create-rstack/template-lib-vue-js/tests/rstest.setup.js
+++ b/packages/create-rstack/template-lib-vue-js/tests/rstest.setup.js
@@ -1,4 +1,6 @@
-import { expect } from 'rstack/test';
+import { afterEach, expect } from 'rstack/test';
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+import { enableAutoUnmount } from '@vue/test-utils';
 
 expect.extend(jestDomMatchers);
+enableAutoUnmount(afterEach);

--- a/packages/create-rstack/template-lib-vue-ts/tests/rstest.setup.ts
+++ b/packages/create-rstack/template-lib-vue-ts/tests/rstest.setup.ts
@@ -1,4 +1,6 @@
-import { expect } from 'rstack/test';
+import { afterEach, expect } from 'rstack/test';
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+import { enableAutoUnmount } from '@vue/test-utils';
 
 expect.extend(jestDomMatchers);
+enableAutoUnmount(afterEach);


### PR DESCRIPTION
Vue Test Utils does not automatically unmount wrappers created with `mount`, allowing lifecycle side effects to leak between tests in generated projects.

This PR calls `enableAutoUnmount(afterEach)` from the shared Rstest setup in all Vue app and library templates.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8238