### PR TITLE
feat(rstack): add help for Rspress commands

### DIFF
--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -110,6 +110,86 @@ const renderPreviewHelp = (): string =>
     ],
   });
 
+const renderDocHelp = (): string =>
+  renderHelp({
+    usage: 'rs doc [command] [root] [options]',
+    sections: [
+      {
+        title: 'Commands',
+        items: [
+          ['[root]', 'Run the docs dev server (default)'],
+          ['build [root]', 'Build docs for production'],
+          ['preview [root]', 'Preview the docs production build'],
+          ['eject [component]', 'Eject a theme component'],
+        ],
+      },
+      {
+        content: `For command-specific options, run:
+  $ rs doc <command> -h`,
+        dim: true,
+      },
+      {
+        title: 'Options',
+        items: [
+          ['--port <port>', 'Set the port number for the server'],
+          ['--host [host]', 'Set the host that the server listens to'],
+          ['--base <base>', 'Set the base path and override config.base'],
+          ['-c, --config <path>', 'Specify Rstack config file path'],
+          ['-h, --help', 'Display this help message'],
+        ],
+      },
+    ],
+  });
+
+const renderDocBuildHelp = (): string =>
+  renderHelp({
+    usage: 'rs doc build [root] [options]',
+    description: 'Build docs for production',
+    sections: [
+      {
+        title: 'Options',
+        items: [
+          ['--base <base>', 'Set the base path and override config.base'],
+          ['-c, --config <path>', 'Specify Rstack config file path'],
+          ['-h, --help', 'Display this help message'],
+        ],
+      },
+    ],
+  });
+
+const renderDocPreviewHelp = (): string =>
+  renderHelp({
+    usage: 'rs doc preview [root] [options]',
+    description: 'Preview the docs production build',
+    sections: [
+      {
+        title: 'Options',
+        items: [
+          ['--port <port>', 'Set the port number for the server'],
+          ['--host [host]', 'Set the host that the server listens to'],
+          ['--base <base>', 'Set the base path and override config.base'],
+          ['-c, --config <path>', 'Specify Rstack config file path'],
+          ['-h, --help', 'Display this help message'],
+        ],
+      },
+    ],
+  });
+
+const renderDocEjectHelp = (): string =>
+  renderHelp({
+    usage: 'rs doc eject [component] [options]',
+    description: 'Eject a theme component',
+    sections: [
+      {
+        title: 'Options',
+        items: [
+          ['-c, --config <path>', 'Specify Rstack config file path'],
+          ['-h, --help', 'Display this help message'],
+        ],
+      },
+    ],
+  });
+
 const renderTestHelp = (): string =>
   renderHelp({
     usage: 'rs test [command] [...filters] [options]',
@@ -443,6 +523,23 @@ const isMissingRspressCoreError = (error: unknown): boolean => {
 };
 
 async function runRspressCLI(args: string[]): Promise<void> {
+  if (hasHelpFlag(args)) {
+    switch (args[0]) {
+      case 'build':
+        console.log(renderDocBuildHelp());
+        return;
+      case 'preview':
+        console.log(renderDocPreviewHelp());
+        return;
+      case 'eject':
+        console.log(renderDocEjectHelp());
+        return;
+      default:
+        console.log(renderDocHelp());
+        return;
+    }
+  }
+
   const argv = [
     process.execPath,
     'rspress',

--- a/packages/rstack/tests/cli/__snapshots__/help.test.ts.snap
+++ b/packages/rstack/tests/cli/__snapshots__/help.test.ts.snap
@@ -35,6 +35,76 @@ Options:
 "
 `;
 
+exports[`displays doc build help 1`] = `
+"Rstack v<version>
+
+Usage:
+  $ rs doc build [root] [options]
+
+Build docs for production
+
+Options:
+  --base <base>        Set the base path and override config.base
+  -c, --config <path>  Specify Rstack config file path
+  -h, --help           Display this help message
+"
+`;
+
+exports[`displays doc eject help 1`] = `
+"Rstack v<version>
+
+Usage:
+  $ rs doc eject [component] [options]
+
+Eject a theme component
+
+Options:
+  -c, --config <path>  Specify Rstack config file path
+  -h, --help           Display this help message
+"
+`;
+
+exports[`displays doc help 1`] = `
+"Rstack v<version>
+
+Usage:
+  $ rs doc [command] [root] [options]
+
+Commands:
+  [root]             Run the docs dev server (default)
+  build [root]       Build docs for production
+  preview [root]     Preview the docs production build
+  eject [component]  Eject a theme component
+
+For command-specific options, run:
+  $ rs doc <command> -h
+
+Options:
+  --port <port>        Set the port number for the server
+  --host [host]        Set the host that the server listens to
+  --base <base>        Set the base path and override config.base
+  -c, --config <path>  Specify Rstack config file path
+  -h, --help           Display this help message
+"
+`;
+
+exports[`displays doc preview help 1`] = `
+"Rstack v<version>
+
+Usage:
+  $ rs doc preview [root] [options]
+
+Preview the docs production build
+
+Options:
+  --port <port>        Set the port number for the server
+  --host [host]        Set the host that the server listens to
+  --base <base>        Set the base path and override config.base
+  -c, --config <path>  Specify Rstack config file path
+  -h, --help           Display this help message
+"
+`;
+
 exports[`displays lib build help 1`] = `
 "Rstack v<version>
 

--- a/packages/rstack/tests/cli/help.test.ts
+++ b/packages/rstack/tests/cli/help.test.ts
@@ -30,6 +30,15 @@ for (const command of ['lib', 'lib build', 'lib inspect', 'lib mf-dev']) {
   });
 }
 
+for (const command of ['doc', 'doc build', 'doc preview', 'doc eject']) {
+  test(`displays ${command} help`, ({ execCli, expect }) => {
+    const output = execCli(`${command} --help`);
+
+    expect(execCli(`${command} -h`)).toBe(output);
+    expect(normalizeHelpOutput(output)).toMatchSnapshot();
+  });
+}
+
 for (const command of [
   'test',
   'test run',


### PR DESCRIPTION
Rstack currently delegates `rs doc` help to Rspress, exposing upstream branding and options outside Rstack's CLI surface. This PR renders dedicated help for `rs doc` and its supported `build`, `preview`, and `eject` subcommands before loading Rspress, with snapshot coverage for both help flags.