### PR TITLE
docs: add AI guide

### DIFF
--- a/website/docs/en/guide/_meta.json
+++ b/website/docs/en/guide/_meta.json
@@ -15,6 +15,11 @@
   },
   {
     "type": "file",
+    "name": "ai",
+    "label": "AI"
+  },
+  {
+    "type": "file",
     "name": "api-reference",
     "label": "API reference"
   },

--- a/website/docs/en/guide/ai.mdx
+++ b/website/docs/en/guide/ai.mdx
@@ -1,0 +1,81 @@
+---
+description: 'Use Rstack CLI with coding agents through Agent Skills, llms.txt, Markdown docs, and AGENTS.md.'
+---
+
+import { PackageManagerTabs } from '@rspress/core/theme';
+
+# AI
+
+To help coding agents understand Rstack CLI commands, configuration, and best practices, Rstack CLI provides the following resources:
+
+- [AGENTS.md](#agentsmd)
+- [Agent Skills](#agent-skills)
+- [llms.txt](#llmstxt)
+- [Markdown docs](#markdown-docs)
+
+## AGENTS.md
+
+Projects created with [create-rstack](https://www.npmjs.com/package/create-rstack) include an [`AGENTS.md`](https://agents.md/) file that gives coding agents the key context for working with Rstack CLI.
+
+You can also copy the following content into your own `AGENTS.md`:
+
+```markdown wrapCode title="AGENTS.md"
+This project uses Rstack CLI as its JavaScript toolchain.
+
+- Before working with `rs` commands, `rstack.config.*` files, or imports from `rstack`, start with `node_modules/rstack/dist/docs/llms.txt`, then read only the linked pages relevant to the task.
+- For command details, use `rs -h` or `rs <command> -h`.
+- If the local documentation is unavailable, use https://rstack.rs/llms.txt and `rs <command> -h`.
+```
+
+This content serves a similar purpose to the [rstack-cli-best-practices](#rstack-cli-best-practices) Skill, helping coding agents use Rstack CLI and find relevant documentation. Add it to `AGENTS.md` or install the Skill; either is sufficient.
+
+## Agent Skills
+
+Rstack CLI provides domain-specific Agent Skills that help coding agents give more accurate guidance and perform relevant tasks.
+
+### rstack-cli-best-practices
+
+The [rstack-cli-best-practices](https://github.com/rstackjs/rstack-cli/tree/main/.agents/skills/rstack-cli-best-practices) Skill provides guidance and best practices for using Rstack CLI.
+
+Install it with the [skills](https://www.npmjs.com/package/skills) package:
+
+<PackageManagerTabs
+  command="skills add rstackjs/rstack-cli --skill rstack-cli-best-practices"
+  dlx
+/>
+
+### migrate-to-rstack-cli
+
+The [migrate-to-rstack-cli](https://github.com/rstackjs/rstack-cli/tree/main/.agents/skills/migrate-to-rstack-cli) Skill migrates projects from standalone Rstack tools and related development tools to Rstack CLI.
+
+To migrate an existing project, install the Skill:
+
+<PackageManagerTabs command="skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli" dlx />
+
+For supported tools and migration instructions, see [Migrate to Rstack CLI](./migration).
+
+## llms.txt
+
+[llms.txt](https://llmstxt.org/) is a standard that helps LLMs discover and use project documentation. The Rstack CLI documentation site provides the following files:
+
+- [llms.txt](https://rstack.rs/llms.txt): A structured index containing the title, link, and description of each documentation page.
+
+```text
+https://rstack.rs/llms.txt
+```
+
+- [llms-full.txt](https://rstack.rs/llms-full.txt): A single file containing the full content of all documentation pages.
+
+```text
+https://rstack.rs/llms-full.txt
+```
+
+Use `llms.txt` when the agent can follow links and load only the pages relevant to a task. Use `llms-full.txt` when the agent needs the complete documentation in one context and the larger token cost is acceptable.
+
+## Markdown docs
+
+Every Rstack CLI documentation page has a corresponding `.md` plain-text version that can be provided directly to an agent. On any documentation page, use “Copy Markdown” or “Copy Markdown Link” under the title to copy its content or URL.
+
+```text
+https://rstack.rs/guide/quick-start.md
+```

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -1,3 +1,7 @@
+---
+description: 'Install Rstack CLI, add project scripts, and configure the Rstack JavaScript toolchain.'
+---
+
 # Quick start
 
 import { PackageManagerTabs } from '@rspress/core/theme';
@@ -88,22 +92,6 @@ define.lint({
 
 See [Configuration](./configuration) for all available configuration APIs.
 
-## Skills
+## AI
 
-### Best practice
-
-Install the Rstack CLI skill so the agent can understand how to use it:
-
-```bash
-npx skills add rstackjs/rstack-cli --skill rstack-cli-best-practices
-```
-
-### Migration
-
-Install the migration skill so the agent can migrate existing projects to Rstack CLI:
-
-```bash
-npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
-```
-
-For supported tools and migration instructions, see [Migrate to Rstack CLI](./migration).
+To learn how to use Rstack CLI with coding agents, see the [AI guide](./ai).

--- a/website/docs/zh/guide/_meta.json
+++ b/website/docs/zh/guide/_meta.json
@@ -15,6 +15,11 @@
   },
   {
     "type": "file",
+    "name": "ai",
+    "label": "AI"
+  },
+  {
+    "type": "file",
     "name": "api-reference",
     "label": "API 参考"
   },

--- a/website/docs/zh/guide/ai.mdx
+++ b/website/docs/zh/guide/ai.mdx
@@ -1,0 +1,81 @@
+---
+description: '通过 Agent Skills、llms.txt、Markdown 文档和 AGENTS.md，配合 Coding Agent 使用 Rstack CLI。'
+---
+
+import { PackageManagerTabs } from '@rspress/core/theme';
+
+# AI
+
+为了帮助 Coding Agent 理解 Rstack CLI 的命令、配置和最佳实践，Rstack CLI 提供了以下资源：
+
+- [AGENTS.md](#agentsmd)
+- [Agent Skills](#agent-skills)
+- [llms.txt](#llmstxt)
+- [Markdown 文档](#markdown-docs)
+
+## AGENTS.md
+
+使用 [create-rstack](https://www.npmjs.com/package/create-rstack) 创建的项目会包含一个遵循 [`AGENTS.md`](https://agents.md/) 规范的文件，为 Coding Agent 提供使用 Rstack CLI 所需的关键上下文。
+
+你也可以将以下内容复制到自己的 `AGENTS.md` 中：
+
+```markdown wrapCode title="AGENTS.md"
+This project uses Rstack CLI as its JavaScript toolchain.
+
+- Before working with `rs` commands, `rstack.config.*` files, or imports from `rstack`, start with `node_modules/rstack/dist/docs/llms.txt`, then read only the linked pages relevant to the task.
+- For command details, use `rs -h` or `rs <command> -h`.
+- If the local documentation is unavailable, use https://rstack.rs/llms.txt and `rs <command> -h`.
+```
+
+这段内容与 [rstack-cli-best-practices](#rstack-cli-best-practices) Skill 作用相似，都能指导 Coding Agent 使用 Rstack CLI 并查找相关文档。将其添加到 `AGENTS.md` 或安装该 Skill，任选其一即可。
+
+## Agent Skills
+
+Rstack CLI 提供面向特定领域的 Agent Skills，帮助 Coding Agent 更准确地提供建议并执行相关任务。
+
+### rstack-cli-best-practices
+
+[rstack-cli-best-practices](https://github.com/rstackjs/rstack-cli/tree/main/.agents/skills/rstack-cli-best-practices) Skill 提供 Rstack CLI 的使用指南和最佳实践。
+
+使用 [skills](https://www.npmjs.com/package/skills) 包安装该 Skill：
+
+<PackageManagerTabs
+  command="skills add rstackjs/rstack-cli --skill rstack-cli-best-practices"
+  dlx
+/>
+
+### migrate-to-rstack-cli
+
+[migrate-to-rstack-cli](https://github.com/rstackjs/rstack-cli/tree/main/.agents/skills/migrate-to-rstack-cli) Skill 可以将使用独立 Rstack 工具及相关开发工具的项目迁移到 Rstack CLI。
+
+迁移现有项目时，安装该 Skill：
+
+<PackageManagerTabs command="skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli" dlx />
+
+支持的工具和迁移说明请参阅[迁移到 Rstack CLI](./migration)。
+
+## llms.txt
+
+[llms.txt](https://llmstxt.org/) 是一种帮助 LLM 发现和使用项目文档的标准规范。Rstack CLI 文档站提供了以下文件：
+
+- [llms.txt](https://rstack.rs/zh/llms.txt)：结构化索引文件，包含每篇文档的标题、链接和描述。
+
+```text
+https://rstack.rs/zh/llms.txt
+```
+
+- [llms-full.txt](https://rstack.rs/zh/llms-full.txt)：包含所有文档完整内容的单个文件。
+
+```text
+https://rstack.rs/zh/llms-full.txt
+```
+
+当 Agent 可以按需跟随链接并只加载与任务相关的页面时，使用 `llms.txt`。当 Agent 需要在同一上下文中读取完整文档，并且可以接受更多 token 消耗时，使用 `llms-full.txt`。
+
+## Markdown 文档 \{#markdown-docs}
+
+Rstack CLI 的每篇文档都有对应的 `.md` 纯文本版本，可以直接提供给 Agent。在任意文档页面的标题下方使用「复制 Markdown」或「复制 Markdown 链接」，即可复制文档内容或 URL。
+
+```text
+https://rstack.rs/zh/guide/quick-start.md
+```

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -1,3 +1,7 @@
+---
+description: '安装 Rstack CLI、添加项目脚本，并配置 Rstack JavaScript 工具链。'
+---
+
 # 快速上手 \{#quick-start}
 
 import { PackageManagerTabs } from '@rspress/core/theme';
@@ -88,22 +92,6 @@ define.lint({
 
 所有可用的配置 API 请参见[配置](./configuration)。
 
-## Skills \{#skills}
+## AI
 
-### 最佳实践 \{#best-practice}
-
-安装 Rstack CLI Skill，使 Agent 能够了解如何使用 Rstack CLI：
-
-```bash
-npx skills add rstackjs/rstack-cli --skill rstack-cli-best-practices
-```
-
-### 迁移 \{#migration}
-
-安装迁移 Skill，使 Agent 能够将现有项目迁移到 Rstack CLI：
-
-```bash
-npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
-```
-
-支持的工具和迁移说明请参阅[迁移到 Rstack CLI](./migration)。
+如需了解如何配合 Coding Agent 使用 Rstack CLI，请参阅 [AI 指南](./ai)。


### PR DESCRIPTION
## Summary

This PR adds a dedicated bilingual AI guide for using Rstack CLI with coding agents. It moves the Skill guidance out of Quick start, documents AGENTS.md, Agent Skills, llms.txt, and Markdown docs, and adds the new page to both sidebars.