### PR TITLE
fix(create-rstack): only add staged setup at Git root

### DIFF
--- a/packages/create-rstack/src/index.ts
+++ b/packages/create-rstack/src/index.ts
@@ -1,5 +1,14 @@
-import { type Argv, checkCancel, create, select } from '@rstackjs/create-toolkit';
+import {
+  type Argv,
+  type GitResolvedContext,
+  checkCancel,
+  create,
+  select,
+} from '@rstackjs/create-toolkit';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+
+const packageRoot = path.join(import.meta.dirname, '..');
 
 const getTemplateName = async ({ template }: Argv): Promise<string> => {
   if (typeof template === 'string') {
@@ -103,8 +112,61 @@ const getTemplateName = async ({ template }: Argv): Promise<string> => {
   return `${projectType}-${templateType}-${language}`;
 };
 
+const getStagedConfig = (templateName: string): string => {
+  const scriptExtensions = ['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs', 'mts', 'cts'];
+  const formatExtensions = ['json', 'jsonc', 'md', 'mdx', 'css', 'html', 'yml', 'yaml'];
+  const componentExtensions = ['svelte', 'vue'];
+  const templateFormatExtensions = [
+    ...formatExtensions,
+    ...componentExtensions.filter((extension) => templateName.includes(extension)),
+  ];
+
+  return [
+    '',
+    'define.staged({',
+    `  '*.{${scriptExtensions.join(',')}}': ['rs lint --fix', 'rs fmt'],`,
+    `  '*.{${templateFormatExtensions.join(',')}}': 'rs fmt',`,
+    '});',
+    '',
+  ].join('\n');
+};
+
+const injectStagedSetup = async ({
+  templateName,
+  distFolder,
+  gitEnabled,
+  isGitRoot,
+}: GitResolvedContext): Promise<void> => {
+  if (!gitEnabled || !isGitRoot) {
+    return;
+  }
+
+  const configExtension = templateName.endsWith('-js') ? 'js' : 'ts';
+  const packageJsonPath = path.join(distFolder, 'package.json');
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+    scripts: Record<string, string>;
+  };
+
+  packageJson.scripts = Object.fromEntries(
+    Object.entries({ ...packageJson.scripts, prepare: 'rs setup' }).sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  );
+
+  const hooksDirectory = path.join(distFolder, '.rstack', 'hooks');
+  await mkdir(hooksDirectory, { recursive: true });
+  await Promise.all([
+    writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`),
+    appendFile(
+      path.join(distFolder, `rstack.config.${configExtension}`),
+      getStagedConfig(templateName),
+    ),
+    writeFile(path.join(hooksDirectory, 'pre-commit'), 'rs staged\n'),
+  ]);
+};
+
 await create({
-  root: path.join(import.meta.dirname, '..'),
+  root: packageRoot,
   name: 'rstack',
   templates: [
     'app-vanilla-js',
@@ -136,4 +198,5 @@ await create({
   ],
   builtinTools: [],
   getTemplateName,
+  onGitResolved: injectStagedSetup,
 });

--- a/packages/create-rstack/template-app-lit-js/package.json
+++ b/packages/create-rstack/template-app-lit-js/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-lit-js/rstack.config.js
+++ b/packages/create-rstack/template-app-lit-js/rstack.config.js
@@ -26,8 +26,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-lit-ts/package.json
+++ b/packages/create-rstack/template-app-lit-ts/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-lit-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-lit-ts/rstack.config.ts
@@ -25,8 +25,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-preact-js/package.json
+++ b/packages/create-rstack/template-app-preact-js/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-preact-js/rstack.config.js
+++ b/packages/create-rstack/template-app-preact-js/rstack.config.js
@@ -27,8 +27,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-preact-ts/package.json
+++ b/packages/create-rstack/template-app-preact-ts/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-preact-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-preact-ts/rstack.config.ts
@@ -27,8 +27,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-react-js/package.json
+++ b/packages/create-rstack/template-app-react-js/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-react-js/rstack.config.js
+++ b/packages/create-rstack/template-app-react-js/rstack.config.js
@@ -27,8 +27,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-react-ts/package.json
+++ b/packages/create-rstack/template-app-react-ts/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-react-ts/rstack.config.ts
@@ -27,8 +27,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-solid-js/package.json
+++ b/packages/create-rstack/template-app-solid-js/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-solid-js/rstack.config.js
+++ b/packages/create-rstack/template-app-solid-js/rstack.config.js
@@ -29,8 +29,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-solid-ts/package.json
+++ b/packages/create-rstack/template-app-solid-ts/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-solid-ts/rstack.config.ts
@@ -28,8 +28,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-svelte-js/package.json
+++ b/packages/create-rstack/template-app-svelte-js/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-svelte-js/rstack.config.js
+++ b/packages/create-rstack/template-app-svelte-js/rstack.config.js
@@ -24,8 +24,3 @@ define.fmt({
   plugins: ['prettier-plugin-svelte'],
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml,svelte}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-svelte-ts/package.json
+++ b/packages/create-rstack/template-app-svelte-ts/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
@@ -23,8 +23,3 @@ define.fmt({
   plugins: ['prettier-plugin-svelte'],
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml,svelte}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-vanilla-js/package.json
+++ b/packages/create-rstack/template-app-vanilla-js/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-vanilla-js/rstack.config.js
+++ b/packages/create-rstack/template-app-vanilla-js/rstack.config.js
@@ -19,8 +19,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-vanilla-ts/package.json
+++ b/packages/create-rstack/template-app-vanilla-ts/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
@@ -18,8 +18,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-vue-js/package.json
+++ b/packages/create-rstack/template-app-vue-js/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-vue-js/rstack.config.js
+++ b/packages/create-rstack/template-app-vue-js/rstack.config.js
@@ -23,8 +23,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml,vue}': 'rs fmt',
-});

--- a/packages/create-rstack/template-app-vue-ts/package.json
+++ b/packages/create-rstack/template-app-vue-ts/package.json
@@ -9,7 +9,6 @@
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs preview",
     "test": "rs test",
     "test:watch": "rs test --watch"

--- a/packages/create-rstack/template-app-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vue-ts/rstack.config.ts
@@ -22,8 +22,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml,vue}': 'rs fmt',
-});

--- a/packages/create-rstack/template-common/.rstack/hooks/pre-commit
+++ b/packages/create-rstack/template-common/.rstack/hooks/pre-commit
@@ -1,1 +1,0 @@
-rs staged

--- a/packages/create-rstack/template-doc-basic/package.json
+++ b/packages/create-rstack/template-doc-basic/package.json
@@ -9,7 +9,6 @@
     "dev": "rs doc",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs doc preview"
   },
   "devDependencies": {

--- a/packages/create-rstack/template-doc-basic/rstack.config.ts
+++ b/packages/create-rstack/template-doc-basic/rstack.config.ts
@@ -21,8 +21,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-doc-i18n/package.json
+++ b/packages/create-rstack/template-doc-i18n/package.json
@@ -9,7 +9,6 @@
     "dev": "rs doc",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "preview": "rs doc preview"
   },
   "devDependencies": {

--- a/packages/create-rstack/template-doc-i18n/rstack.config.ts
+++ b/packages/create-rstack/template-doc-i18n/rstack.config.ts
@@ -37,8 +37,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-lib-node-js/package.json
+++ b/packages/create-rstack/template-lib-node-js/package.json
@@ -18,7 +18,6 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-node-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-node-js/rstack.config.js
@@ -19,8 +19,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-lib-node-ts/package.json
+++ b/packages/create-rstack/template-lib-node-ts/package.json
@@ -20,7 +20,6 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-node-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-node-ts/rstack.config.ts
@@ -19,8 +19,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-lib-react-js/package.json
+++ b/packages/create-rstack/template-lib-react-js/package.json
@@ -17,7 +17,6 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-react-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-react-js/rstack.config.js
@@ -36,8 +36,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-lib-react-ts/package.json
+++ b/packages/create-rstack/template-lib-react-ts/package.json
@@ -19,7 +19,6 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-react-ts/rstack.config.ts
@@ -37,8 +37,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-lib-solid-js/package.json
+++ b/packages/create-rstack/template-lib-solid-js/package.json
@@ -18,7 +18,6 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-solid-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-solid-js/rstack.config.js
@@ -84,8 +84,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-lib-solid-ts/package.json
+++ b/packages/create-rstack/template-lib-solid-ts/package.json
@@ -20,7 +20,6 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
@@ -84,8 +84,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml}': 'rs fmt',
-});

--- a/packages/create-rstack/template-lib-svelte-js/package.json
+++ b/packages/create-rstack/template-lib-svelte-js/package.json
@@ -17,7 +17,6 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-svelte-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-svelte-js/rstack.config.js
@@ -33,8 +33,3 @@ define.fmt({
   plugins: ['prettier-plugin-svelte'],
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml,svelte}': 'rs fmt',
-});

--- a/packages/create-rstack/template-lib-svelte-ts/package.json
+++ b/packages/create-rstack/template-lib-svelte-ts/package.json
@@ -19,7 +19,6 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
@@ -33,8 +33,3 @@ define.fmt({
   plugins: ['prettier-plugin-svelte'],
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml,svelte}': 'rs fmt',
-});

--- a/packages/create-rstack/template-lib-vue-js/package.json
+++ b/packages/create-rstack/template-lib-vue-js/package.json
@@ -17,7 +17,6 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-vue-js/rstack.config.js
+++ b/packages/create-rstack/template-lib-vue-js/rstack.config.js
@@ -32,8 +32,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml,vue}': 'rs fmt',
-});

--- a/packages/create-rstack/template-lib-vue-ts/package.json
+++ b/packages/create-rstack/template-lib-vue-ts/package.json
@@ -19,7 +19,6 @@
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",
-    "prepare": "rs setup",
     "test": "rs test",
     "test:watch": "rs test --watch"
   },

--- a/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
@@ -31,8 +31,3 @@ define.lint(async () => {
 define.fmt({
   singleQuote: true,
 });
-
-define.staged({
-  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint --fix', 'rs fmt'],
-  '*.{json,jsonc,md,mdx,css,html,yml,yaml,vue}': 'rs fmt',
-});

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { access, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -35,27 +35,78 @@ const expectStagedSetup = async (
   ).toContain('define.staged({');
 };
 
+const expectNoStagedSetup = async (
+  projectDirectory: string,
+  configExtension: string,
+  scripts: Record<string, string>,
+): Promise<void> => {
+  expect(scripts.prepare).toBeUndefined();
+  await expect(
+    access(path.join(projectDirectory, '.rstack', 'hooks', 'pre-commit')),
+  ).rejects.toThrow();
+  expect(
+    await readFile(path.join(projectDirectory, `rstack.config.${configExtension}`), 'utf8'),
+  ).not.toContain('define.staged({');
+};
+
 afterEach(async () => {
   await Promise.all(
     tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
   );
 });
 
-const createProject = async (template: string) => {
+const createProject = async (
+  template: string,
+  {
+    args = [],
+    initializeGitIn,
+  }: {
+    args?: string[];
+    initializeGitIn?: 'parent' | 'project';
+  } = {},
+) => {
   const tempDirectory = await mkdtemp(path.join(tmpdir(), 'create-rstack-'));
   const projectDirectory = path.join(tempDirectory, 'my-app');
   tempDirectories.push(tempDirectory);
 
-  await execFileAsync(process.execPath, [binPath, projectDirectory, '--template', template], {
-    cwd: tempDirectory,
-    env: {
-      ...process.env,
-      npm_config_user_agent: 'pnpm/11.20.0',
+  if (initializeGitIn) {
+    const gitDirectory = initializeGitIn === 'project' ? projectDirectory : tempDirectory;
+    await mkdir(gitDirectory, { recursive: true });
+    await execFileAsync('git', ['init', '--quiet'], { cwd: gitDirectory });
+  }
+
+  await execFileAsync(
+    process.execPath,
+    [binPath, projectDirectory, '--template', template, ...args],
+    {
+      cwd: tempDirectory,
+      env: {
+        ...process.env,
+        npm_config_user_agent: 'pnpm/11.20.0',
+      },
     },
-  });
+  );
 
   return projectDirectory;
 };
+
+test.each([
+  {
+    scenario: 'Git initialization is disabled',
+    options: { args: ['--no-git'], initializeGitIn: 'project' as const },
+  },
+  {
+    scenario: 'the project is inside an existing Git repository',
+    options: { initializeGitIn: 'parent' as const },
+  },
+])('omits staged setup when $scenario', async ({ options }) => {
+  const projectDirectory = await createProject('app-vanilla-ts', options);
+  const packageJson = JSON.parse(
+    await readFile(path.join(projectDirectory, 'package.json'), 'utf8'),
+  );
+
+  await expectNoStagedSetup(projectDirectory, 'ts', packageJson.scripts);
+});
 
 test.each([
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ catalogs:
       specifier: 1.14.7
       version: 1.14.7
     '@rstackjs/create-toolkit':
-      specifier: 2.2.1
-      version: 2.2.1
+      specifier: 2.2.2
+      version: 2.2.2
     '@rstackjs/load-config':
       specifier: ^0.1.2
       version: 0.1.2
@@ -335,7 +335,7 @@ importers:
     dependencies:
       '@rstackjs/create-toolkit':
         specifier: 'catalog:'
-        version: 2.2.1
+        version: 2.2.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1434,8 +1434,8 @@ packages:
       '@rspress/core':
         optional: true
 
-  '@rstackjs/create-toolkit@2.2.1':
-    resolution: {integrity: sha512-zH0wfbjU8caMuCNn9PWp49u4Y6XuB40RBkuwM8Vo40XGeqWs8RkP527ojmDIPqm4dL3ojRksHYsKy1ROGSXBoA==}
+  '@rstackjs/create-toolkit@2.2.2':
+    resolution: {integrity: sha512-0TDePC6+jwow0WoCWDdxBAazDO2HoW6acblMLNgBRAZOk8IKzVN35aXWxyHka3vJP0+zBQppLo9nVGdaFepnRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@rstackjs/load-config@0.1.2':
@@ -3843,7 +3843,7 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.19(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
-  '@rstackjs/create-toolkit@2.2.1': {}
+  '@rstackjs/create-toolkit@2.2.2': {}
 
   '@rstackjs/load-config@0.1.2': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@rspress/plugin-client-redirects': '^2.0.19'
   '@rspress/plugin-sitemap': '^2.0.19'
   '@rstack-dev/doc-ui': '1.14.7'
-  '@rstackjs/create-toolkit': '2.2.1'
+  '@rstackjs/create-toolkit': '2.2.2'
   '@rstackjs/load-config': ^0.1.2
   '@rstackjs/test-utils': ^0.2.0
   '@rstest/adapter-rsbuild': '~0.11.5'


### PR DESCRIPTION
## Summary

create-rstack currently adds repository-level staged checks even when Git initialization is disabled or the generated project is nested inside another worktree.

This PR upgrades `@rstackjs/create-toolkit` to v2.2.2 and uses `onGitResolved` to inject the prepare script, pre-commit hook, and `define.staged()` only when the generated project is its Git root.

## Related Links

- https://github.com/rstackjs/create-toolkit/releases/tag/v2.2.2