### PR TITLE
feat(rstack): add help for Rslint command

### DIFF
--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -321,6 +321,31 @@ const renderLibMfDevHelp = (): string =>
     ],
   });
 
+const renderLintHelp = (): string =>
+  renderHelp({
+    usage: 'rs lint [options] [files...]',
+    description: 'Lint code',
+    sections: [
+      {
+        title: 'Options',
+        items: [
+          ['--fix', 'Automatically fix problems'],
+          ['--type-check', 'Enable TypeScript type checking'],
+          ['--type-check-only', 'Run only TypeScript type checking'],
+          ['--format <format>', 'Set output format (default | jsonline | github | gitlab)'],
+          ['--quiet', 'Report errors only'],
+          ['--timing [all|N]', 'Print a per-rule timing table (all rules or top N)'],
+          ['--max-warnings <count>', 'Set the maximum number of warnings'],
+          ['--rule <rule>', 'Override a rule (repeatable)'],
+          ['--no-color', 'Disable colored output'],
+          ['--force-color', 'Force colored output'],
+          ['-c, --config <path>', 'Specify Rstack config file path'],
+          ['-h, --help', 'Display this help message'],
+        ],
+      },
+    ],
+  });
+
 async function runRsbuildCLI(args: string[]): Promise<void> {
   if (hasHelpFlag(args)) {
     switch (args[0]) {
@@ -439,6 +464,11 @@ async function runRspressCLI(args: string[]): Promise<void> {
 }
 
 async function runRslintCLI(args: string[]): Promise<void> {
+  if (hasHelpFlag(args)) {
+    console.log(renderLintHelp());
+    return;
+  }
+
   const argv = [
     process.execPath,
     'rslint',

--- a/packages/rstack/tests/cli/__snapshots__/help.test.ts.snap
+++ b/packages/rstack/tests/cli/__snapshots__/help.test.ts.snap
@@ -103,6 +103,30 @@ Options:
 "
 `;
 
+exports[`displays lint help 1`] = `
+"Rstack v<version>
+
+Usage:
+  $ rs lint [options] [files...]
+
+Lint code
+
+Options:
+  --fix                   Automatically fix problems
+  --type-check            Enable TypeScript type checking
+  --type-check-only       Run only TypeScript type checking
+  --format <format>       Set output format (default | jsonline | github | gitlab)
+  --quiet                 Report errors only
+  --timing [all|N]        Print a per-rule timing table (all rules or top N)
+  --max-warnings <count>  Set the maximum number of warnings
+  --rule <rule>           Override a rule (repeatable)
+  --no-color              Disable colored output
+  --force-color           Force colored output
+  -c, --config <path>     Specify Rstack config file path
+  -h, --help              Display this help message
+"
+`;
+
 exports[`displays preview help 1`] = `
 "Rstack v<version>
 

--- a/packages/rstack/tests/cli/help.test.ts
+++ b/packages/rstack/tests/cli/help.test.ts
@@ -12,7 +12,7 @@ test('displays top-level help', ({ execCli, expect }) => {
   expect(normalizeHelpOutput(execCli('--help'))).toMatchSnapshot();
 });
 
-for (const command of ['dev', 'build', 'preview']) {
+for (const command of ['dev', 'build', 'preview', 'lint']) {
   test(`displays ${command} help`, ({ execCli, expect }) => {
     const output = execCli(`${command} --help`);
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -10,6 +10,7 @@ extglob
 fnames
 huskyrc
 indentable
+jsonline
 llms
 napi
 noformat


### PR DESCRIPTION
Rstack currently delegates `rs lint` help output to Rslint, making it inconsistent with the unified CLI help style. This PR adds declarative help for `rs lint`, excludes the standalone `--init` workflow, and snapshots the migrated output.