### PR TITLE
docs: document check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,19 @@ Rstack CLI brings the Rstack toolchain together for JavaScript development, with
 
 It also covers local development needs outside Rstack's scope, with Prettier formatting and lint-staged commands.
 
-| Command      | Description                      | Powered by                                                                                        |
-| ------------ | -------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `rs dev`     | Run the app dev server           | [Rsbuild](https://github.com/web-infra-dev/rsbuild)                                               |
-| `rs build`   | Build the app for production     | [Rsbuild](https://github.com/web-infra-dev/rsbuild)                                               |
-| `rs preview` | Preview the app production build | [Rsbuild](https://github.com/web-infra-dev/rsbuild)                                               |
-| `rs test`    | Run tests                        | [Rstest](https://github.com/web-infra-dev/rstest)                                                 |
-| `rs lint`    | Lint code                        | [Rslint](https://github.com/web-infra-dev/rslint)                                                 |
-| `rs lib`     | Build library                    | [Rslib](https://github.com/web-infra-dev/rslib)                                                   |
-| `rs doc`     | Serve or build docs              | [Rspress](https://github.com/web-infra-dev/rspress)                                               |
-| `rs fmt`     | Format code                      | [Prettier](https://github.com/prettier/prettier) + [Yuku](https://github.com/yuku-toolchain/yuku) |
-| `rs setup`   | Install Git hooks                | -                                                                                                 |
-| `rs staged`  | Run tasks on staged Git files    | [lint-staged](https://github.com/lint-staged/lint-staged)                                         |
+| Command                                             | Description                      |
+| --------------------------------------------------- | -------------------------------- |
+| [`rs dev`](https://rstack.rs/guide/cli/dev)         | Run the app dev server           |
+| [`rs build`](https://rstack.rs/guide/cli/build)     | Build the app for production     |
+| [`rs preview`](https://rstack.rs/guide/cli/preview) | Preview the app production build |
+| [`rs test`](https://rstack.rs/guide/cli/test)       | Run tests                        |
+| [`rs lint`](https://rstack.rs/guide/cli/lint)       | Lint code                        |
+| [`rs fmt`](https://rstack.rs/guide/cli/fmt)         | Format code                      |
+| [`rs check`](https://rstack.rs/guide/cli/check)     | Run static checks                |
+| [`rs lib`](https://rstack.rs/guide/cli/lib)         | Build library                    |
+| [`rs doc`](https://rstack.rs/guide/cli/doc)         | Serve or build docs              |
+| [`rs setup`](https://rstack.rs/guide/cli/setup)     | Install Git hooks                |
+| [`rs staged`](https://rstack.rs/guide/cli/staged)   | Run tasks on staged Git files    |
 
 Rstack CLI fits into your existing project workflow. It does not replace your runtime, package manager, or task runner, such as [pnpm](https://github.com/pnpm/pnpm), [Bun](https://github.com/oven-sh/bun), [Turborepo](https://github.com/vercel/turborepo), [Nx](https://github.com/nrwl/nx), and [Nub](https://github.com/nubjs/nub).
 
@@ -57,6 +58,7 @@ bun add -d rstack
     "build": "rs build",
     "preview": "rs preview",
     "test": "rs test",
+    "check": "rs check --type-check",
     "lint": "rs lint",
     "lib": "rs lib",
     "doc": "rs doc",
@@ -73,6 +75,7 @@ pnpm dev
 pnpm build
 pnpm preview
 pnpm test
+pnpm check
 pnpm lint
 pnpm lib
 pnpm doc

--- a/website/docs/en/guide/cli/_meta.json
+++ b/website/docs/en/guide/cli/_meta.json
@@ -1,1 +1,1 @@
-["dev", "build", "preview", "lib", "doc", "test", "lint", "fmt", "setup", "staged"]
+["dev", "build", "preview", "lib", "doc", "test", "check", "lint", "fmt", "setup", "staged"]

--- a/website/docs/en/guide/cli/check.mdx
+++ b/website/docs/en/guide/cli/check.mdx
@@ -1,0 +1,53 @@
+---
+description: 'Run linting and formatting checks together, with optional TypeScript type checking.'
+---
+
+# check
+
+The `rs check` command combines linting, formatting, and optional TypeScript type checking for the current project. By default, it runs [`rs lint`](./lint) followed by [`rs fmt --check`](./fmt#--check).
+
+## Usage
+
+```bash
+rs check [options]
+```
+
+## Checks
+
+Running `rs check` is equivalent to:
+
+```bash
+rs lint && rs fmt --check
+```
+
+Checks run sequentially. If linting fails, `rs check` stops without running the formatting check. The command exits successfully only when every enabled check passes.
+
+## Options
+
+### `--type-check`
+
+Enable TypeScript type checking as part of linting:
+
+```bash
+rs check --type-check
+```
+
+This is equivalent to:
+
+```bash
+rs lint --type-check && rs fmt --check
+```
+
+Type checking is disabled when this option is omitted.
+
+### `-h, --help`
+
+Display usage and option information without running checks:
+
+```bash
+rs check --help
+```
+
+## Configuration
+
+`rs check` has no separate `define.check()` configuration. It uses the linting configuration from [`define.lint()`](../configuration#define-lint) and the formatting configuration from [`define.fmt()`](../configuration#define-fmt).

--- a/website/docs/en/guide/monorepo.mdx
+++ b/website/docs/en/guide/monorepo.mdx
@@ -1,3 +1,7 @@
+---
+description: 'Configure shared Rstack checks, formatting, staged tasks, and project workflows in a monorepo.'
+---
+
 # Monorepo
 
 This guide explains how to use Rstack CLI in a monorepo, including how it works with task orchestrators such as [Turborepo](https://turborepo.com/docs) and [Nx](https://nx.dev/docs/getting-started/intro).
@@ -65,9 +69,9 @@ Expose these tasks through scripts in the root `package.json`:
 {
   "private": true,
   "scripts": {
-    "lint": "rs lint",
+    "check": "rs check --type-check",
     "format": "rs fmt",
-    "check:format": "rs fmt --check",
+    "lint": "rs lint",
     "staged": "rs staged"
   }
 }

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -128,6 +128,7 @@ Add the commands your project needs to the `scripts` field in `package.json`. Fo
     "build": "rs build",
     "preview": "rs preview",
     "test": "rs test",
+    "check": "rs check",
     "lint": "rs lint",
     "format": "rs fmt"
   }
@@ -144,6 +145,7 @@ The following commands are available:
 - [`rs lib`](./cli/lib): Build a library with Rslib.
 - [`rs doc`](./cli/doc): Develop, build, or preview a documentation site with Rspress.
 - [`rs test`](./cli/test): Run tests with Rstest.
+- [`rs check`](./cli/check): Run linting and formatting checks, with optional TypeScript type checking.
 - [`rs lint`](./cli/lint): Lint source code with Rslint.
 - [`rs fmt`](./cli/fmt): Format code.
 - [`rs setup`](./cli/setup): Install repository-level Git hooks.

--- a/website/docs/zh/guide/cli/_meta.json
+++ b/website/docs/zh/guide/cli/_meta.json
@@ -1,1 +1,1 @@
-["dev", "build", "preview", "lib", "doc", "test", "lint", "fmt", "setup", "staged"]
+["dev", "build", "preview", "lib", "doc", "test", "check", "lint", "fmt", "setup", "staged"]

--- a/website/docs/zh/guide/cli/check.mdx
+++ b/website/docs/zh/guide/cli/check.mdx
@@ -1,0 +1,53 @@
+---
+description: '同时运行 lint 和格式检查，并可选启用 TypeScript 类型检查。'
+---
+
+# check
+
+`rs check` 命令可统一运行当前项目的 lint、格式和可选的 TypeScript 类型检查。默认情况下，它会先运行 [`rs lint`](./lint)，再运行 [`rs fmt --check`](./fmt#--check)。
+
+## 用法 \{#usage}
+
+```bash
+rs check [options]
+```
+
+## 检查内容 \{#checks}
+
+运行 `rs check` 等同于：
+
+```bash
+rs lint && rs fmt --check
+```
+
+各项检查会按顺序运行。如果 lint 失败，`rs check` 会停止运行，不再检查格式。只有所有已启用的检查均通过时，该命令才会成功退出。
+
+## 选项 \{#options}
+
+### `--type-check`
+
+在 lint 过程中启用 TypeScript 类型检查：
+
+```bash
+rs check --type-check
+```
+
+该命令等同于：
+
+```bash
+rs lint --type-check && rs fmt --check
+```
+
+省略此选项时，不会运行类型检查。
+
+### `-h, --help`
+
+显示命令用法和选项信息，但不运行检查：
+
+```bash
+rs check --help
+```
+
+## 配置 \{#configuration}
+
+`rs check` 没有独立的 `define.check()` 配置。它会使用 [`define.lint()`](../configuration#define-lint) 中的 lint 配置，以及 [`define.fmt()`](../configuration#define-fmt) 中的格式化配置。

--- a/website/docs/zh/guide/monorepo.mdx
+++ b/website/docs/zh/guide/monorepo.mdx
@@ -1,3 +1,7 @@
+---
+description: '在 Monorepo 中配置共享的 Rstack 检查、格式化、暂存文件任务和项目工作流。'
+---
+
 # Monorepo
 
 本指南介绍如何在 Monorepo 中使用 Rstack CLI，以及如何让它与 [Turborepo](https://turborepo.com/docs)、[Nx](https://nx.dev/docs/getting-started/intro) 等任务编排工具协同工作。
@@ -65,9 +69,9 @@ define.staged({
 {
   "private": true,
   "scripts": {
-    "lint": "rs lint",
+    "check": "rs check --type-check",
     "format": "rs fmt",
-    "check:format": "rs fmt --check",
+    "lint": "rs lint",
     "staged": "rs staged"
   }
 }

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -128,6 +128,7 @@ Available templates: app-vanilla-js, app-vanilla-ts, app-react-js, app-react-ts,
     "build": "rs build",
     "preview": "rs preview",
     "test": "rs test",
+    "check": "rs check",
     "lint": "rs lint",
     "format": "rs fmt"
   }
@@ -144,6 +145,7 @@ Rstack 提供以下命令：
 - [`rs lib`](./cli/lib)：使用 Rslib 构建库。
 - [`rs doc`](./cli/doc)：使用 Rspress 开发、构建或预览文档站点。
 - [`rs test`](./cli/test)：使用 Rstest 运行测试。
+- [`rs check`](./cli/check)：运行 lint 和格式检查，并可选启用 TypeScript 类型检查。
 - [`rs lint`](./cli/lint)：使用 Rslint 检查源代码。
 - [`rs fmt`](./cli/fmt)：格式化代码。
 - [`rs setup`](./cli/setup)：安装仓库级 Git hooks。


### PR DESCRIPTION
## Summary

This PR documents the `rs check` command so users can see how it combines linting, formatting checks, and optional TypeScript type checking. It adds aligned English and Chinese CLI references, updates quick-start and monorepo examples, and links commands in the root README to their documentation.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/304