### PR TITLE
build(native): use CLI platform package names

### DIFF
--- a/packages/rstack/binding.cjs
+++ b/packages/rstack/binding.cjs
@@ -75,8 +75,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-android-arm64')
-        const bindingPackageVersion = require('@rstackjs/binding-android-arm64/package.json').version
+        const binding = require('@rstackjs/cli-android-arm64')
+        const bindingPackageVersion = require('@rstackjs/cli-android-arm64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -91,8 +91,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-android-arm-eabi')
-        const bindingPackageVersion = require('@rstackjs/binding-android-arm-eabi/package.json').version
+        const binding = require('@rstackjs/cli-android-arm-eabi')
+        const bindingPackageVersion = require('@rstackjs/cli-android-arm-eabi/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -112,8 +112,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-win32-x64-gnu')
-        const bindingPackageVersion = require('@rstackjs/binding-win32-x64-gnu/package.json').version
+        const binding = require('@rstackjs/cli-win32-x64-gnu')
+        const bindingPackageVersion = require('@rstackjs/cli-win32-x64-gnu/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -128,8 +128,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-win32-x64-msvc')
-        const bindingPackageVersion = require('@rstackjs/binding-win32-x64-msvc/package.json').version
+        const binding = require('@rstackjs/cli-win32-x64-msvc')
+        const bindingPackageVersion = require('@rstackjs/cli-win32-x64-msvc/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -145,8 +145,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-win32-ia32-msvc')
-        const bindingPackageVersion = require('@rstackjs/binding-win32-ia32-msvc/package.json').version
+        const binding = require('@rstackjs/cli-win32-ia32-msvc')
+        const bindingPackageVersion = require('@rstackjs/cli-win32-ia32-msvc/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -161,8 +161,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-win32-arm64-msvc')
-        const bindingPackageVersion = require('@rstackjs/binding-win32-arm64-msvc/package.json').version
+        const binding = require('@rstackjs/cli-win32-arm64-msvc')
+        const bindingPackageVersion = require('@rstackjs/cli-win32-arm64-msvc/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -180,8 +180,8 @@ function requireNative() {
       loadErrors.push(e)
     }
     try {
-      const binding = require('@rstackjs/binding-darwin-universal')
-      const bindingPackageVersion = require('@rstackjs/binding-darwin-universal/package.json').version
+      const binding = require('@rstackjs/cli-darwin-universal')
+      const bindingPackageVersion = require('@rstackjs/cli-darwin-universal/package.json').version
       if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
         throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
@@ -196,8 +196,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-darwin-x64')
-        const bindingPackageVersion = require('@rstackjs/binding-darwin-x64/package.json').version
+        const binding = require('@rstackjs/cli-darwin-x64')
+        const bindingPackageVersion = require('@rstackjs/cli-darwin-x64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -212,8 +212,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-darwin-arm64')
-        const bindingPackageVersion = require('@rstackjs/binding-darwin-arm64/package.json').version
+        const binding = require('@rstackjs/cli-darwin-arm64')
+        const bindingPackageVersion = require('@rstackjs/cli-darwin-arm64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -232,8 +232,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-freebsd-x64')
-        const bindingPackageVersion = require('@rstackjs/binding-freebsd-x64/package.json').version
+        const binding = require('@rstackjs/cli-freebsd-x64')
+        const bindingPackageVersion = require('@rstackjs/cli-freebsd-x64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -248,8 +248,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-freebsd-arm64')
-        const bindingPackageVersion = require('@rstackjs/binding-freebsd-arm64/package.json').version
+        const binding = require('@rstackjs/cli-freebsd-arm64')
+        const bindingPackageVersion = require('@rstackjs/cli-freebsd-arm64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -269,8 +269,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@rstackjs/binding-linux-x64-musl')
-          const bindingPackageVersion = require('@rstackjs/binding-linux-x64-musl/package.json').version
+          const binding = require('@rstackjs/cli-linux-x64-musl')
+          const bindingPackageVersion = require('@rstackjs/cli-linux-x64-musl/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -285,8 +285,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@rstackjs/binding-linux-x64-gnu')
-          const bindingPackageVersion = require('@rstackjs/binding-linux-x64-gnu/package.json').version
+          const binding = require('@rstackjs/cli-linux-x64-gnu')
+          const bindingPackageVersion = require('@rstackjs/cli-linux-x64-gnu/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -303,8 +303,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@rstackjs/binding-linux-arm64-musl')
-          const bindingPackageVersion = require('@rstackjs/binding-linux-arm64-musl/package.json').version
+          const binding = require('@rstackjs/cli-linux-arm64-musl')
+          const bindingPackageVersion = require('@rstackjs/cli-linux-arm64-musl/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -319,8 +319,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@rstackjs/binding-linux-arm64-gnu')
-          const bindingPackageVersion = require('@rstackjs/binding-linux-arm64-gnu/package.json').version
+          const binding = require('@rstackjs/cli-linux-arm64-gnu')
+          const bindingPackageVersion = require('@rstackjs/cli-linux-arm64-gnu/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -337,8 +337,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@rstackjs/binding-linux-arm-musleabihf')
-          const bindingPackageVersion = require('@rstackjs/binding-linux-arm-musleabihf/package.json').version
+          const binding = require('@rstackjs/cli-linux-arm-musleabihf')
+          const bindingPackageVersion = require('@rstackjs/cli-linux-arm-musleabihf/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -353,8 +353,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@rstackjs/binding-linux-arm-gnueabihf')
-          const bindingPackageVersion = require('@rstackjs/binding-linux-arm-gnueabihf/package.json').version
+          const binding = require('@rstackjs/cli-linux-arm-gnueabihf')
+          const bindingPackageVersion = require('@rstackjs/cli-linux-arm-gnueabihf/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -371,8 +371,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@rstackjs/binding-linux-loong64-musl')
-          const bindingPackageVersion = require('@rstackjs/binding-linux-loong64-musl/package.json').version
+          const binding = require('@rstackjs/cli-linux-loong64-musl')
+          const bindingPackageVersion = require('@rstackjs/cli-linux-loong64-musl/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -387,8 +387,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@rstackjs/binding-linux-loong64-gnu')
-          const bindingPackageVersion = require('@rstackjs/binding-linux-loong64-gnu/package.json').version
+          const binding = require('@rstackjs/cli-linux-loong64-gnu')
+          const bindingPackageVersion = require('@rstackjs/cli-linux-loong64-gnu/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -405,8 +405,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@rstackjs/binding-linux-riscv64-musl')
-          const bindingPackageVersion = require('@rstackjs/binding-linux-riscv64-musl/package.json').version
+          const binding = require('@rstackjs/cli-linux-riscv64-musl')
+          const bindingPackageVersion = require('@rstackjs/cli-linux-riscv64-musl/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -421,8 +421,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@rstackjs/binding-linux-riscv64-gnu')
-          const bindingPackageVersion = require('@rstackjs/binding-linux-riscv64-gnu/package.json').version
+          const binding = require('@rstackjs/cli-linux-riscv64-gnu')
+          const bindingPackageVersion = require('@rstackjs/cli-linux-riscv64-gnu/package.json').version
           if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -438,8 +438,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-linux-ppc64-gnu')
-        const bindingPackageVersion = require('@rstackjs/binding-linux-ppc64-gnu/package.json').version
+        const binding = require('@rstackjs/cli-linux-ppc64-gnu')
+        const bindingPackageVersion = require('@rstackjs/cli-linux-ppc64-gnu/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -454,8 +454,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-linux-s390x-gnu')
-        const bindingPackageVersion = require('@rstackjs/binding-linux-s390x-gnu/package.json').version
+        const binding = require('@rstackjs/cli-linux-s390x-gnu')
+        const bindingPackageVersion = require('@rstackjs/cli-linux-s390x-gnu/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -474,8 +474,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-openharmony-arm64')
-        const bindingPackageVersion = require('@rstackjs/binding-openharmony-arm64/package.json').version
+        const binding = require('@rstackjs/cli-openharmony-arm64')
+        const bindingPackageVersion = require('@rstackjs/cli-openharmony-arm64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -490,8 +490,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-openharmony-x64')
-        const bindingPackageVersion = require('@rstackjs/binding-openharmony-x64/package.json').version
+        const binding = require('@rstackjs/cli-openharmony-x64')
+        const bindingPackageVersion = require('@rstackjs/cli-openharmony-x64/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -506,8 +506,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@rstackjs/binding-openharmony-arm')
-        const bindingPackageVersion = require('@rstackjs/binding-openharmony-arm/package.json').version
+        const binding = require('@rstackjs/cli-openharmony-arm')
+        const bindingPackageVersion = require('@rstackjs/cli-openharmony-arm/package.json').version
         if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -643,16 +643,16 @@ if (!nativeBinding || forceWasi) {
     let candidateError = null
     let candidateFailed = false
     try {
-      candidateError = __napiWasiResolveCandidate('@rstackjs/binding-wasm32-wasi', true, undefined)
+      candidateError = __napiWasiResolveCandidate('@rstackjs/cli-wasm32-wasi', true, undefined)
       candidateFailed = candidateError !== null
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          const bindingPackageVersion = require('@rstackjs/binding-wasm32-wasi/package.json').version
+          const bindingPackageVersion = require('@rstackjs/cli-wasm32-wasi/package.json').version
           if (bindingPackageVersion !== '0.4.0') {
             throw new Error(`WASI binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
-        wasiBinding = require('@rstackjs/binding-wasm32-wasi')
+        wasiBinding = require('@rstackjs/cli-wasm32-wasi')
         nativeBinding = wasiBinding
         wasiBindingLoaded = true
       }

--- a/packages/rstack/napi.json
+++ b/packages/rstack/napi.json
@@ -1,6 +1,6 @@
 {
   "binaryName": "rstack",
-  "packageName": "@rstackjs/binding",
+  "packageName": "@rstackjs/cli",
   "targets": [
     "x86_64-unknown-linux-gnu",
     "aarch64-unknown-linux-gnu",


### PR DESCRIPTION
This PR renames the NAPI-RS platform package family from `@rstackjs/binding-*` to `@rstackjs/cli-*` so native binaries are clearly associated with Rstack CLI while preserving NAPI-RS's generated naming convention. It updates `napi.json` and regenerates the private binding loader; target coverage and runtime loading behavior are unchanged.