### PR TITLE
chore(lint): enable type-aware linting

### DIFF
--- a/packages/rstack/src/fmt/lsp/server.ts
+++ b/packages/rstack/src/fmt/lsp/server.ts
@@ -87,7 +87,7 @@ const redirectConsoleToConnection = (connection: Connection): void => {
     counters.set(key, count);
     connection.console.log(`${key}: ${count}`);
   };
-  console.countReset = (label?: unknown): void => {
+  console.countReset = (label?: string): void => {
     if (label === undefined) {
       counters.clear();
     } else {

--- a/packages/rstack/src/fmt/yukuPlugin.ts
+++ b/packages/rstack/src/fmt/yukuPlugin.ts
@@ -423,11 +423,7 @@ const indexToPosition = (text: string, index: number): { column: number; line: n
   };
 };
 
-const createParseError = (error: Diagnostic, text: string): Diagnostic | SyntaxError => {
-  if (typeof error?.start !== 'number' || typeof error?.end !== 'number') {
-    return error;
-  }
-
+const createParseError = (error: Diagnostic, text: string): SyntaxError => {
   const start = indexToPosition(text, error.start);
   const end = indexToPosition(text, error.end);
 

--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -57,7 +57,10 @@ export async function runStagedCLI(args: string[]): Promise<void> {
 
   const success = await lintStaged({
     allowEmpty: values.allowEmpty,
-    concurrent: values.concurrent === undefined ? undefined : JSON.parse(values.concurrent),
+    concurrent:
+      values.concurrent === undefined
+        ? undefined
+        : (JSON.parse(values.concurrent) as boolean | number),
     config: stagedConfig,
     cwd: values.cwd,
     debug: values.debug,

--- a/packages/rstack/tests/cli/staged/index.test.ts
+++ b/packages/rstack/tests/cli/staged/index.test.ts
@@ -58,9 +58,9 @@ test('should pass default options to lint-staged', async ({ expect }) => {
 });
 
 test('should set the staged environment', async ({ expect }) => {
-  mocks.lintStaged.mockImplementation(async () => {
+  mocks.lintStaged.mockImplementation(() => {
     expect(process.env.RSTACK_STAGED).toBe('1');
-    return true;
+    return Promise.resolve(true);
   });
 
   await runStagedCLI([]);

--- a/packages/rstack/tests/fmt/helpers.ts
+++ b/packages/rstack/tests/fmt/helpers.ts
@@ -17,7 +17,7 @@ export const createFmtCacheContext = (rootPath: string): FmtCacheContext => ({
 });
 
 export const withTempProject = async (
-  callback: (rootPath: string) => Promise<void>,
+  callback: (rootPath: string) => void | Promise<void>,
 ): Promise<void> => {
   const rootPath = mkdtempSync(path.join(import.meta.dirname, 'test-temp-fmt-'));
   // Prevent repository-level ignore rules from affecting the fixture.

--- a/packages/rstack/tests/fmt/lsp/server.test.ts
+++ b/packages/rstack/tests/fmt/lsp/server.test.ts
@@ -4,7 +4,7 @@ import { createDocumentEdits } from '../../../src/fmt/lsp/server.ts';
 test('maps the edit onto the formatted document', async () => {
   const edits = await createDocumentEdits(
     () => 'const a = 1;\nconst b=2;\n',
-    async () => 'const a = 1;\nconst b = 2;\n',
+    () => Promise.resolve('const a = 1;\nconst b = 2;\n'),
   );
 
   expect(edits).toEqual([
@@ -18,15 +18,15 @@ test('maps the edit onto the formatted document', async () => {
 test('returns no edits for an already formatted document', async () => {
   const getText = () => 'const a = 1;\n';
 
-  expect(await createDocumentEdits(getText, async () => 'const a = 1;\n')).toEqual([]);
-  expect(await createDocumentEdits(getText, async () => undefined)).toEqual([]);
+  expect(await createDocumentEdits(getText, () => Promise.resolve('const a = 1;\n'))).toEqual([]);
+  expect(await createDocumentEdits(getText, () => Promise.resolve(undefined))).toEqual([]);
 });
 
 test('returns no edits for a document that is not open', async () => {
   expect(
     await createDocumentEdits(
       () => undefined,
-      async () => '',
+      () => Promise.resolve(''),
     ),
   ).toEqual([]);
 });
@@ -38,10 +38,10 @@ test('returns no edits when the document changes while it is formatted', async (
 
   const edits = await createDocumentEdits(
     () => text,
-    async (source) => {
+    (source) => {
       text = 'const b=2;\n';
 
-      return source.replace('const b=2;', 'const b = 2;');
+      return Promise.resolve(source.replace('const b=2;', 'const b = 2;'));
     },
   );
 

--- a/packages/rstack/tests/fmt/plugins.test.ts
+++ b/packages/rstack/tests/fmt/plugins.test.ts
@@ -4,7 +4,7 @@ import { createFingerprintResolver, createPluginResolver } from '../../src/fmt/p
 import { withTempProject, writeProjectFile } from './helpers.ts';
 
 test('resolves plugin specifiers from the config root', async () => {
-  await withTempProject(async (rootPath) => {
+  await withTempProject((rootPath) => {
     const packageEntry = writeProjectFile(
       rootPath,
       'node_modules/prettier-plugin-packagejson/import.mjs',

--- a/packages/rstack/tests/setup/install.test.ts
+++ b/packages/rstack/tests/setup/install.test.ts
@@ -79,7 +79,7 @@ test('resolves repository context with a single Git process when unchanged', () 
     const starts = readFileSync(tracePath, 'utf8')
       .trim()
       .split('\n')
-      .map((line) => JSON.parse(line))
+      .map((line) => JSON.parse(line) as { argv: string[]; event: string })
       .filter((event) => event.event === 'start');
     expect(starts).toHaveLength(1);
     expect(starts[0].argv).toContain('rev-parse');

--- a/packages/rstack/tests/types/resolution-bundler/index.ts
+++ b/packages/rstack/tests/types/resolution-bundler/index.ts
@@ -23,7 +23,7 @@ const configs: Configs = {};
 void loadedConfig;
 void configs;
 
-createRsbuild({ config: appConfig });
+void createRsbuild({ config: appConfig });
 define.app(appConfig);
 define.lib(libConfig);
 define.doc({});

--- a/packages/rstack/tests/types/resolution-nodenext/index.ts
+++ b/packages/rstack/tests/types/resolution-nodenext/index.ts
@@ -23,7 +23,7 @@ const configs: Configs = {};
 void loadedConfig;
 void configs;
 
-createRsbuild({ config: appConfig });
+void createRsbuild({ config: appConfig });
 define.app(appConfig);
 define.lib(libConfig);
 define.doc({});

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -6,7 +6,7 @@ define.lint(async () => {
   const { js, ts } = await import('rstack/lint');
   return [
     js.configs.recommended,
-    ts.configs.recommended,
+    ts.configs.recommendedTypeChecked,
     {
       files: ['**/*.{js,jsx,cjs,mjs}'],
       languageOptions: {


### PR DESCRIPTION
This PR enables Rslint's type-checked TypeScript recommendations to catch unsafe values and unhandled promises across the repository. It resolves the newly surfaced diagnostics with behavior-preserving type annotations and explicit promise handling, without changing public APIs.