### PR TITLE
build(native): reduce release binary size

### DIFF
--- a/.cargo/release.toml
+++ b/.cargo/release.toml
@@ -1,0 +1,3 @@
+# Remove source locations from release panic metadata to reduce binary size.
+[target.'cfg(all())']
+rustflags = ["-Zlocation-detail=none"]

--- a/.cargo/release.toml
+++ b/.cargo/release.toml
@@ -1,3 +1,0 @@
-# Remove source locations from release panic metadata to reduce binary size.
-[target.'cfg(all())']
-rustflags = ["-Zlocation-detail=none"]

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -109,6 +109,7 @@ jobs:
               ;;
           esac
 
+          args+=(-- --config ../../.cargo/release.toml)
           pnpm exec napi "${args[@]}"
 
       - name: Upload native binding

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -109,7 +109,7 @@ jobs:
               ;;
           esac
 
-          args+=(-- --config ../../.cargo/release.toml)
+          args+=(-- --config "target.'cfg(all())'.rustflags = ['-Zlocation-detail=none']")
           pnpm exec napi "${args[@]}"
 
       - name: Upload native binding

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -110,7 +110,7 @@ jobs:
           esac
 
           # Omit panic source locations to reduce the release binary size.
-          args+=(-- --config "target.'cfg(all())'.rustflags = ['-Zlocation-detail=none']")
+          args+=(-- --config ../../.cargo/release.toml)
           pnpm exec napi "${args[@]}"
 
       - name: Upload native binding

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -109,6 +109,7 @@ jobs:
               ;;
           esac
 
+          # Omit panic source locations to reduce the release binary size.
           args+=(-- --config "target.'cfg(all())'.rustflags = ['-Zlocation-detail=none']")
           pnpm exec napi "${args[@]}"
 

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -67,7 +67,7 @@
     "build": "rslib",
     "build:native": "napi build --config-path napi.json --platform --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
     "build:native:ci": "napi build --config-path napi.json --platform --profile ci --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
-    "build:native:release": "napi build --config-path napi.json --platform --release --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
+    "build:native:release": "napi build --config-path napi.json --platform --release --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts -- --config ../../.cargo/release.toml",
     "dev": "rslib -w",
     "package:native": "napi create-npm-dirs --config-path napi.json",
     "test": "rs test"

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -67,7 +67,7 @@
     "build": "rslib",
     "build:native": "napi build --config-path napi.json --platform --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
     "build:native:ci": "napi build --config-path napi.json --platform --profile ci --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
-    "build:native:release": "napi build --config-path napi.json --platform --release --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts -- --config ../../.cargo/release.toml",
+    "build:native:release": "napi build --config-path napi.json --platform --release --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts -- --config \"target.'cfg(all())'.rustflags = ['-Zlocation-detail=none']\"",
     "dev": "rslib -w",
     "package:native": "napi create-npm-dirs --config-path napi.json",
     "test": "rs test"

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -67,7 +67,7 @@
     "build": "rslib",
     "build:native": "napi build --config-path napi.json --platform --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
     "build:native:ci": "napi build --config-path napi.json --platform --profile ci --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
-    "build:native:release": "napi build --config-path napi.json --platform --release --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts -- --config \"target.'cfg(all())'.rustflags = ['-Zlocation-detail=none']\"",
+    "build:native:release": "napi build --config-path napi.json --platform --release --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts -- --config ../../.cargo/release.toml",
     "dev": "rslib -w",
     "package:native": "napi create-npm-dirs --config-path napi.json",
     "test": "rs test"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
-channel = "1.97.1"
+# Required by the release-only -Zlocation-detail=none flag.
+channel = "nightly-2026-04-16"
 components = ["clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

Pin Rust to `nightly-2026-04-16` and enable `-Zlocation-detail=none` only for local and CI release native builds. This removes source locations from panic metadata without changing the dev or CI profile flags.

Paired macOS arm64 builds from the same commit and nightly toolchain:

| Release build | Binary size | Change |
| --- | ---: | ---: |
| Without `-Zlocation-detail=none` | 1,066,560 bytes | — |
| With `-Zlocation-detail=none` | 1,016,928 bytes | -49,632 bytes (-4.65%) |

The existing `rs fmt --check` benchmark showed no statistically significant execution-time change.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --profile ci --workspace --all-targets --locked -- -D warnings`
- `cargo test --profile ci --workspace --locked`
- `pnpm --filter rstack build:native:release`
- `pnpm build`
- `pnpm check`
- `pnpm --filter rstack test` (223 tests)

## Related Links

- https://github.com/web-infra-dev/rspack/blob/main/crates/node_binding/scripts/build.js