### PR TITLE
build(native): configure Cargo profiles

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,10 +41,10 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Lint Rust
-        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+        run: cargo clippy --profile ci --workspace --all-targets --locked -- -D warnings
 
       - name: Build Native Binding
-        run: pnpm --filter rstack build:native
+        run: pnpm --filter rstack build:native:ci
 
       - name: Check
         run: node --run check

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -96,6 +96,7 @@ jobs:
               export MACOSX_DEPLOYMENT_TARGET=11.0
               ;;
             i686-pc-windows-msvc)
+              # Reduce peak link time and memory usage for the constrained 32-bit target.
               export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=32
               export CARGO_PROFILE_RELEASE_LTO=false
               ;;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,10 @@ jobs:
         run: node --run build
 
       - name: Run Rust Tests
-        run: cargo test --workspace --locked
+        run: cargo test --profile ci --workspace --locked
 
       - name: Build Native Binding
-        run: pnpm --filter rstack build:native:release
+        run: pnpm --filter rstack build:native:ci
 
       - name: Check Generated Native Files
         run: git diff --exit-code -- packages/rstack/binding.cjs packages/rstack/binding.d.cts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,34 @@ napi-derive = "3.6.2"
 pathdiff = "0.2.3"
 rstack-ignore = { path = "crates/rstack-ignore" }
 
+# Local development: 16 codegen units are sufficient for this small workspace while preserving
+# parallel compilation and full debugging support.
+[profile.dev]
+codegen-units = 16
+debug = 2
+incremental = true
+panic = "unwind"
+split-debuginfo = "unpacked"
+
+# CI: 256 codegen units favor clean-build parallelism, while disabling cross-crate LTO avoids the
+# release-only linking cost.
+[profile.ci]
+codegen-units = 256
+debug = false
+incremental = false
+inherits = "release"
+lto = false
+opt-level = 2
+# Cargo tests require unwinding, so keep the CI native build consistent.
+panic = "unwind"
+strip = false
+
+# Release: one codegen unit and fat LTO maximize optimization; abort prevents unwinding across the
+# NAPI FFI boundary.
 [profile.release]
-lto = true
-strip = "symbols"
+codegen-units = 1
+debug = false
+lto = "fat"
+opt-level = 3
+panic = "abort"
+strip = true

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -66,6 +66,7 @@
   "scripts": {
     "build": "rslib",
     "build:native": "napi build --config-path napi.json --platform --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
+    "build:native:ci": "napi build --config-path napi.json --platform --profile ci --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
     "build:native:release": "napi build --config-path napi.json --platform --release --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
     "dev": "rslib -w",
     "package:native": "napi create-npm-dirs --config-path napi.json",


### PR DESCRIPTION
## Summary

This PR adds explicit Cargo profiles for local development, CI, and published native bindings. CI uses an optimized profile without release-only fat LTO, while release builds use one codegen unit, fat LTO, abort-on-panic, and symbol stripping.

## Binary size

Measured with clean NAPI-RS release builds from identical sources and toolchains on `aarch64-apple-darwin`.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Raw `.node` | 1,281,936 B | 1,066,560 B | -215,376 B (-16.80%) |
| gzip -9 | 588,693 B | 510,889 B | -77,804 B (-13.22%) |

The exception and unwind sections decreased by 132,616 B, accounting for most of the reduction.

Validated with Cargo formatting, clippy, CI-profile tests, CI and release NAPI builds, package builds and checks, and 223 Rstest cases against both native profiles.