### PR TITLE
feat(create-rstack): add pnpm config to Svelte libraries

### DIFF
--- a/packages/create-rstack/src/index.ts
+++ b/packages/create-rstack/src/index.ts
@@ -135,6 +135,5 @@ await create({
     'doc-i18n',
   ],
   builtinTools: [],
-  git: !process.argv.includes('--no-git'),
   getTemplateName,
 });

--- a/packages/create-rstack/template-lib-svelte-js/pnpm-workspace.yaml
+++ b/packages/create-rstack/template-lib-svelte-js/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  svelte-preprocess: false

--- a/packages/create-rstack/template-lib-svelte-ts/pnpm-workspace.yaml
+++ b/packages/create-rstack/template-lib-svelte-ts/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  svelte-preprocess: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ catalogs:
       specifier: 1.14.7
       version: 1.14.7
     '@rstackjs/create-toolkit':
-      specifier: 2.2.0
-      version: 2.2.0
+      specifier: 2.2.1
+      version: 2.2.1
     '@rstackjs/load-config':
       specifier: ^0.1.2
       version: 0.1.2
@@ -335,7 +335,7 @@ importers:
     dependencies:
       '@rstackjs/create-toolkit':
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.2.1
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1434,8 +1434,8 @@ packages:
       '@rspress/core':
         optional: true
 
-  '@rstackjs/create-toolkit@2.2.0':
-    resolution: {integrity: sha512-FYoJSxELw7E2qsq88GnkOSugG00KwczMVAtzG5qawwYIYdGgHa2ljW1Omm3xHbVfPshGzZJIKlfjcxlTxUVwMw==}
+  '@rstackjs/create-toolkit@2.2.1':
+    resolution: {integrity: sha512-zH0wfbjU8caMuCNn9PWp49u4Y6XuB40RBkuwM8Vo40XGeqWs8RkP527ojmDIPqm4dL3ojRksHYsKy1ROGSXBoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@rstackjs/load-config@0.1.2':
@@ -3843,7 +3843,7 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.19(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
-  '@rstackjs/create-toolkit@2.2.0': {}
+  '@rstackjs/create-toolkit@2.2.1': {}
 
   '@rstackjs/load-config@0.1.2': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@rspress/plugin-client-redirects': '^2.0.19'
   '@rspress/plugin-sitemap': '^2.0.19'
   '@rstack-dev/doc-ui': '1.14.7'
-  '@rstackjs/create-toolkit': '2.2.0'
+  '@rstackjs/create-toolkit': '2.2.1'
   '@rstackjs/load-config': ^0.1.2
   '@rstackjs/test-utils': ^0.2.0
   '@rstest/adapter-rsbuild': '~0.11.5'


### PR DESCRIPTION
## Summary

Generated Svelte library projects need an explicit pnpm build-script policy for `svelte-preprocess`. This PR adds `pnpm-workspace.yaml` to the JavaScript and TypeScript templates and upgrades create-toolkit to v2.2.1 so the file is copied only when pnpm is selected. It also relies on the toolkit's built-in `--no-git` handling instead of forwarding the option manually.

## Related Links

- https://github.com/rstackjs/create-toolkit/releases/tag/v2.2.1