### PR TITLE
feat: add check command

### DIFF
--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 import { color } from 'rslog';
 import { getConfigState } from '../config.ts';
-import { insertConfigArg, parseCliArgs } from './args.ts';
+import { insertConfigArg, parseArgs, parseCliArgs } from './args.ts';
 
 declare global {
   const RSTACK_VERSION: string;
@@ -20,6 +20,7 @@ ${color.cyan('Commands')}:
   doc          Serve or build docs
   fmt, format  Format code
   lint         Lint code
+  check        Run lint and formatting checks
   test         Run tests
   staged       Run tasks on staged Git files
   setup        Install Git hooks
@@ -31,6 +32,17 @@ ${color.cyan('Options')}:
   -c, --config <path>       Specify Rstack config file path
   -h, --help                Display this help message
   -v, --version             Display version number`;
+
+const checkHelpMessage = `Rstack v${RSTACK_VERSION}
+
+${color.cyan('Usage')}:
+${color.yellow('  $ rs check [options]')}
+
+Run lint and formatting checks.
+
+${color.cyan('Options')}:
+  --type-check  Enable TypeScript type checking
+  -h, --help    Display this help message`;
 
 async function runRsbuildCLI(args: string[]): Promise<void> {
   const argv = [
@@ -106,6 +118,34 @@ async function runRslintCLI(args: string[]): Promise<void> {
   await runCLI({ argv });
 }
 
+async function runCheckCLI(args: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args,
+    options: {
+      'type-check': { type: 'boolean' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  if (values.help) {
+    console.log(checkHelpMessage);
+    return;
+  }
+
+  await runRslintCLI(values.typeCheck ? ['--type-check'] : []);
+  if (process.exitCode) {
+    return;
+  }
+
+  const { runFmtCLI } = await import(
+    /* rspackChunkName: 'fmt' */
+    '../fmt/cli.ts'
+  );
+  await runFmtCLI(['--check']);
+}
+
 export async function setupCommands(): Promise<void> {
   const { args, configPath } = parseCliArgs(process.argv.slice(2));
   const command = args[0];
@@ -139,6 +179,11 @@ export async function setupCommands(): Promise<void> {
 
   if (command === 'lint') {
     await runRslintCLI(args.slice(1));
+    return;
+  }
+
+  if (command === 'check') {
+    await runCheckCLI(args.slice(1));
     return;
   }
 

--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -20,7 +20,7 @@ ${color.cyan('Commands')}:
   doc          Serve or build docs
   fmt, format  Format code
   lint         Lint code
-  check        Run static checks
+  check        Run static checks, including linting and formatting
   test         Run tests
   staged       Run tasks on staged Git files
   setup        Install Git hooks
@@ -38,7 +38,7 @@ const checkHelpMessage = `Rstack v${RSTACK_VERSION}
 ${color.cyan('Usage')}:
 ${color.yellow('  $ rs check [options]')}
 
-Run static checks.
+Run static checks, including linting and formatting.
 
 ${color.cyan('Options')}:
   --type-check  Enable TypeScript type checking

--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -20,7 +20,7 @@ ${color.cyan('Commands')}:
   doc          Serve or build docs
   fmt, format  Format code
   lint         Lint code
-  check        Run lint and formatting checks
+  check        Run static checks
   test         Run tests
   staged       Run tasks on staged Git files
   setup        Install Git hooks
@@ -38,7 +38,7 @@ const checkHelpMessage = `Rstack v${RSTACK_VERSION}
 ${color.cyan('Usage')}:
 ${color.yellow('  $ rs check [options]')}
 
-Run lint and formatting checks.
+Run static checks.
 
 ${color.cyan('Options')}:
   --type-check  Enable TypeScript type checking

--- a/packages/rstack/tests/cli/__snapshots__/check.test.ts.snap
+++ b/packages/rstack/tests/cli/__snapshots__/check.test.ts.snap
@@ -1,0 +1,15 @@
+// Rstest Snapshot v1
+
+exports[`displays check help without loading config 1`] = `
+"Rstack v<version>
+
+Usage:
+  $ rs check [options]
+
+Run lint and formatting checks.
+
+Options:
+  --type-check  Enable TypeScript type checking
+  -h, --help    Display this help message
+"
+`;

--- a/packages/rstack/tests/cli/__snapshots__/check.test.ts.snap
+++ b/packages/rstack/tests/cli/__snapshots__/check.test.ts.snap
@@ -6,7 +6,7 @@ exports[`displays check help without loading config 1`] = `
 Usage:
   $ rs check [options]
 
-Run static checks.
+Run static checks, including linting and formatting.
 
 Options:
   --type-check  Enable TypeScript type checking

--- a/packages/rstack/tests/cli/__snapshots__/check.test.ts.snap
+++ b/packages/rstack/tests/cli/__snapshots__/check.test.ts.snap
@@ -6,7 +6,7 @@ exports[`displays check help without loading config 1`] = `
 Usage:
   $ rs check [options]
 
-Run lint and formatting checks.
+Run static checks.
 
 Options:
   --type-check  Enable TypeScript type checking

--- a/packages/rstack/tests/cli/check.test.ts
+++ b/packages/rstack/tests/cli/check.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from 'rstack/test';
+import { setupFmtTest } from './fmt/helpers.ts';
+
+const { runCLI, writeProjectFile } = setupFmtTest();
+const runCheck = (args: string[] = []) => runCLI(['check', ...args]);
+
+const writeLintConfig = (): void => {
+  writeProjectFile(
+    'rstack.config.ts',
+    `import { define } from "rstack";
+
+define.lint([
+  {
+    files: ["**/*.{js,ts}"],
+    rules: { "no-debugger": "error" },
+  },
+]);
+`,
+  );
+};
+
+test('displays check help without loading config', () => {
+  writeProjectFile('rstack.config.ts', 'throw new Error("must not load");\n');
+
+  const result = runCheck(['--help']);
+
+  expect(result.stdout.replace(/^Rstack v.+/u, 'Rstack v<version>')).toMatchSnapshot();
+});
+
+test('runs lint followed by a formatting check', () => {
+  writeLintConfig();
+  writeProjectFile('src/index.ts', 'const value=true');
+
+  const unformatted = runCheck();
+
+  expect(unformatted.status).toBe(1);
+  expect(unformatted.stdout).toContain('Checking formatting...');
+  expect(unformatted.stderr).toContain('Formatting issues found in 1 file.');
+
+  writeProjectFile('src/index.ts', 'const value = true;\n');
+  const formatted = runCheck();
+
+  expect(formatted.status).toBe(0);
+  expect(formatted.stdout).toContain('No issues found.');
+  expect(formatted.stderr).toBe('');
+});
+
+test('enables type checking only with --type-check', () => {
+  writeLintConfig();
+  writeProjectFile(
+    'tsconfig.json',
+    `{
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["src"]
+}
+`,
+  );
+  writeProjectFile('src/index.ts', 'const value: string = 1;\n');
+
+  const withoutTypeCheck = runCheck();
+  const withTypeCheck = runCheck(['--type-check']);
+
+  expect(withoutTypeCheck.status).toBe(0);
+  expect(withTypeCheck.status).toBe(1);
+  expect(`${withTypeCheck.stdout}\n${withTypeCheck.stderr}`).toContain('TS2322');
+});
+
+test('does not run the formatting check when lint fails', () => {
+  writeLintConfig();
+  writeProjectFile('src/index.js', 'debugger;\n');
+
+  const result = runCheck();
+
+  expect(result.status).toBe(1);
+  expect(`${result.stdout}\n${result.stderr}`).toContain("Unexpected 'debugger' statement");
+  expect(result.stdout).not.toContain('Checking formatting...');
+});


### PR DESCRIPTION
This PR adds `rs check` as a fail-fast wrapper that runs linting before `rs fmt --check`, giving projects one command for local and CI validation.

Type checking remains opt-in through `rs check --type-check`; the command does not introduce `define.check` or new configuration. It includes CLI coverage for help output, formatting failures, type-check behavior, and lint short-circuiting.