### PR TITLE
chore(deps): update create-toolkit to v2.2.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ catalogs:
       specifier: 1.14.7
       version: 1.14.7
     '@rstackjs/create-toolkit':
-      specifier: 2.2.2
-      version: 2.2.2
+      specifier: 2.2.3
+      version: 2.2.3
     '@rstackjs/load-config':
       specifier: ^0.1.2
       version: 0.1.2
@@ -335,7 +335,7 @@ importers:
     dependencies:
       '@rstackjs/create-toolkit':
         specifier: 'catalog:'
-        version: 2.2.2
+        version: 2.2.3
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1434,8 +1434,8 @@ packages:
       '@rspress/core':
         optional: true
 
-  '@rstackjs/create-toolkit@2.2.2':
-    resolution: {integrity: sha512-0TDePC6+jwow0WoCWDdxBAazDO2HoW6acblMLNgBRAZOk8IKzVN35aXWxyHka3vJP0+zBQppLo9nVGdaFepnRw==}
+  '@rstackjs/create-toolkit@2.2.3':
+    resolution: {integrity: sha512-0I1U/BGGLXBkvE+C9oDKYfmg1wjFMHCPQlG2BJF+f41kL0BmXZaQMa/m515lo8Q349otqyAEam4A5BMuxetTVw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@rstackjs/load-config@0.1.2':
@@ -3843,7 +3843,7 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.19(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
-  '@rstackjs/create-toolkit@2.2.2': {}
+  '@rstackjs/create-toolkit@2.2.3': {}
 
   '@rstackjs/load-config@0.1.2': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@rspress/plugin-client-redirects': '^2.0.19'
   '@rspress/plugin-sitemap': '^2.0.19'
   '@rstack-dev/doc-ui': '1.14.7'
-  '@rstackjs/create-toolkit': '2.2.2'
+  '@rstackjs/create-toolkit': '2.2.3'
   '@rstackjs/load-config': ^0.1.2
   '@rstackjs/test-utils': ^0.2.0
   '@rstest/adapter-rsbuild': '~0.11.6'

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -89,28 +89,19 @@ npx -y create-rstack@latest my-project -t app-react-ts --no-git
 
 All CLI flags supported by `create-rstack`:
 
-```
+```text wrapCode
 Usage: create-rstack [dir] [options]
 
 Options:
-
   -h, --help                display help for command
   -d, --dir <dir>           create project in specified directory
   -t, --template <tpl>      specify the template to use
   --no-git                  skip Git repository initialization
   --override                override files in target directory
-  --packageName <name>      specify the package name
+  --package-name <name>     specify the package name
   --template-version <ver>  specify the npm template version
 
-Available templates:
-
-  app-vanilla-js, app-vanilla-ts, app-react-js, app-react-ts,
-  app-preact-js, app-preact-ts, app-vue-js, app-vue-ts,
-  app-lit-js, app-lit-ts, app-svelte-js, app-svelte-ts,
-  app-solid-js, app-solid-ts, lib-node-js, lib-node-ts,
-  lib-react-js, lib-react-ts, lib-vue-js, lib-vue-ts,
-  lib-svelte-js, lib-svelte-ts, lib-solid-js, lib-solid-ts,
-  doc-basic, doc-i18n
+Available templates: app-vanilla-js, app-vanilla-ts, app-react-js, app-react-ts, app-preact-js, app-preact-ts, app-vue-js, app-vue-ts, app-lit-js, app-lit-ts, app-svelte-js, app-svelte-ts, app-solid-js, app-solid-ts, lib-node-js, lib-node-ts, lib-react-js, lib-react-ts, lib-vue-js, lib-vue-ts, lib-svelte-js, lib-svelte-ts, lib-solid-js, lib-solid-ts, doc-basic, doc-i18n
 ```
 
 ## Install Rstack

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -89,28 +89,19 @@ npx -y create-rstack@latest my-project -t app-react-ts --no-git
 
 `create-rstack` 支持的全部 CLI 选项如下：
 
-```
+```text wrapCode
 Usage: create-rstack [dir] [options]
 
 Options:
-
   -h, --help                display help for command
   -d, --dir <dir>           create project in specified directory
   -t, --template <tpl>      specify the template to use
   --no-git                  skip Git repository initialization
   --override                override files in target directory
-  --packageName <name>      specify the package name
+  --package-name <name>     specify the package name
   --template-version <ver>  specify the npm template version
 
-Available templates:
-
-  app-vanilla-js, app-vanilla-ts, app-react-js, app-react-ts,
-  app-preact-js, app-preact-ts, app-vue-js, app-vue-ts,
-  app-lit-js, app-lit-ts, app-svelte-js, app-svelte-ts,
-  app-solid-js, app-solid-ts, lib-node-js, lib-node-ts,
-  lib-react-js, lib-react-ts, lib-vue-js, lib-vue-ts,
-  lib-svelte-js, lib-svelte-ts, lib-solid-js, lib-solid-ts,
-  doc-basic, doc-i18n
+Available templates: app-vanilla-js, app-vanilla-ts, app-react-js, app-react-ts, app-preact-js, app-preact-ts, app-vue-js, app-vue-ts, app-lit-js, app-lit-ts, app-svelte-js, app-svelte-ts, app-solid-js, app-solid-ts, lib-node-js, lib-node-ts, lib-react-js, lib-react-ts, lib-vue-js, lib-vue-ts, lib-svelte-js, lib-svelte-ts, lib-solid-js, lib-solid-ts, doc-basic, doc-i18n
 ```
 
 ## 安装 Rstack \{#install-rstack}


### PR DESCRIPTION
This PR upgrades `@rstackjs/create-toolkit` to v2.2.3 so `create-rstack` uses the improved CLI help output.

It updates the English and Chinese Quick Start examples to match the aligned output and kebab-case `--package-name` flag.

## Related Links

- https://github.com/rstackjs/create-toolkit/releases/tag/v2.2.3