### PR TITLE
chore(ci): publish binding packages directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
           NPM_TAG: ${{ inputs.npm_tag }}
         run: |
           for package_dir in packages/rstack/npm/*; do
-            pnpm stage publish "$package_dir" --tag "$NPM_TAG" --no-git-checks
+            pnpm publish "$package_dir" --tag "$NPM_TAG" --no-git-checks
           done
 
           pnpm --filter './packages/*' -r stage publish --tag "$NPM_TAG" --no-git-checks


### PR DESCRIPTION
Binding packages do not need manual staged approval and should be released automatically with each Rstack release.

This changes the native package loop to use direct `pnpm publish`, while keeping staged publishing for `rstack` and `create-rstack`.