### PR TITLE
chore(ci): run workspace scripts on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "pnpm --filter './packages/**' build",
+    "build": "pnpm --filter \"./packages/**\" build",
     "check:format": "rs fmt --check",
     "check:spell": "pnpm dlx cspell && heading-case",
     "doc": "pnpm --dir website dev",
@@ -14,7 +14,7 @@
     "lint": "rs lint --type-check",
     "prepare": "node scripts/rs.js setup",
     "release:prepare": "node scripts/prepare-release.js",
-    "test": "pnpm --filter './packages/**' test"
+    "test": "pnpm --filter \"./packages/**\" test"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/rstack/tests/config/define-doc/index.test.ts
+++ b/packages/rstack/tests/config/define-doc/index.test.ts
@@ -12,4 +12,4 @@ test('should build docs with define.doc config', async ({ prepareDist, execCli, 
   const output = getFileContent(files, 'index.html');
 
   expect(output).toContain(expectedText);
-});
+}, 15_000);

--- a/packages/rstack/tests/helpers/cli.ts
+++ b/packages/rstack/tests/helpers/cli.ts
@@ -25,7 +25,7 @@ export const execCli: ExecCli = (command, options = {}) => {
   const { logHelper, ...execOptions } = options;
 
   try {
-    const output = execSync(`${RSTACK_BIN_PATH} ${command}`, {
+    const output = execSync(`"${process.execPath}" "${RSTACK_BIN_PATH}" ${command}`, {
       stdio: 'pipe',
       ...execOptions,
       env: {


### PR DESCRIPTION
Workspace build and test scripts used POSIX single quotes, which Windows treated as literal filter characters and matched no packages. This PR uses cross-platform double quotes so Windows CI runs both package builds and tests, launches the shared CLI test helper through the current Node executable so `.js` entrypoints execute correctly on Windows, and gives the full documentation build test enough time on slower Windows runners.

## Related Links

- https://github.com/rstackjs/rstack-cli/actions/runs/31388135341
- https://github.com/rstackjs/rstack-cli/actions/runs/31390781218
- https://github.com/rstackjs/rstack-cli/actions/runs/31391455824