### PR TITLE
fix(fmt): propagate native gitignore errors

### DIFF
--- a/packages/rstack/src/fmt/discoverPaths.ts
+++ b/packages/rstack/src/fmt/discoverPaths.ts
@@ -188,13 +188,14 @@ class GitIgnoreFiles {
     }
 
     // Ignore files may disappear or become unreadable during traversal.
-    const loading = readFile(path.join(directoryPath, '.gitignore'), 'utf8')
-      .then((content) => {
+    const loading = readFile(path.join(directoryPath, '.gitignore'), 'utf8').then(
+      (content) => {
         const relativePath = toPosixPath(this.#resolveRelativePath(directoryPath));
         this.#matcher ??= new (loadNativeBinding().GitIgnoreMatcher)();
         this.#hasRules = this.#matcher.addSource(relativePath, content);
-      })
-      .catch(() => undefined);
+      },
+      () => undefined,
+    );
 
     this.#loads.set(directoryPath, loading);
     return loading;
@@ -204,11 +205,14 @@ class GitIgnoreFiles {
 const createTraversalOptions = (
   gitIgnore: GitIgnoreFiles,
   ignoredDirNames: ReadonlySet<string>,
+  signal: { aborted: boolean },
+  onError: (error: unknown) => void,
   isIncluded?: (filePath: string) => boolean,
   isIgnored?: (filePath: string, isDirectory: boolean) => boolean,
 ) => {
   return {
     followSymlinks: false,
+    signal,
     ignore: (targetPath: string, targetContext: DirentLike) => {
       // With symlink following disabled, tiny-readdir always provides a Dirent here.
       const dirent = targetContext as Dirent;
@@ -233,41 +237,76 @@ const createTraversalOptions = (
       );
     },
     onDirents: async (dirents: Dirent[]) => {
-      const parentPath = getDirentParentPath(dirents[0]);
-      let hasGitIgnore = false;
+      try {
+        const parentPath = getDirentParentPath(dirents[0]);
+        let hasGitIgnore = false;
 
-      for (const dirent of dirents) {
-        if (dirent.name === '.gitignore') {
-          hasGitIgnore = true;
-        }
-      }
-
-      if (hasGitIgnore) {
-        await gitIgnore.load(parentPath);
-      }
-
-      const ignored = gitIgnore.matchDirents(parentPath, dirents);
-      if (typeof ignored === 'boolean') {
-        if (ignored) {
-          (dirents[0] as GitIgnoreDirent)[gitIgnored] = true;
-        }
-      } else if (typeof ignored === 'number') {
-        for (let index = 0; index < dirents.length; index++) {
-          if (ignored & (1 << index)) {
-            (dirents[index] as GitIgnoreDirent)[gitIgnored] = true;
+        for (const dirent of dirents) {
+          if (dirent.name === '.gitignore') {
+            hasGitIgnore = true;
           }
         }
-      } else if (ignored) {
-        for (let index = 0; index < ignored.length; index++) {
-          if (ignored[index] === 1) {
-            (dirents[index] as GitIgnoreDirent)[gitIgnored] = true;
+
+        if (hasGitIgnore) {
+          await gitIgnore.load(parentPath);
+        }
+
+        const ignored = gitIgnore.matchDirents(parentPath, dirents);
+        if (typeof ignored === 'boolean') {
+          if (ignored) {
+            (dirents[0] as GitIgnoreDirent)[gitIgnored] = true;
+          }
+        } else if (typeof ignored === 'number') {
+          for (let index = 0; index < dirents.length; index++) {
+            if (ignored & (1 << index)) {
+              (dirents[index] as GitIgnoreDirent)[gitIgnored] = true;
+            }
+          }
+        } else if (ignored) {
+          for (let index = 0; index < ignored.length; index++) {
+            if (ignored[index] === 1) {
+              (dirents[index] as GitIgnoreDirent)[gitIgnored] = true;
+            }
           }
         }
+      } catch (error) {
+        onError(error);
       }
 
       return undefined;
     },
   };
+};
+
+const discoverDirectoryFiles = async (
+  rootPath: string,
+  gitIgnore: GitIgnoreFiles,
+  ignoredDirNames: ReadonlySet<string>,
+  isIncluded?: (filePath: string) => boolean,
+  isIgnored?: (filePath: string, isDirectory: boolean) => boolean,
+): Promise<string[]> => {
+  let failed = false;
+  let failure: unknown;
+  const signal = { aborted: false };
+  const onError = (error: unknown): void => {
+    if (!failed) {
+      failed = true;
+      failure = error;
+    }
+    signal.aborted = true;
+  };
+
+  const result = await readdir(
+    rootPath,
+    createTraversalOptions(gitIgnore, ignoredDirNames, signal, onError, isIncluded, isIgnored),
+  );
+
+  // tiny-readdir only handles fulfilled onDirents promises, so rethrow after its counter settles.
+  if (failed) {
+    throw failure;
+  }
+
+  return result.files;
 };
 
 const normalizeGlob = (cwd: string, pattern: string): string => {
@@ -426,12 +465,7 @@ const discoverFmtPaths = async ({
               return globMatchers.some((matches) => matches(relativePath));
             };
 
-        return (
-          await readdir(
-            rootPath,
-            createTraversalOptions(gitIgnore, ignoredDirNames, isIncluded, isIgnored),
-          )
-        ).files;
+        return discoverDirectoryFiles(rootPath, gitIgnore, ignoredDirNames, isIncluded, isIgnored);
       }),
     );
 

--- a/packages/rstack/tests/fmt/discoverPaths.test.ts
+++ b/packages/rstack/tests/fmt/discoverPaths.test.ts
@@ -1,7 +1,8 @@
 import { symlinkSync } from 'node:fs';
 import path from 'node:path';
-import { expect, test } from 'rstack/test';
+import { expect, rs, test } from 'rstack/test';
 import { discoverFmtPaths } from '../../src/fmt/discoverPaths.ts';
+import { loadNativeBinding } from '../../src/native/index.ts';
 import { withTempProject, writeProjectFile } from './helpers.ts';
 
 const relativePaths = (rootPath: string, files: string[]): string[] =>
@@ -162,6 +163,44 @@ test('keeps valid nested gitignore rules around normalized and malformed lines',
     const files = await discoverFmtPaths({ cwd: rootPath, patterns: ['**/*.{js,ts}'] });
 
     expect(relativePaths(rootPath, files)).toEqual([path.join('src', 'keep.js'), 'visible.ts']);
+  });
+});
+
+test.sequential('propagates errors while loading a nested gitignore', async () => {
+  await withTempProject(async (rootPath) => {
+    writeProjectFile(rootPath, 'src/.gitignore', '*.js\n');
+    writeProjectFile(rootPath, 'src/index.js');
+    const nativeError = new Error('Failed to add nested gitignore source');
+    const addSource = rs
+      .spyOn(loadNativeBinding().GitIgnoreMatcher.prototype, 'addSource')
+      .mockImplementation(() => {
+        throw nativeError;
+      });
+
+    try {
+      await expect(discoverFmtPaths({ cwd: rootPath })).rejects.toBe(nativeError);
+    } finally {
+      addSource.mockRestore();
+    }
+  });
+});
+
+test.sequential('propagates errors from batched native gitignore matching', async () => {
+  await withTempProject(async (rootPath) => {
+    writeProjectFile(rootPath, '.gitignore', '*.js\n');
+    writeProjectFile(rootPath, 'index.js');
+    const nativeError = new Error('Failed to match gitignore entries');
+    const matchBatch = rs
+      .spyOn(loadNativeBinding().GitIgnoreMatcher.prototype, 'isIgnoredBatchMask')
+      .mockImplementation(() => {
+        throw nativeError;
+      });
+
+    try {
+      await expect(discoverFmtPaths({ cwd: rootPath })).rejects.toBe(nativeError);
+    } finally {
+      matchBatch.mockRestore();
+    }
   });
 });
 

--- a/packages/rstack/tests/fmt/discoverPaths.test.ts
+++ b/packages/rstack/tests/fmt/discoverPaths.test.ts
@@ -2,7 +2,7 @@ import { symlinkSync } from 'node:fs';
 import path from 'node:path';
 import { expect, rs, test } from 'rstack/test';
 import { discoverFmtPaths } from '../../src/fmt/discoverPaths.ts';
-import { loadNativeBinding } from '../../src/native/index.ts';
+import * as nativeBinding from '../../src/native/index.ts';
 import { withTempProject, writeProjectFile } from './helpers.ts';
 
 const relativePaths = (rootPath: string, files: string[]): string[] =>
@@ -166,13 +166,13 @@ test('keeps valid nested gitignore rules around normalized and malformed lines',
   });
 });
 
-test.sequential('propagates errors while loading a nested gitignore', async () => {
+test('propagates native binding errors while loading a nested gitignore', async () => {
   await withTempProject(async (rootPath) => {
     writeProjectFile(rootPath, 'src/.gitignore', '*.js\n');
     writeProjectFile(rootPath, 'src/index.js');
-    const nativeError = new Error('Failed to add nested gitignore source');
-    const addSource = rs
-      .spyOn(loadNativeBinding().GitIgnoreMatcher.prototype, 'addSource')
+    const nativeError = new Error('Failed to load native binding');
+    const loadNativeBinding = rs
+      .spyOn(nativeBinding, 'loadNativeBinding')
       .mockImplementation(() => {
         throw nativeError;
       });
@@ -180,26 +180,7 @@ test.sequential('propagates errors while loading a nested gitignore', async () =
     try {
       await expect(discoverFmtPaths({ cwd: rootPath })).rejects.toBe(nativeError);
     } finally {
-      addSource.mockRestore();
-    }
-  });
-});
-
-test.sequential('propagates errors from batched native gitignore matching', async () => {
-  await withTempProject(async (rootPath) => {
-    writeProjectFile(rootPath, '.gitignore', '*.js\n');
-    writeProjectFile(rootPath, 'index.js');
-    const nativeError = new Error('Failed to match gitignore entries');
-    const matchBatch = rs
-      .spyOn(loadNativeBinding().GitIgnoreMatcher.prototype, 'isIgnoredBatchMask')
-      .mockImplementation(() => {
-        throw nativeError;
-      });
-
-    try {
-      await expect(discoverFmtPaths({ cwd: rootPath })).rejects.toBe(nativeError);
-    } finally {
-      matchBatch.mockRestore();
+      loadNativeBinding.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Summary

This PR prevents `rs fmt` from silently ignoring native Gitignore matcher failures, which could otherwise cause ignored files to be formatted. It limits best-effort handling to `.gitignore` read errors and converts `tiny-readdir` callback failures into a normal rejected discovery operation. It also adds regression coverage for nested native binding failures without mutating the native matcher prototype.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/318