### PR TITLE
fix(fmt): skip malformed ignore patterns

### DIFF
--- a/crates/rstack-ignore/src/lib.rs
+++ b/crates/rstack-ignore/src/lib.rs
@@ -68,7 +68,9 @@ impl SourceMatcher {
         for line in source.patterns.split('\n') {
             let line = line.strip_suffix('\r').unwrap_or(line);
             let line = line.strip_prefix('\u{feff}').unwrap_or(line);
-            builder.add_line(None, line)?;
+            // Gitignore files and the previous JavaScript matcher treat malformed lines as
+            // nonmatching, while continuing to apply the remaining valid rules.
+            let _ = builder.add_line(None, line);
         }
 
         Ok(Self {

--- a/packages/rstack/tests/fmt/ignore.test.ts
+++ b/packages/rstack/tests/fmt/ignore.test.ts
@@ -29,6 +29,13 @@ test('matches gitignore patterns relative to the config root', async () => {
   expect(isIgnored(path.join(rootPath, 'src/index.js'))).toBe(false);
 });
 
+test('skips malformed patterns without discarding valid patterns', async () => {
+  const isIgnored = await createMatcher(['ignored.js', 'malformed\\']);
+
+  expect(isIgnored(path.join(rootPath, 'ignored.js'))).toBe(true);
+  expect(isIgnored(path.join(rootPath, 'other.js'))).toBe(false);
+});
+
 test('distinguishes directory-only patterns from files', async () => {
   const isIgnored = await createMatcher(['dist/']);
   const directoryPath = path.join(rootPath, 'dist');


### PR DESCRIPTION
This PR prevents malformed Gitignore lines from aborting `rs fmt`, preserving the tolerant behavior of the previous JavaScript matcher. Invalid lines are skipped while valid rules in the same source continue to apply, with a regression test covering a dangling backslash.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/301#discussion_r3754828432