### PR TITLE
chore(ci): skip published native packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,5 @@ jobs:
         env:
           NPM_TAG: ${{ inputs.npm_tag }}
         run: |
-          for package_dir in packages/rstack/npm/*; do
-            pnpm publish "$package_dir" --tag "$NPM_TAG" --no-git-checks
-          done
-
+          pnpm --dir packages/rstack/npm -r publish --tag "$NPM_TAG" --no-git-checks
           pnpm --filter './packages/*' -r stage publish --tag "$NPM_TAG" --no-git-checks

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,11 @@ doc_build
 /target/
 /artifacts/
 /packages/rstack/*.node
-/packages/rstack/npm/
+
+# Native packages are generated
+/packages/rstack/npm/*
+# Keep only the publish workspace manifest
+!/packages/rstack/npm/pnpm-workspace.yaml
 
 # Temp files
 test-temp-*

--- a/packages/rstack/npm/pnpm-workspace.yaml
+++ b/packages/rstack/npm/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+# Isolate generated native packages from the root workspace while enabling recursive publish.
+packages:
+  - '*'


### PR DESCRIPTION
This PR makes native package releases retryable after a partial publish. It publishes generated native packages through an isolated pnpm workspace so recursive publishing skips versions already present in npm without adding them to the root workspace.

## Related Links

- https://github.com/rstackjs/rstack-cli/actions/runs/31394187061