### PR TITLE
feat(fmt): log when formatting starts

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -335,7 +335,9 @@ const runFmtCLI = async (args: string[]): Promise<void> => {
       }
     }
 
-    if (mode === 'check') {
+    if (mode === 'write') {
+      logger.start('Formatting...');
+    } else if (mode === 'check') {
       logger.start('Checking formatting...');
     }
 
@@ -350,6 +352,8 @@ const runFmtCLI = async (args: string[]): Promise<void> => {
       if (ignoreUnknown) {
         if (mode === 'check') {
           logger.success('No supported files to check.');
+        } else if (mode === 'write') {
+          logger.success('No supported files to format.');
         }
         return;
       }

--- a/packages/rstack/tests/cli/fmt/files.test.ts
+++ b/packages/rstack/tests/cli/fmt/files.test.ts
@@ -137,7 +137,7 @@ test('returns exit code 2 for formatting errors', () => {
   const result = runFmt(['index.ts']);
 
   expect(result.status).toBe(2);
-  expect(result.stdout).toBe('');
+  expect(result.stdout).toBe('start   Formatting...\n');
   expect(result.stderr).toContain('error   index.ts: SyntaxError:');
 });
 
@@ -148,7 +148,9 @@ test('reports partial writes when formatting fails', () => {
   const result = runFmt(['valid.ts', 'invalid.ts']);
 
   expect(result.status).toBe(2);
-  expect(normalizeDuration(result.stdout)).toBe('info    Formatted 1 of 2 files in <duration>.\n');
+  expect(normalizeDuration(result.stdout)).toBe(
+    'start   Formatting...\ninfo    Formatted 1 of 2 files in <duration>.\n',
+  );
   expect(result.stderr).toContain('error   invalid.ts: SyntaxError:');
   expect(readProjectFile('valid.ts')).toBe('const value = true;\n');
   expect(readProjectFile('invalid.ts')).toBe('const invalid = ;');

--- a/packages/rstack/tests/cli/fmt/helpers.ts
+++ b/packages/rstack/tests/cli/fmt/helpers.ts
@@ -34,7 +34,7 @@ export const expectWriteSummary = (
   const message = writtenCount
     ? `Formatted ${writtenCount} of ${matchedFileCount} ${files} in <duration>.`
     : `Checked ${matchedFileCount} ${files} in <duration>. No changes needed.`;
-  expect(normalizeDuration(output)).toBe(`success ${message}\n`);
+  expect(normalizeDuration(output)).toBe(`start   Formatting...\nsuccess ${message}\n`);
 };
 
 export const setupFmtTest = (): FmtTestHarness => {

--- a/packages/rstack/tests/cli/fmt/patterns.test.ts
+++ b/packages/rstack/tests/cli/fmt/patterns.test.ts
@@ -62,11 +62,12 @@ test('ignores unsupported files with --ignore-unknown', () => {
     const result = runFmt([...modeArgs, '--ignore-unknown', 'notes.unknown']);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toBe(
-      modeArgs.includes('--check')
-        ? 'start   Checking formatting...\nsuccess No supported files to check.\n'
-        : '',
-    );
+    const expectedStdout = modeArgs.includes('--check')
+      ? 'start   Checking formatting...\nsuccess No supported files to check.\n'
+      : modeArgs.includes('--list-different')
+        ? ''
+        : 'start   Formatting...\nsuccess No supported files to format.\n';
+    expect(result.stdout).toBe(expectedStdout);
     expect(result.stderr).toBe('');
   }
 });
@@ -77,7 +78,7 @@ test('supports -u as an alias for --ignore-unknown', () => {
   const result = runFmt(['-u', 'notes.unknown']);
 
   expect(result.status).toBe(0);
-  expect(result.stdout).toBe('');
+  expect(result.stdout).toBe('start   Formatting...\nsuccess No supported files to format.\n');
   expect(result.stderr).toBe('');
 });
 
@@ -95,6 +96,6 @@ test('does not treat unsupported files as unmatched patterns', () => {
   const result = runFmt(['--no-error-on-unmatched-pattern', 'notes.unknown']);
 
   expect(result.status).toBe(2);
-  expect(result.stdout).toBe('');
+  expect(result.stdout).toBe('start   Formatting...\n');
   expect(result.stderr).toContain('No supported files matched "notes.unknown"');
 });


### PR DESCRIPTION
## Summary

`rs fmt` did not report progress until write mode completed, unlike `rs fmt --check`. This PR adds a `Formatting...` start message for write mode and reports when `--ignore-unknown` leaves no supported files. Machine-readable `--list-different` and stdin output remain unchanged.