### PR TITLE
docs: improve generated llms.txt summaries

### DIFF
--- a/website/docs/en/guide/cli/doc.mdx
+++ b/website/docs/en/guide/cli/doc.mdx
@@ -1,3 +1,7 @@
+---
+description: 'Develop, build, and preview Rspress documentation sites with the rs doc command.'
+---
+
 # doc
 
 import { PackageManagerTabs } from '@rspress/core/theme';

--- a/website/docs/en/guide/formatting.mdx
+++ b/website/docs/en/guide/formatting.mdx
@@ -1,3 +1,7 @@
+---
+description: 'Format files with Rstack CLI using Prettier-compatible options, plugins, parallel formatting, and a persistent cache.'
+---
+
 # Formatting
 
 import { PackageManagerTabs } from '@rspress/core/theme';

--- a/website/docs/zh/guide/cli/doc.mdx
+++ b/website/docs/zh/guide/cli/doc.mdx
@@ -1,3 +1,7 @@
+---
+description: '使用 rs doc 命令开发、构建和预览 Rspress 文档站点。'
+---
+
 # doc
 
 import { PackageManagerTabs } from '@rspress/core/theme';

--- a/website/docs/zh/guide/formatting.mdx
+++ b/website/docs/zh/guide/formatting.mdx
@@ -1,3 +1,7 @@
+---
+description: '使用 Rstack CLI 格式化文件，支持与 Prettier 兼容的选项、插件、并行格式化和持久化缓存。'
+---
+
 # 格式化 \{#formatting}
 
 import { PackageManagerTabs } from '@rspress/core/theme';


### PR DESCRIPTION
## Summary

Generated llms.txt descriptions for the Formatting and rs doc pages currently flatten body content into malformed or incomplete summaries. This PR adds explicit, aligned English and Chinese frontmatter descriptions so the generated indexes stay concise and readable.

## Validation

- Built the native binding and checked formatting for the four changed MDX files.
- Ran cspell against only the four changed source files; ignored generated documentation outputs were intentionally excluded.
- Ran the full documentation build and release preparation, then verified the corrected English, Chinese, and packaged llms.txt entries and the absence of the malformed fragments.
