### PR TITLE
chore(create-rstack): update Rstack to v0.4.0

### DIFF
--- a/packages/create-rstack/template-app-lit-js/package.json
+++ b/packages/create-rstack/template-app-lit-js/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5"
+    "rstack": "^0.4.0"
   }
 }

--- a/packages/create-rstack/template-app-lit-ts/package.json
+++ b/packages/create-rstack/template-app-lit-ts/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-app-preact-js/package.json
+++ b/packages/create-rstack/template-app-preact-js/package.json
@@ -21,6 +21,6 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/preact": "^3.2.4",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5"
+    "rstack": "^0.4.0"
   }
 }

--- a/packages/create-rstack/template-app-preact-ts/package.json
+++ b/packages/create-rstack/template-app-preact-ts/package.json
@@ -22,7 +22,7 @@
     "@testing-library/preact": "^3.2.4",
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-app-react-js/package.json
+++ b/packages/create-rstack/template-app-react-js/package.json
@@ -23,6 +23,6 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5"
+    "rstack": "^0.4.0"
   }
 }

--- a/packages/create-rstack/template-app-react-ts/package.json
+++ b/packages/create-rstack/template-app-react-ts/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-app-solid-js/package.json
+++ b/packages/create-rstack/template-app-solid-js/package.json
@@ -22,6 +22,6 @@
     "@solidjs/testing-library": "^0.8.10",
     "@testing-library/jest-dom": "^7.0.0",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5"
+    "rstack": "^0.4.0"
   }
 }

--- a/packages/create-rstack/template-app-solid-ts/package.json
+++ b/packages/create-rstack/template-app-solid-ts/package.json
@@ -23,7 +23,7 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-app-svelte-js/package.json
+++ b/packages/create-rstack/template-app-svelte-js/package.json
@@ -22,6 +22,6 @@
     "@testing-library/svelte": "^5.4.2",
     "happy-dom": "^20.11.1",
     "prettier-plugin-svelte": "^4.1.1",
-    "rstack": "^0.3.5"
+    "rstack": "^0.4.0"
   }
 }

--- a/packages/create-rstack/template-app-svelte-ts/package.json
+++ b/packages/create-rstack/template-app-svelte-ts/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.1",
     "prettier-plugin-svelte": "^4.1.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "svelte-check": "^4.7.4",
     "typescript": "^6.0.3"
   }

--- a/packages/create-rstack/template-app-vanilla-js/package.json
+++ b/packages/create-rstack/template-app-vanilla-js/package.json
@@ -17,6 +17,6 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5"
+    "rstack": "^0.4.0"
   }
 }

--- a/packages/create-rstack/template-app-vanilla-ts/package.json
+++ b/packages/create-rstack/template-app-vanilla-ts/package.json
@@ -18,7 +18,7 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-app-vue-js/package.json
+++ b/packages/create-rstack/template-app-vue-js/package.json
@@ -21,6 +21,6 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5"
+    "rstack": "^0.4.0"
   }
 }

--- a/packages/create-rstack/template-app-vue-ts/package.json
+++ b/packages/create-rstack/template-app-vue-ts/package.json
@@ -22,7 +22,7 @@
     "@types/node": "^24.13.3",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "typescript": "^6.0.3",
     "vue-tsc": "^3.3.9"
   }

--- a/packages/create-rstack/template-doc-basic/package.json
+++ b/packages/create-rstack/template-doc-basic/package.json
@@ -18,7 +18,7 @@
     "@types/react-dom": "^19.2.4",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-doc-i18n/package.json
+++ b/packages/create-rstack/template-doc-i18n/package.json
@@ -18,7 +18,7 @@
     "@types/react-dom": "^19.2.4",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-lib-node-js/package.json
+++ b/packages/create-rstack/template-lib-node-js/package.json
@@ -22,7 +22,7 @@
     "test:watch": "rs test --watch"
   },
   "devDependencies": {
-    "rstack": "^0.3.5"
+    "rstack": "^0.4.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/packages/create-rstack/template-lib-node-ts/package.json
+++ b/packages/create-rstack/template-lib-node-ts/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.13.3",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "typescript": "^7.0.2"
   },
   "engines": {

--- a/packages/create-rstack/template-lib-react-js/package.json
+++ b/packages/create-rstack/template-lib-react-js/package.json
@@ -29,7 +29,7 @@
     "happy-dom": "^20.11.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "rstack": "^0.3.5"
+    "rstack": "^0.4.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/create-rstack/template-lib-react-ts/package.json
+++ b/packages/create-rstack/template-lib-react-ts/package.json
@@ -33,7 +33,7 @@
     "happy-dom": "^20.11.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "typescript": "^7.0.2"
   },
   "peerDependencies": {

--- a/packages/create-rstack/template-lib-solid-js/package.json
+++ b/packages/create-rstack/template-lib-solid-js/package.json
@@ -27,7 +27,7 @@
     "@solidjs/testing-library": "^0.8.10",
     "@testing-library/jest-dom": "^7.0.0",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "solid-js": "^1.9.14"
   },
   "peerDependencies": {

--- a/packages/create-rstack/template-lib-solid-ts/package.json
+++ b/packages/create-rstack/template-lib-solid-ts/package.json
@@ -30,7 +30,7 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "solid-js": "^1.9.14",
     "typescript": "^7.0.2"
   },

--- a/packages/create-rstack/template-lib-svelte-js/package.json
+++ b/packages/create-rstack/template-lib-svelte-js/package.json
@@ -24,7 +24,7 @@
     "@rsbuild/plugin-svelte": "^2.0.1",
     "happy-dom": "^20.11.1",
     "prettier-plugin-svelte": "^4.1.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "svelte": "^5.56.8"
   },
   "peerDependencies": {

--- a/packages/create-rstack/template-lib-svelte-ts/package.json
+++ b/packages/create-rstack/template-lib-svelte-ts/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.1",
     "prettier-plugin-svelte": "^4.1.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "svelte": "^5.56.8",
     "svelte-check": "^4.7.4",
     "svelte2tsx": "^0.7.59",

--- a/packages/create-rstack/template-lib-vue-js/package.json
+++ b/packages/create-rstack/template-lib-vue-js/package.json
@@ -25,7 +25,7 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "vue": "^3.5.40"
   },
   "peerDependencies": {

--- a/packages/create-rstack/template-lib-vue-ts/package.json
+++ b/packages/create-rstack/template-lib-vue-ts/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^24.13.3",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.1",
-    "rstack": "^0.3.5",
+    "rstack": "^0.4.0",
     "typescript": "^6.0.3",
     "vue": "^3.5.40",
     "vue-tsc": "^3.3.9"


### PR DESCRIPTION
## Summary

This PR updates the `rstack` dependency in all `create-rstack` templates from `^0.3.5` to `^0.4.0`, so newly generated projects use the latest stable Rstack release.

## Related Links

- https://github.com/rstackjs/rstack-cli/releases/tag/v0.4.0