### PR TITLE
docs: update Rstack release skill

### DIFF
--- a/.agents/skills/release-rstack/SKILL.md
+++ b/.agents/skills/release-rstack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-rstack
-description: Create a release pull request for the `rstack` npm package at a specific version. Use when asked to prepare, create, or open an rstack package release PR.
+description: Create a coordinated release pull request for the `rstack` and `create-rstack` npm packages. Use when asked to prepare, create, or open an rstack package release PR.
 ---
 
 # Release Rstack
@@ -11,6 +11,16 @@ description: Create a release pull request for the `rstack` npm package at a spe
 
 If the version is missing, ask for it before making changes.
 
+## Version rules
+
+- Read both package versions before editing. Require the rstack target to be a valid, increasing SemVer version.
+- Keep the package version lines independent. Apply the rstack bump type to the current `create-rstack` version:
+  - Patch: increment the patch version.
+  - Minor: increment the minor version and reset patch to `0`.
+  - Prerelease: use the rstack target's identifier. From a stable version, increment patch and append `-<identifier>.0`; otherwise increment the final prerelease number.
+  - Prerelease to stable with the same core version: remove the `create-rstack` prerelease suffix.
+- Stop and ask the user for major or ambiguous changes.
+
 ## Steps
 
 1. Check the worktree with `git status --short`. If there are uncommitted changes or untracked files, stop and ask the user how to proceed. Do not stash, discard, or include them.
@@ -19,16 +29,18 @@ If the version is missing, ask for it before making changes.
 
 3. Create and switch to `release/v<version>` from the clean default-branch HEAD.
 
-4. Update the `version` field in `packages/rstack/package.json` to `<version>`.
+4. Update the `version` field in `packages/rstack/package.json` to `<version>` and the `version` field in `packages/create-rstack/package.json` to the derived `create-rstack` version.
 
-5. Run `pnpm --filter rstack build:native` to regenerate `packages/rstack/binding.cjs` and `packages/rstack/binding.d.cts` for the new version. Do not edit generated binding files manually.
+5. In every `packages/create-rstack/template-*/package.json`, set the `rstack` dependency to `^<version>`. Update only that dependency entry and verify every template package manifest uses the same target version.
 
-6. Review the diff and confirm it contains only the version-field change and regenerated binding files above.
+6. Run `pnpm --filter rstack build:native` to regenerate `packages/rstack/binding.cjs` and `packages/rstack/binding.d.cts` for the new version. Do not edit generated binding files manually.
 
-7. Create a commit with this exact message: `release: v<version>`.
+7. Review the diff and confirm it contains only both package version changes, the template `rstack` dependency updates, and the regenerated binding files above. Verify the two package version changes use the intended matching bump type and no template retains an older rstack version.
 
-8. Push the branch to `origin`. Recheck that the branch being pushed is `release/v<version>` and never push the default branch directly.
+8. Create a commit with this exact message: `release: v<version>`.
 
-9. Create a pull request against the default branch. In Codex, use the GitHub connector/plugin; use another available GitHub workflow only when the connector is unavailable. Use `release: v<version>` as the PR title.
+9. Push the branch to `origin`. Recheck that the branch being pushed is `release/v<version>` and never push the default branch directly.
+
+10. Create a pull request against the default branch. In Codex, use the GitHub connector/plugin; use another available GitHub workflow only when the connector is unavailable. Use `release: v<version>` as the PR title.
 
 Return the pull request URL.


### PR DESCRIPTION
This PR keeps `create-rstack` releases coordinated with `rstack` releases. It updates the release skill to apply the same patch, minor, or prerelease bump to `create-rstack` and to refresh every template's `rstack` dependency to the target release.