### PR TITLE
test: run package tests in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "rs lint --type-check",
     "prepare": "node scripts/rs.js setup",
     "release:prepare": "node scripts/prepare-release.js",
-    "test": "pnpm --filter \"./packages/**\" test"
+    "test": "pnpm --parallel --filter \"./packages/**\" test"
   },
   "devDependencies": {
     "@types/node": "catalog:",


### PR DESCRIPTION
The root test script currently follows workspace dependency order, so `create-rstack` waits for `rstack` even though their test suites are independent. This PR enables pnpm's `--parallel` mode so both package tests start together.

## Benchmark

Local macOS benchmark with Node.js 24.12.0 and pnpm 11.20.0, using the median wall time from three runs per mode:

| Mode | Median | Change |
| --- | ---: | ---: |
| Serial | 9.85s | — |
| Parallel | 7.17s | -2.67s (-27.2%) |

All six benchmark runs passed.