### PR TITLE
refactor(fmt): simplify internal names

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -82,7 +82,7 @@ const assertExclusiveMode = (option: string, hasMode: boolean, positionals: stri
   }
 };
 
-const parseFmtCLIArgs = (args: string[]): ParsedFmtCLIArgs => {
+const parseFmtArgs = (args: string[]): ParsedFmtCLIArgs => {
   const { values, positionals } = parseArgs({
     args,
     options: {
@@ -292,7 +292,7 @@ const runFmtCLI = async (args: string[]): Promise<void> => {
       patterns,
       stdinFilepath,
       withNodeModules,
-    } = parseFmtCLIArgs(args);
+    } = parseFmtArgs(args);
     if (help) {
       logger.log(renderFmtHelp());
       return;

--- a/packages/rstack/src/fmt/config.ts
+++ b/packages/rstack/src/fmt/config.ts
@@ -90,7 +90,7 @@ const normalizeFmtConfig = (config: FmtConfig | undefined, rootPath: string): Re
 };
 
 /** Creates a reusable resolver for applying per-file formatter overrides. */
-const createFmtOptionsResolver = (config: ResolvedFmtConfig): FmtOptionsResolver => {
+const createOptionsResolver = (config: ResolvedFmtConfig): FmtOptionsResolver => {
   if (config.overrides.length === 0) {
     return () => config.baseOptions;
   }
@@ -127,5 +127,5 @@ const resolveFmtConfig = async ({
   return normalizeFmtConfig(config, rootPath);
 };
 
-export { createFmtOptionsResolver, normalizeFmtConfig, resolveFmtConfig };
+export { createOptionsResolver, normalizeFmtConfig, resolveFmtConfig };
 export type { FmtOptionsResolver };

--- a/packages/rstack/src/fmt/discovery.ts
+++ b/packages/rstack/src/fmt/discovery.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { createFmtOptionsResolver, type FmtOptionsResolver } from './config.ts';
+import { createOptionsResolver, type FmtOptionsResolver } from './config.ts';
 import { discoverFmtPaths } from './discoverPaths.ts';
 import { createIgnoreMatcher } from './ignore.ts';
 import type { FmtPluginResolver } from './plugins.ts';
@@ -21,7 +21,7 @@ const createLazyPluginResolver = (rootPath: string): (() => Promise<FmtPluginRes
     (resolver ??= import(
       /* rspackChunkName: 'fmtPlugins' */
       './plugins.ts'
-    ).then(({ createFmtPluginResolver }) => createFmtPluginResolver(rootPath)));
+    ).then(({ createPluginResolver }) => createPluginResolver(rootPath)));
 };
 
 /** Resolves the plugin specifiers of a request whose options configure plugins. */
@@ -63,7 +63,7 @@ const discoverFmtFiles = async ({
     return [];
   }
 
-  const resolveOptions = createFmtOptionsResolver(config);
+  const resolveOptions = createOptionsResolver(config);
   const getPluginResolver = createLazyPluginResolver(config.rootPath);
 
   return Promise.all(

--- a/packages/rstack/src/fmt/ignore.ts
+++ b/packages/rstack/src/fmt/ignore.ts
@@ -21,13 +21,13 @@ interface CreateIgnoreMatcherOptions {
   ignorePaths?: string[];
 }
 
-const createDefaultIgnoreMatcher = (): IgnorePredicate => {
+const createDefaultMatcher = (): IgnorePredicate => {
   const suffixes = defaultIgnoreNames.map((name) => `${path.sep}${name}`);
 
   return (filePath) => suffixes.some((suffix) => filePath.endsWith(suffix));
 };
 
-const createPatternMatcherSet = (sources: IgnoreSource[]): IgnorePredicate => {
+const createSourceMatcher = (sources: IgnoreSource[]): IgnorePredicate => {
   const matcher = new (loadNativeBinding().IgnoreMatcher)(sources);
   return (filePath, isDirectory = false) => matcher.isIgnored(filePath, isDirectory);
 };
@@ -60,7 +60,7 @@ const createIgnoreMatcher = async ({
     ignorePaths.map((ignorePath) => loadIgnoreSource(cwd, ignorePath)),
   );
   if (config.ignorePatterns.length) {
-    return createPatternMatcherSet([
+    return createSourceMatcher([
       {
         rootPath: config.rootPath,
         patterns: [...defaultIgnoreNames, ...config.ignorePatterns].join('\n'),
@@ -69,12 +69,12 @@ const createIgnoreMatcher = async ({
     ]);
   }
 
-  const defaultMatcher = createDefaultIgnoreMatcher();
+  const defaultMatcher = createDefaultMatcher();
   if (ignoreFileSources.length === 0) {
     return defaultMatcher;
   }
 
-  const cliMatcher = createPatternMatcherSet(ignoreFileSources);
+  const cliMatcher = createSourceMatcher(ignoreFileSources);
   return (filePath, isDirectory = false) =>
     defaultMatcher(filePath, isDirectory) || cliMatcher(filePath, isDirectory);
 };

--- a/packages/rstack/src/fmt/lsp/server.ts
+++ b/packages/rstack/src/fmt/lsp/server.ts
@@ -9,7 +9,7 @@ import {
   type InitializeParams,
   type TextEdit,
 } from 'vscode-languageserver/node';
-import { createFmtOptionsResolver, type FmtOptionsResolver } from '../config.ts';
+import { createOptionsResolver, type FmtOptionsResolver } from '../config.ts';
 import {
   createFileRequest,
   createLazyPluginResolver,
@@ -122,7 +122,7 @@ const createFmtLspSession = async ({
 
   return {
     isIgnored,
-    resolveOptions: createFmtOptionsResolver(config),
+    resolveOptions: createOptionsResolver(config),
     getPluginResolver: createLazyPluginResolver(config.rootPath),
   };
 };

--- a/packages/rstack/src/fmt/plugins.ts
+++ b/packages/rstack/src/fmt/plugins.ts
@@ -92,7 +92,7 @@ const createFingerprintResolver = (): FingerprintResolver => {
 };
 
 /** Creates a project-root resolver for plugins in final per-file options. */
-const createFmtPluginResolver = (rootPath: string): FmtPluginResolver => {
+const createPluginResolver = (rootPath: string): FmtPluginResolver => {
   const parentUrl = pathToFileURL(join(rootPath, 'index.js'));
   const cache = new Map<string, string>();
 
@@ -143,5 +143,5 @@ const createFmtPluginResolver = (rootPath: string): FmtPluginResolver => {
   };
 };
 
-export { createFingerprintResolver, createFmtPluginResolver };
+export { createFingerprintResolver, createPluginResolver };
 export type { FingerprintResolver, FmtPluginResolver };

--- a/packages/rstack/src/fmt/runner.ts
+++ b/packages/rstack/src/fmt/runner.ts
@@ -89,7 +89,7 @@ const loadPluginFingerprints = async (
 };
 
 /** Resolves the portable cache identity before work is dispatched. */
-const createFmtFileRunTask = (file: FmtFileRequest, cache?: RunCache): FmtFileRunTask => {
+const createRunTask = (file: FmtFileRequest, cache?: RunCache): FmtFileRunTask => {
   let key: string | undefined;
   let fileCache: FmtFileCache | undefined;
 
@@ -160,7 +160,7 @@ const runFmtFile = async (
 };
 
 /** Starts slower Markdown parsers first while preserving order within both priority groups. */
-const runPriorityFmtFiles = async (
+const runPriorityTasks = async (
   tasks: FmtFileRunTask[],
   shouldWrite: boolean,
   formatFile: FormatFile,
@@ -184,13 +184,13 @@ const runPriorityFmtFiles = async (
 };
 
 /** Processes files in a worker pool while preserving input order. */
-const runFmtFilesInWorkerPool = async (
+const runWithWorkers = async (
   files: FmtFileRequest[],
   shouldWrite: boolean,
   maxWorkers?: number,
   cache?: RunCache,
 ): Promise<FmtWorkerPoolResult> => {
-  const tasks = files.map((file) => createFmtFileRunTask(file, cache));
+  const tasks = files.map((file) => createRunTask(file, cache));
   const pendingFileCount = tasks.reduce(
     (count, task) => count + (isCachedUnsupported(task) ? 0 : 1),
     0,
@@ -199,13 +199,13 @@ const runFmtFilesInWorkerPool = async (
     return { files: [], processedFileCount: 0 };
   }
 
-  const { createFmtWorkerPool } = await import('./workerPool.ts');
-  const workerPool = await createFmtWorkerPool(pendingFileCount, maxWorkers);
+  const { createWorkerPool } = await import('./workerPool.ts');
+  const workerPool = await createWorkerPool(pendingFileCount, maxWorkers);
 
   try {
     const results =
       workerPool.workerCount >= minPriorityWorkers
-        ? await runPriorityFmtFiles(tasks, shouldWrite, workerPool.formatFile)
+        ? await runPriorityTasks(tasks, shouldWrite, workerPool.formatFile)
         : await Promise.all(
             tasks.map((task) => runFmtFile(task, shouldWrite, workerPool.formatFile)),
           );
@@ -233,7 +233,7 @@ const runFmtFilesInWorkerPool = async (
 };
 
 /** Maps file results to the Prettier-compatible CLI exit code. */
-const getFmtExitCode = (files: FmtFileResult[]): FmtExitCode => {
+const getExitCode = (files: FmtFileResult[]): FmtExitCode => {
   let exitCode: FmtExitCode = 0;
 
   for (const file of files) {
@@ -272,13 +272,12 @@ const runFmtFiles = async ({
   const result =
     files.length === 0
       ? { files: [], processedFileCount: 0 }
-      : await runFmtFilesInWorkerPool(files, shouldWrite, maxWorkers, runCache);
+      : await runWithWorkers(files, shouldWrite, maxWorkers, runCache);
   await runCache?.store.save().catch(() => false);
 
   return {
     ...result,
-    exitCode:
-      files.length > 0 && result.processedFileCount === 0 ? 2 : getFmtExitCode(result.files),
+    exitCode: files.length > 0 && result.processedFileCount === 0 ? 2 : getExitCode(result.files),
   };
 };
 

--- a/packages/rstack/src/fmt/stdin.ts
+++ b/packages/rstack/src/fmt/stdin.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { createFmtOptionsResolver } from './config.ts';
+import { createOptionsResolver } from './config.ts';
 import {
   createFileRequest,
   createLazyPluginResolver,
@@ -84,7 +84,7 @@ const runFmtStdin = async ({
   }
 
   const file = await resolveFileRequestPlugins(
-    createFileRequest(absolutePath, createFmtOptionsResolver(config)),
+    createFileRequest(absolutePath, createOptionsResolver(config)),
     createLazyPluginResolver(config.rootPath),
   );
   const result = await formatFmtSource(file, () => source);

--- a/packages/rstack/src/fmt/workerPool.ts
+++ b/packages/rstack/src/fmt/workerPool.ts
@@ -21,10 +21,10 @@ interface FmtWorkerPool {
  * plateau before all CPU cores are occupied, while additional workers increase
  * scheduling and memory pressure.
  */
-const getFmtWorkerCount = (fileCount: number, maxWorkers?: number): number =>
+const getWorkerCount = (fileCount: number, maxWorkers?: number): number =>
   Math.min(fileCount, maxWorkers ?? Math.min(8, Math.max(1, availableParallelism() - 1)));
 
-const getFmtWorkerUrl = (): URL => {
+const getWorkerUrl = (): URL => {
   // Source tests run after build and exercise the same worker artifact as the CLI.
   const workerPath = new URL(import.meta.url).pathname.endsWith('.ts')
     ? '../../dist/fmtWorker.js'
@@ -33,13 +33,10 @@ const getFmtWorkerUrl = (): URL => {
 };
 
 /** Creates and starts every worker before formatting can begin. */
-const createFmtWorkerPool = async (
-  fileCount: number,
-  maxWorkers?: number,
-): Promise<FmtWorkerPool> => {
-  const workerCount = getFmtWorkerCount(fileCount, maxWorkers);
+const createWorkerPool = async (fileCount: number, maxWorkers?: number): Promise<FmtWorkerPool> => {
+  const workerCount = getWorkerCount(fileCount, maxWorkers);
   const pool = new Tinypool({
-    filename: getFmtWorkerUrl().href,
+    filename: getWorkerUrl().href,
     name: 'initializeFmtWorker',
     minThreads: workerCount,
     maxThreads: workerCount,
@@ -64,5 +61,5 @@ const createFmtWorkerPool = async (
   };
 };
 
-export { createFmtWorkerPool };
+export { createWorkerPool };
 export type { FmtWorkerPool };

--- a/packages/rstack/tests/fmt/config.test.ts
+++ b/packages/rstack/tests/fmt/config.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { expect, test } from 'rstack/test';
-import { createFmtOptionsResolver, normalizeFmtConfig } from '../../src/fmt/config.ts';
+import { createOptionsResolver, normalizeFmtConfig } from '../../src/fmt/config.ts';
 
 const rootPath = path.join(import.meta.dirname, 'project');
 
@@ -12,7 +12,7 @@ test('reuses base options when no override matches', () => {
     },
     rootPath,
   );
-  const resolveOptions = createFmtOptionsResolver(config);
+  const resolveOptions = createOptionsResolver(config);
 
   expect(resolveOptions(path.join(rootPath, 'index.js'))).toBe(config.baseOptions);
 });
@@ -39,7 +39,7 @@ test('applies basename and path overrides in declaration order', () => {
     },
     rootPath,
   );
-  const resolveOptions = createFmtOptionsResolver(config);
+  const resolveOptions = createOptionsResolver(config);
 
   const options = resolveOptions(path.join(rootPath, 'src/index.ts'));
   const testOptions = resolveOptions(path.join(rootPath, 'src/index.test.ts'));
@@ -57,7 +57,7 @@ test('applies overrides outside the config root', () => {
     },
     rootPath,
   );
-  const resolveOptions = createFmtOptionsResolver(config);
+  const resolveOptions = createOptionsResolver(config);
 
   expect(resolveOptions(path.join(rootPath, '../shared/index.ts'))).toEqual({ semi: false });
 });

--- a/packages/rstack/tests/fmt/plugins.test.ts
+++ b/packages/rstack/tests/fmt/plugins.test.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from 'node:url';
 import { expect, test } from 'rstack/test';
-import { createFingerprintResolver, createFmtPluginResolver } from '../../src/fmt/plugins.ts';
+import { createFingerprintResolver, createPluginResolver } from '../../src/fmt/plugins.ts';
 import { withTempProject, writeProjectFile } from './helpers.ts';
 
 test('resolves plugin specifiers from the config root', async () => {
@@ -40,7 +40,7 @@ test('resolves plugin specifiers from the config root', async () => {
       ],
     };
 
-    const resolved = createFmtPluginResolver(rootPath)(options);
+    const resolved = createPluginResolver(rootPath)(options);
 
     expect(resolved.plugins).toEqual([
       pathToFileURL(packageEntry).href,
@@ -56,7 +56,7 @@ test('resolves plugin specifiers from the config root', async () => {
 test('rejects imported plugin objects', () => {
   const options = { plugins: [{ languages: [] }] };
 
-  expect(() => createFmtPluginResolver(import.meta.dirname)(options)).toThrow(
+  expect(() => createPluginResolver(import.meta.dirname)(options)).toThrow(
     'Prettier plugin objects are not supported. Use a package name, path, or URL instead.',
   );
 });

--- a/packages/rstack/tests/fmt/runnerWorkerPreflight.test.ts
+++ b/packages/rstack/tests/fmt/runnerWorkerPreflight.test.ts
@@ -10,18 +10,18 @@ import {
 } from './helpers.ts';
 
 const mocks = rs.hoisted(() => ({
-  createFmtWorkerPoolCalls: [] as [number, number | undefined][],
+  workerPoolCalls: [] as [number, number | undefined][],
 }));
 
 rs.mock('../../src/fmt/workerPool.ts', () => ({
-  createFmtWorkerPool: (fileCount: number, maxWorkers?: number) => {
-    mocks.createFmtWorkerPoolCalls.push([fileCount, maxWorkers]);
+  createWorkerPool: (fileCount: number, maxWorkers?: number) => {
+    mocks.workerPoolCalls.push([fileCount, maxWorkers]);
     return Promise.reject(new Error('worker startup failed'));
   },
 }));
 
 beforeEach(() => {
-  mocks.createFmtWorkerPoolCalls.length = 0;
+  mocks.workerPoolCalls.length = 0;
 });
 
 const createCachedUnsupportedFile = async (rootPath: string, fileName: string) => {
@@ -55,7 +55,7 @@ test('does not start the worker pool when every parser result is cached as unsup
       files: [],
       processedFileCount: 0,
     });
-    expect(mocks.createFmtWorkerPoolCalls).toEqual([]);
+    expect(mocks.workerPoolCalls).toEqual([]);
   });
 });
 
@@ -70,6 +70,6 @@ test('starts the worker pool for a path-only unsupported entry without an extens
         cache,
       }),
     ).rejects.toThrow('worker startup failed');
-    expect(mocks.createFmtWorkerPoolCalls).toEqual([[1, undefined]]);
+    expect(mocks.workerPoolCalls).toEqual([[1, undefined]]);
   });
 });


### PR DESCRIPTION
This PR simplifies overly verbose internal formatter identifiers to make the execution, resolver, ignore, and worker-pool code easier to scan and maintain.

It removes redundant `Fmt` and module context from private names, updates dynamic imports and tests consistently, and leaves the public package exports and CLI behavior unchanged.