### PR TITLE
ci(release): stage native binding packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,17 @@ jobs:
           fi
           echo "npm_tag validation passed: $NPM_TAG"
 
+  native:
+    name: Build native packages
+    needs: validate_inputs
+    permissions:
+      contents: read
+    uses: ./.github/workflows/reusable-native-release.yml
+
   release:
     name: Release
     if: github.repository == 'rstackjs/rstack-cli' && github.event_name == 'workflow_dispatch'
-    needs: validate_inputs
+    needs: native
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -78,6 +85,21 @@ jobs:
       - name: Prepare release
         run: node --run release:prepare
 
+      - name: Download native packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: native-packages
+          path: packages/rstack/npm
+
+      - name: Prepare native packages
+        run: pnpm --dir packages/rstack exec napi pre-publish --config-path napi.json --skip-optional-publish --no-gh-release
+
       - name: Publish to npm
+        env:
+          NPM_TAG: ${{ inputs.npm_tag }}
         run: |
-          pnpm --filter './packages/*' -r stage publish --tag ${{ github.event.inputs.npm_tag }} --no-git-checks
+          for package_dir in packages/rstack/npm/*; do
+            pnpm stage publish "$package_dir" --tag "$NPM_TAG" --no-git-checks
+          done
+
+          pnpm --filter './packages/*' -r stage publish --tag "$NPM_TAG" --no-git-checks


### PR DESCRIPTION
This PR connects the Tier 1 native package artifacts to the existing manual staged release so `rstack` can ship its platform-specific optional dependencies. The release reconciles native package metadata with NAPI-RS, while keeping npm and GitHub publishing disabled there, then stages every platform package before the existing workspace packages through pnpm.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/270