### PR TITLE
release: v5.0.0-alpha.0

### DIFF
--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rstack",
-  "version": "0.4.0",
+  "version": "5.0.0-alpha.0",
   "description": "One CLI for JavaScript development, powered by Rstack.",
   "homepage": "https://rstack.rs",
   "bugs": {


### PR DESCRIPTION
This PR bumps `rstack` to `5.0.0-alpha.0` for the first Tier 1 native binding release.