### PR TITLE
feat(create-rstack): use rs check in templates

### DIFF
--- a/packages/create-rstack/template-app-lit-ts/package.json
+++ b/packages/create-rstack/template-app-lit-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "check": "rs lint --type-check && rs fmt --check",
+    "check": "rs check --type-check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-lit/package.json
+++ b/packages/create-rstack/template-app-lit/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-preact-ts/package.json
+++ b/packages/create-rstack/template-app-preact-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "check": "rs lint --type-check && rs fmt --check",
+    "check": "rs check --type-check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-preact/package.json
+++ b/packages/create-rstack/template-app-preact/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-react-ts/package.json
+++ b/packages/create-rstack/template-app-react-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "check": "rs lint --type-check && rs fmt --check",
+    "check": "rs check --type-check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-react/package.json
+++ b/packages/create-rstack/template-app-react/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-solid-ts/package.json
+++ b/packages/create-rstack/template-app-solid-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "check": "rs lint --type-check && rs fmt --check",
+    "check": "rs check --type-check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-solid/package.json
+++ b/packages/create-rstack/template-app-solid/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-svelte-ts/package.json
+++ b/packages/create-rstack/template-app-svelte-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "svelte-check && rs build",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-svelte/package.json
+++ b/packages/create-rstack/template-app-svelte/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-vanilla-ts/package.json
+++ b/packages/create-rstack/template-app-vanilla-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "check": "rs lint --type-check && rs fmt --check",
+    "check": "rs check --type-check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-vanilla/package.json
+++ b/packages/create-rstack/template-app-vanilla/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-vue-ts/package.json
+++ b/packages/create-rstack/template-app-vue-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vue-tsc && rs build",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-app-vue/package.json
+++ b/packages/create-rstack/template-app-vue/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs build",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs dev",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-doc-i18n/package.json
+++ b/packages/create-rstack/template-doc-i18n/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs doc build",
-    "check": "rs lint --type-check && rs fmt --check",
+    "check": "rs check --type-check",
     "dev": "rs doc",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-doc/package.json
+++ b/packages/create-rstack/template-doc/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rs doc build",
-    "check": "rs lint --type-check && rs fmt --check",
+    "check": "rs check --type-check",
     "dev": "rs doc",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-node-ts/package.json
+++ b/packages/create-rstack/template-lib-node-ts/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "rs lib",
-    "check": "rs lint --type-check && rs fmt --check",
+    "check": "rs check --type-check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-node/package.json
+++ b/packages/create-rstack/template-lib-node/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "rs lib",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-react-ts/package.json
+++ b/packages/create-rstack/template-lib-react-ts/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "rs lib",
-    "check": "rs lint --type-check && rs fmt --check",
+    "check": "rs check --type-check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-react/package.json
+++ b/packages/create-rstack/template-lib-react/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "build": "rs lib",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-solid-ts/package.json
+++ b/packages/create-rstack/template-lib-solid-ts/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "rs lib",
-    "check": "rs lint --type-check && rs fmt --check",
+    "check": "rs check --type-check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-solid/package.json
+++ b/packages/create-rstack/template-lib-solid/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "rs lib",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-svelte-ts/package.json
+++ b/packages/create-rstack/template-lib-svelte-ts/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "svelte-check && rs lib",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-svelte/package.json
+++ b/packages/create-rstack/template-lib-svelte/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "build": "rs lib",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-vue-ts/package.json
+++ b/packages/create-rstack/template-lib-vue-ts/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "rs lib && vue-tsc",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/template-lib-vue/package.json
+++ b/packages/create-rstack/template-lib-vue/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "build": "rs lib",
-    "check": "rs lint && rs fmt --check",
+    "check": "rs check",
     "dev": "rs lib --watch",
     "format": "rs fmt",
     "lint": "rs lint",

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -9,8 +9,8 @@ const execFileAsync = promisify(execFile);
 const packageRoot = path.resolve(import.meta.dirname, '..');
 const binPath = path.join(packageRoot, 'bin.js');
 const tempDirectories: string[] = [];
-const jsCheckScript = 'rs lint && rs fmt --check';
-const tsCheckScript = 'rs lint --type-check && rs fmt --check';
+const checkScript = 'rs check';
+const typeCheckScript = 'rs check --type-check';
 const templatesWithoutTypeCheck = new Set([
   'app-svelte-ts',
   'app-vue-ts',
@@ -74,7 +74,7 @@ const docTemplates = [
 ];
 
 const getCheckScript = (template: string, hasTypeScript: boolean): string =>
-  hasTypeScript && !templatesWithoutTypeCheck.has(template) ? tsCheckScript : jsCheckScript;
+  hasTypeScript && !templatesWithoutTypeCheck.has(template) ? typeCheckScript : checkScript;
 
 const readProjectPackage = async (projectDirectory: string): Promise<ProjectPackage> =>
   JSON.parse(await readFile(path.join(projectDirectory, 'package.json'), 'utf8')) as ProjectPackage;


### PR DESCRIPTION
## Summary

The templates still compose `rs lint` and `rs fmt` even though Rstack now provides the unified `rs check` command. This updates all app, library, and documentation templates to use `rs check`, retaining `--type-check` only where it was previously enabled, and aligns the generation tests.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/304
- https://github.com/rstackjs/rstack-cli/pull/308