### PR TITLE
docs(create-rstack): document template scripts

### DIFF
--- a/packages/create-rstack/template-common/README.md
+++ b/packages/create-rstack/template-common/README.md
@@ -8,25 +8,16 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Start the development server:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Build the app for production:
-
-```bash
-{{ packageManager }} run build
-```
-
-Preview the production build locally:
-
-```bash
-{{ packageManager }} run preview
-```
+- `{{ packageManager }} run build`: Build the app for production.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Run the app dev server.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run preview`: Preview the app production build.
+- `{{ packageManager }} run test`: Run tests.
+- `{{ packageManager }} run test:watch`: Run tests in watch mode.
 
 ## Learn more
 

--- a/packages/create-rstack/template-doc-i18n/README.md
+++ b/packages/create-rstack/template-doc-i18n/README.md
@@ -8,25 +8,14 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Start the development server:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Build the website for production:
-
-```bash
-{{ packageManager }} run build
-```
-
-Preview the production build locally:
-
-```bash
-{{ packageManager }} run preview
-```
+- `{{ packageManager }} run build`: Build the documentation site for production.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Start the documentation dev server.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run preview`: Preview the production build locally.
 
 ## Learn more
 

--- a/packages/create-rstack/template-doc/README.md
+++ b/packages/create-rstack/template-doc/README.md
@@ -8,25 +8,14 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Start the development server:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Build the website for production:
-
-```bash
-{{ packageManager }} run build
-```
-
-Preview the production build locally:
-
-```bash
-{{ packageManager }} run preview
-```
+- `{{ packageManager }} run build`: Build the documentation site for production.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Start the documentation dev server.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run preview`: Preview the production build locally.
 
 ## Learn more
 

--- a/packages/create-rstack/template-lib-node-ts/README.md
+++ b/packages/create-rstack/template-lib-node-ts/README.md
@@ -8,31 +8,15 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Build the library:
-
-```bash
-{{ packageManager }} run build
-```
-
-Build the library in watch mode:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Run tests:
-
-```bash
-{{ packageManager }} run test
-```
-
-Run tests in watch mode:
-
-```bash
-{{ packageManager }} run test:watch
-```
+- `{{ packageManager }} run build`: Build the library.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Build the library in watch mode.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run test`: Run tests.
+- `{{ packageManager }} run test:watch`: Run tests in watch mode.
 
 ## Learn more
 

--- a/packages/create-rstack/template-lib-node/README.md
+++ b/packages/create-rstack/template-lib-node/README.md
@@ -8,31 +8,15 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Build the library:
-
-```bash
-{{ packageManager }} run build
-```
-
-Build the library in watch mode:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Run tests:
-
-```bash
-{{ packageManager }} run test
-```
-
-Run tests in watch mode:
-
-```bash
-{{ packageManager }} run test:watch
-```
+- `{{ packageManager }} run build`: Build the library.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Build the library in watch mode.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run test`: Run tests.
+- `{{ packageManager }} run test:watch`: Run tests in watch mode.
 
 ## Learn more
 

--- a/packages/create-rstack/template-lib-react-ts/README.md
+++ b/packages/create-rstack/template-lib-react-ts/README.md
@@ -8,31 +8,15 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Build the library:
-
-```bash
-{{ packageManager }} run build
-```
-
-Build the library in watch mode:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Run tests:
-
-```bash
-{{ packageManager }} run test
-```
-
-Run tests in watch mode:
-
-```bash
-{{ packageManager }} run test:watch
-```
+- `{{ packageManager }} run build`: Build the library.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Build the library in watch mode.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run test`: Run tests.
+- `{{ packageManager }} run test:watch`: Run tests in watch mode.
 
 ## Learn more
 

--- a/packages/create-rstack/template-lib-react/README.md
+++ b/packages/create-rstack/template-lib-react/README.md
@@ -8,31 +8,15 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Build the library:
-
-```bash
-{{ packageManager }} run build
-```
-
-Build the library in watch mode:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Run tests:
-
-```bash
-{{ packageManager }} run test
-```
-
-Run tests in watch mode:
-
-```bash
-{{ packageManager }} run test:watch
-```
+- `{{ packageManager }} run build`: Build the library.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Build the library in watch mode.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run test`: Run tests.
+- `{{ packageManager }} run test:watch`: Run tests in watch mode.
 
 ## Learn more
 

--- a/packages/create-rstack/template-lib-solid-ts/README.md
+++ b/packages/create-rstack/template-lib-solid-ts/README.md
@@ -8,31 +8,15 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Build the library:
-
-```bash
-{{ packageManager }} run build
-```
-
-Build the library in watch mode:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Run tests:
-
-```bash
-{{ packageManager }} run test
-```
-
-Run tests in watch mode:
-
-```bash
-{{ packageManager }} run test:watch
-```
+- `{{ packageManager }} run build`: Build the library.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Build the library in watch mode.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run test`: Run tests.
+- `{{ packageManager }} run test:watch`: Run tests in watch mode.
 
 ## Learn more
 

--- a/packages/create-rstack/template-lib-solid/README.md
+++ b/packages/create-rstack/template-lib-solid/README.md
@@ -8,31 +8,15 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Build the library:
-
-```bash
-{{ packageManager }} run build
-```
-
-Build the library in watch mode:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Run tests:
-
-```bash
-{{ packageManager }} run test
-```
-
-Run tests in watch mode:
-
-```bash
-{{ packageManager }} run test:watch
-```
+- `{{ packageManager }} run build`: Build the library.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Build the library in watch mode.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run test`: Run tests.
+- `{{ packageManager }} run test:watch`: Run tests in watch mode.
 
 ## Learn more
 

--- a/packages/create-rstack/template-lib-svelte-ts/README.md
+++ b/packages/create-rstack/template-lib-svelte-ts/README.md
@@ -8,31 +8,15 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Build the library:
-
-```bash
-{{ packageManager }} run build
-```
-
-Build the library in watch mode:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Run tests:
-
-```bash
-{{ packageManager }} run test
-```
-
-Run tests in watch mode:
-
-```bash
-{{ packageManager }} run test:watch
-```
+- `{{ packageManager }} run build`: Build the library.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Build the library in watch mode.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run test`: Run tests.
+- `{{ packageManager }} run test:watch`: Run tests in watch mode.
 
 ## Learn more
 

--- a/packages/create-rstack/template-lib-svelte/README.md
+++ b/packages/create-rstack/template-lib-svelte/README.md
@@ -8,31 +8,15 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Build the library:
-
-```bash
-{{ packageManager }} run build
-```
-
-Build the library in watch mode:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Run tests:
-
-```bash
-{{ packageManager }} run test
-```
-
-Run tests in watch mode:
-
-```bash
-{{ packageManager }} run test:watch
-```
+- `{{ packageManager }} run build`: Build the library.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Build the library in watch mode.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run test`: Run tests.
+- `{{ packageManager }} run test:watch`: Run tests in watch mode.
 
 ## Learn more
 

--- a/packages/create-rstack/template-lib-vue-ts/README.md
+++ b/packages/create-rstack/template-lib-vue-ts/README.md
@@ -8,31 +8,15 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Build the library:
-
-```bash
-{{ packageManager }} run build
-```
-
-Build the library in watch mode:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Run tests:
-
-```bash
-{{ packageManager }} run test
-```
-
-Run tests in watch mode:
-
-```bash
-{{ packageManager }} run test:watch
-```
+- `{{ packageManager }} run build`: Build the library.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Build the library in watch mode.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run test`: Run tests.
+- `{{ packageManager }} run test:watch`: Run tests in watch mode.
 
 ## Learn more
 

--- a/packages/create-rstack/template-lib-vue/README.md
+++ b/packages/create-rstack/template-lib-vue/README.md
@@ -8,31 +8,15 @@ Install the dependencies:
 {{ packageManager }} install
 ```
 
-## Get started
+## Scripts
 
-Build the library:
-
-```bash
-{{ packageManager }} run build
-```
-
-Build the library in watch mode:
-
-```bash
-{{ packageManager }} run dev
-```
-
-Run tests:
-
-```bash
-{{ packageManager }} run test
-```
-
-Run tests in watch mode:
-
-```bash
-{{ packageManager }} run test:watch
-```
+- `{{ packageManager }} run build`: Build the library.
+- `{{ packageManager }} run check`: Run static checks, including linting and formatting.
+- `{{ packageManager }} run dev`: Build the library in watch mode.
+- `{{ packageManager }} run format`: Format code.
+- `{{ packageManager }} run lint`: Lint code.
+- `{{ packageManager }} run test`: Run tests.
+- `{{ packageManager }} run test:watch`: Run tests in watch mode.
 
 ## Learn more
 


### PR DESCRIPTION
## Summary

Template READMEs currently document only a subset of their npm scripts in a step-by-step `Get started` section.

This PR replaces it with a concise `Scripts` list covering every script in each application, library, and documentation template, using descriptions aligned with the Rstack CLI help.