### PR TITLE
test: increase doc build timeout

### DIFF
--- a/packages/rstack/tests/config/define-doc/index.test.ts
+++ b/packages/rstack/tests/config/define-doc/index.test.ts
@@ -12,4 +12,4 @@ test('should build docs with define.doc config', async ({ prepareDist, execCli, 
   const output = getFileContent(files, 'index.html');
 
   expect(output).toContain(expectedText);
-}, 15_000);
+}, 30_000);


### PR DESCRIPTION
## Summary

The full Rspress documentation build can exceed 15 seconds on slower Windows runners even when the build succeeds. This increases the test-specific timeout to 30 seconds to provide enough CI headroom without changing global test behavior.

## Related Links

- https://github.com/rstackjs/rstack-cli/actions/runs/31463004338/job/93690147211