### PR TITLE
build(native): support all release targets

### DIFF
--- a/.github/workflows/reusable-native-release.yml
+++ b/.github/workflows/reusable-native-release.yml
@@ -26,6 +26,33 @@ jobs:
           - target: aarch64-apple-darwin
             runner: macos-latest
             filename: rstack.darwin-arm64.node
+          - target: powerpc64le-unknown-linux-gnu
+            runner: ubuntu-latest
+            filename: rstack.linux-ppc64-gnu.node
+          - target: s390x-unknown-linux-gnu
+            runner: ubuntu-latest
+            filename: rstack.linux-s390x-gnu.node
+          - target: aarch64-pc-windows-msvc
+            runner: windows-latest
+            filename: rstack.win32-arm64-msvc.node
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+            filename: rstack.darwin-x64.node
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+            filename: rstack.linux-x64-musl.node
+          - target: riscv64gc-unknown-linux-gnu
+            runner: ubuntu-latest
+            filename: rstack.linux-riscv64-gnu.node
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-latest
+            filename: rstack.linux-arm64-musl.node
+          - target: riscv64gc-unknown-linux-musl
+            runner: ubuntu-latest
+            filename: rstack.linux-riscv64-musl.node
+          - target: i686-pc-windows-msvc
+            runner: windows-latest
+            filename: rstack.win32-ia32-msvc.node
     uses: ./.github/workflows/reusable-native-build.yml
     with:
       target: ${{ matrix.target }}

--- a/packages/rstack/napi.json
+++ b/packages/rstack/napi.json
@@ -5,6 +5,15 @@
     "x86_64-unknown-linux-gnu",
     "aarch64-unknown-linux-gnu",
     "x86_64-pc-windows-msvc",
-    "aarch64-apple-darwin"
+    "aarch64-apple-darwin",
+    "powerpc64le-unknown-linux-gnu",
+    "s390x-unknown-linux-gnu",
+    "aarch64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-musl",
+    "riscv64gc-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
+    "riscv64gc-unknown-linux-musl",
+    "i686-pc-windows-msvc"
   ]
 }


### PR DESCRIPTION
This PR completes native release platform coverage so Rstack can build packages for every agreed target tier. It expands the NAPI-RS release allowlist and reusable build matrix from Tier 1 to all 13 targets while keeping the existing runner types and build-only policy for platforms below Tier 1.