### PR TITLE
refactor: move package docs outside dist

### DIFF
--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -16,7 +16,7 @@ Before any Rstack work, find and read the relevant Markdown documentation shippe
 
 Model knowledge can be outdated; the installed documentation is the source of truth for the project's Rstack version.
 
-1. Start with `node_modules/rstack/dist/docs/llms.txt`, then read only the linked pages relevant to the task before proposing or making changes.
+1. Start with `node_modules/rstack/docs/llms.txt`, then read only the linked pages relevant to the task before proposing or making changes.
 
 2. For exact CLI flags and behavior, also run `rs -h` or `rs <command> -h` when supported.
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 node_modules
 dist/
 dist-*/
+/packages/rstack/docs/
 test-results
 doc_build
 

--- a/packages/create-rstack/template-common/AGENTS.md
+++ b/packages/create-rstack/template-common/AGENTS.md
@@ -2,6 +2,6 @@
 
 This project uses Rstack CLI as its JavaScript toolchain.
 
-- Before working with `rs` commands, `rstack.config.*` files, or imports from `rstack`, start with `node_modules/rstack/dist/docs/llms.txt`, then read only the linked pages relevant to the task.
+- Before working with `rs` commands, `rstack.config.*` files, or imports from `rstack`, start with `node_modules/rstack/docs/llms.txt`, then read only the linked pages relevant to the task.
 - For command details, use `rs -h` or `rs <command> -h`.
 - If the local documentation is unavailable, use https://rstack.rs/llms.txt and `rs <command> -h`.

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -59,6 +59,7 @@
     "binding.cjs",
     "binding.d.cts",
     "dist",
+    "docs",
     "types",
     "THIRD_PARTY_NOTICES.md"
   ],

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -7,7 +7,6 @@ const rootDir = path.resolve(import.meta.dirname, '..');
 const websiteDir = path.join(rootDir, 'website');
 const websiteDistDir = path.join(websiteDir, 'doc_build');
 const packageDocsDir = path.join(rootDir, 'packages/rstack/docs');
-const legacyPackageDocsDir = path.join(rootDir, 'packages/rstack/dist/docs');
 
 const run = (command, args) =>
   new Promise((resolve, reject) => {
@@ -64,10 +63,7 @@ if (markdownFiles.length === 0) {
   throw new Error(`No English Markdown files found in ${websiteDistDir}.`);
 }
 
-await Promise.all([
-  rm(packageDocsDir, { recursive: true, force: true }),
-  rm(legacyPackageDocsDir, { recursive: true, force: true }),
-]);
+await rm(packageDocsDir, { recursive: true, force: true });
 
 for (const relativePath of markdownFiles) {
   const destination = path.join(packageDocsDir, relativePath);

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -6,7 +6,8 @@ import path from 'node:path';
 const rootDir = path.resolve(import.meta.dirname, '..');
 const websiteDir = path.join(rootDir, 'website');
 const websiteDistDir = path.join(websiteDir, 'doc_build');
-const packageDocsDir = path.join(rootDir, 'packages/rstack/dist/docs');
+const packageDocsDir = path.join(rootDir, 'packages/rstack/docs');
+const legacyPackageDocsDir = path.join(rootDir, 'packages/rstack/dist/docs');
 
 const run = (command, args) =>
   new Promise((resolve, reject) => {
@@ -63,7 +64,10 @@ if (markdownFiles.length === 0) {
   throw new Error(`No English Markdown files found in ${websiteDistDir}.`);
 }
 
-await rm(packageDocsDir, { recursive: true, force: true });
+await Promise.all([
+  rm(packageDocsDir, { recursive: true, force: true }),
+  rm(legacyPackageDocsDir, { recursive: true, force: true }),
+]);
 
 for (const relativePath of markdownFiles) {
   const destination = path.join(packageDocsDir, relativePath);

--- a/website/docs/en/guide/ai.mdx
+++ b/website/docs/en/guide/ai.mdx
@@ -22,7 +22,7 @@ You can also copy the following content into your own `AGENTS.md`:
 ```markdown wrapCode title="AGENTS.md"
 This project uses Rstack CLI as its JavaScript toolchain.
 
-- Before working with `rs` commands, `rstack.config.*` files, or imports from `rstack`, start with `node_modules/rstack/dist/docs/llms.txt`, then read only the linked pages relevant to the task.
+- Before working with `rs` commands, `rstack.config.*` files, or imports from `rstack`, start with `node_modules/rstack/docs/llms.txt`, then read only the linked pages relevant to the task.
 - For command details, use `rs -h` or `rs <command> -h`.
 - If the local documentation is unavailable, use https://rstack.rs/llms.txt and `rs <command> -h`.
 ```

--- a/website/docs/zh/guide/ai.mdx
+++ b/website/docs/zh/guide/ai.mdx
@@ -22,7 +22,7 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 ```markdown wrapCode title="AGENTS.md"
 This project uses Rstack CLI as its JavaScript toolchain.
 
-- Before working with `rs` commands, `rstack.config.*` files, or imports from `rstack`, start with `node_modules/rstack/dist/docs/llms.txt`, then read only the linked pages relevant to the task.
+- Before working with `rs` commands, `rstack.config.*` files, or imports from `rstack`, start with `node_modules/rstack/docs/llms.txt`, then read only the linked pages relevant to the task.
 - For command details, use `rs -h` or `rs <command> -h`.
 - If the local documentation is unavailable, use https://rstack.rs/llms.txt and `rs <command> -h`.
 ```


### PR DESCRIPTION
## Summary

This PR moves the documentation bundled with `rstack` from `dist/docs` to the top-level `docs` directory, providing a shorter and clearer local documentation path. It updates release packaging, create-rstack instructions, the bilingual AI guide, and the best-practices Skill to use `node_modules/rstack/docs/llms.txt`.