### PR TITLE
feat(rstack): add help for Rslib commands

### DIFF
--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -110,6 +110,84 @@ const renderPreviewHelp = (): string =>
     ],
   });
 
+const renderLibHelp = (): string =>
+  renderHelp({
+    usage: 'rs lib [command] [options]',
+    sections: [
+      {
+        title: 'Commands',
+        items: [
+          ['build', 'Build the library for production (default)'],
+          ['inspect', 'Inspect Rslib, Rsbuild, and Rspack configs'],
+          ['mf-dev', 'Start Rsbuild dev server for Module Federation'],
+        ],
+      },
+      {
+        content: `For command-specific options, run:
+  $ rs lib <command> -h`,
+        dim: true,
+      },
+      {
+        title: 'Options',
+        items: [
+          ['-w, --watch', 'Enable watch mode and rebuild on changes'],
+          ['--dts', 'Emit declaration files (use --no-dts to disable)'],
+          ['-c, --config <path>', 'Specify Rstack config file path'],
+          ['-h, --help', 'Display this help message'],
+        ],
+      },
+    ],
+  });
+
+const renderLibBuildHelp = (): string =>
+  renderHelp({
+    usage: 'rs lib build [options]',
+    description: 'Build the library for production',
+    sections: [
+      {
+        title: 'Options',
+        items: [
+          ['-w, --watch', 'Enable watch mode and rebuild on changes'],
+          ['--dts', 'Emit declaration files (use --no-dts to disable)'],
+          ['-c, --config <path>', 'Specify Rstack config file path'],
+          ['-h, --help', 'Display this help message'],
+        ],
+      },
+    ],
+  });
+
+const renderLibInspectHelp = (): string =>
+  renderHelp({
+    usage: 'rs lib inspect [options]',
+    description: 'Inspect Rslib, Rsbuild, and Rspack configs',
+    sections: [
+      {
+        title: 'Options',
+        items: [
+          ['--output <path>', 'Set the output path for inspection results (default: .rsbuild)'],
+          ['--verbose', 'Show complete function definitions in output'],
+          ['-c, --config <path>', 'Specify Rstack config file path'],
+          ['-h, --help', 'Display this help message'],
+        ],
+      },
+    ],
+  });
+
+const renderLibMfDevHelp = (): string =>
+  renderHelp({
+    usage: 'rs lib mf-dev [options]',
+    description: 'Start Rsbuild dev server for Module Federation',
+    sections: [
+      {
+        title: 'Options',
+        items: [
+          ['-c, --config <path>', 'Specify Rstack config file path'],
+          ['-h, --help', 'Display this help message'],
+        ],
+      },
+    ],
+  });
+
 async function runRsbuildCLI(args: string[]): Promise<void> {
   if (hasHelpFlag(args)) {
     switch (args[0]) {
@@ -147,6 +225,23 @@ async function runRstestCLI(args: string[]): Promise<void> {
 }
 
 async function runRslibCLI(args: string[]): Promise<void> {
+  if (hasHelpFlag(args)) {
+    switch (args[0]) {
+      case 'build':
+        console.log(renderLibBuildHelp());
+        return;
+      case 'inspect':
+        console.log(renderLibInspectHelp());
+        return;
+      case 'mf-dev':
+        console.log(renderLibMfDevHelp());
+        return;
+      default:
+        console.log(renderLibHelp());
+        return;
+    }
+  }
+
   const argv = [
     process.execPath,
     'rslib',

--- a/packages/rstack/tests/cli/__snapshots__/help.test.ts.snap
+++ b/packages/rstack/tests/cli/__snapshots__/help.test.ts.snap
@@ -35,6 +35,74 @@ Options:
 "
 `;
 
+exports[`displays lib build help 1`] = `
+"Rstack v<version>
+
+Usage:
+  $ rs lib build [options]
+
+Build the library for production
+
+Options:
+  -w, --watch          Enable watch mode and rebuild on changes
+  --dts                Emit declaration files (use --no-dts to disable)
+  -c, --config <path>  Specify Rstack config file path
+  -h, --help           Display this help message
+"
+`;
+
+exports[`displays lib help 1`] = `
+"Rstack v<version>
+
+Usage:
+  $ rs lib [command] [options]
+
+Commands:
+  build    Build the library for production (default)
+  inspect  Inspect Rslib, Rsbuild, and Rspack configs
+  mf-dev   Start Rsbuild dev server for Module Federation
+
+For command-specific options, run:
+  $ rs lib <command> -h
+
+Options:
+  -w, --watch          Enable watch mode and rebuild on changes
+  --dts                Emit declaration files (use --no-dts to disable)
+  -c, --config <path>  Specify Rstack config file path
+  -h, --help           Display this help message
+"
+`;
+
+exports[`displays lib inspect help 1`] = `
+"Rstack v<version>
+
+Usage:
+  $ rs lib inspect [options]
+
+Inspect Rslib, Rsbuild, and Rspack configs
+
+Options:
+  --output <path>      Set the output path for inspection results (default: .rsbuild)
+  --verbose            Show complete function definitions in output
+  -c, --config <path>  Specify Rstack config file path
+  -h, --help           Display this help message
+"
+`;
+
+exports[`displays lib mf-dev help 1`] = `
+"Rstack v<version>
+
+Usage:
+  $ rs lib mf-dev [options]
+
+Start Rsbuild dev server for Module Federation
+
+Options:
+  -c, --config <path>  Specify Rstack config file path
+  -h, --help           Display this help message
+"
+`;
+
 exports[`displays preview help 1`] = `
 "Rstack v<version>
 

--- a/packages/rstack/tests/cli/help.test.ts
+++ b/packages/rstack/tests/cli/help.test.ts
@@ -20,3 +20,12 @@ for (const command of ['dev', 'build', 'preview']) {
     expect(normalizeHelpOutput(output)).toMatchSnapshot();
   });
 }
+
+for (const command of ['lib', 'lib build', 'lib inspect', 'lib mf-dev']) {
+  test(`displays ${command} help`, ({ execCli, expect }) => {
+    const output = execCli(`${command} --help`);
+
+    expect(execCli(`${command} -h`)).toBe(output);
+    expect(normalizeHelpOutput(output)).toMatchSnapshot();
+  });
+}


### PR DESCRIPTION
## Summary

Rstack currently delegates `rs lib` help to Rslib, exposing upstream branding and options outside Rstack's CLI surface. This PR renders dedicated help for `rs lib` and its `build`, `inspect`, and `mf-dev` subcommands before loading Rslib, with snapshot coverage for both help flags.