### PR TITLE
chore(ci): use rs check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,11 +46,8 @@ jobs:
       - name: Build Native Binding
         run: pnpm --filter rstack build:native
 
-      - name: Lint
-        run: node --run lint
-
-      - name: Check Format
-        run: node --run check:format
+      - name: Check
+        run: node --run check
 
       - name: Check Spell
         run: node --run check:spell

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,13 +14,12 @@
 corepack enable && pnpm install
 
 # dev checks
-pnpm lint
+pnpm check
 pnpm test
 
 # build / format / spelling
 pnpm build
 pnpm format
-pnpm check:format
 pnpm check:spell
 
 # focused work

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm --filter \"./packages/**\" build",
-    "check:format": "rs fmt --check",
+    "check": "rs check --type-check",
     "check:spell": "pnpm dlx cspell && heading-case",
     "doc": "pnpm --dir website dev",
     "doc:build": "node --run build && pnpm --dir website build",


### PR DESCRIPTION
This PR adopts the unified `rs check --type-check` command in repository CI while preserving the existing lint, type-check, and formatting coverage.

It adds the root `check` script, removes the redundant `check:format` script, and updates AGENTS.md to recommend `pnpm check`.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/304