### PR TITLE
chore(create-rstack): enable type-aware linting in templates

### DIFF
--- a/packages/create-rstack/template-app-lit-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-lit-ts/rstack.config.ts
@@ -19,7 +19,7 @@ define.test({
 define.lint(async () => {
   const { js, ts } = await import('rstack/lint');
 
-  return [js.configs.recommended, ts.configs.recommended];
+  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
 });
 
 define.fmt({

--- a/packages/create-rstack/template-app-preact-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-preact-ts/rstack.config.ts
@@ -18,7 +18,7 @@ define.lint(async () => {
 
   return [
     js.configs.recommended,
-    ts.configs.recommended,
+    ts.configs.recommendedTypeChecked,
     reactPlugin.configs.recommended,
     reactHooksPlugin.configs.recommended,
   ];

--- a/packages/create-rstack/template-app-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-react-ts/rstack.config.ts
@@ -18,7 +18,7 @@ define.lint(async () => {
 
   return [
     js.configs.recommended,
-    ts.configs.recommended,
+    ts.configs.recommendedTypeChecked,
     reactPlugin.configs.recommended,
     reactHooksPlugin.configs.recommended,
   ];

--- a/packages/create-rstack/template-app-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-solid-ts/rstack.config.ts
@@ -22,7 +22,7 @@ define.test({
 define.lint(async () => {
   const { js, ts } = await import('rstack/lint');
 
-  return [js.configs.recommended, ts.configs.recommended];
+  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
 });
 
 define.fmt({

--- a/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
@@ -16,7 +16,7 @@ define.test({
 define.lint(async () => {
   const { js, ts } = await import('rstack/lint');
 
-  return [js.configs.recommended, ts.configs.recommended];
+  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
 });
 
 define.fmt({

--- a/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
@@ -12,7 +12,7 @@ define.test({
 define.lint(async () => {
   const { js, ts } = await import('rstack/lint');
 
-  return [js.configs.recommended, ts.configs.recommended];
+  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
 });
 
 define.fmt({

--- a/packages/create-rstack/template-app-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vue-ts/rstack.config.ts
@@ -16,7 +16,7 @@ define.test({
 define.lint(async () => {
   const { js, ts } = await import('rstack/lint');
 
-  return [js.configs.recommended, ts.configs.recommended];
+  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
 });
 
 define.fmt({

--- a/packages/create-rstack/template-app-vue-ts/src/env.d.ts
+++ b/packages/create-rstack/template-app-vue-ts/src/env.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+
+  const component: DefineComponent;
+  export default component;
+}

--- a/packages/create-rstack/template-doc-i18n/rstack.config.ts
+++ b/packages/create-rstack/template-doc-i18n/rstack.config.ts
@@ -28,7 +28,7 @@ define.lint(async () => {
 
   return [
     js.configs.recommended,
-    ts.configs.recommended,
+    ts.configs.recommendedTypeChecked,
     reactPlugin.configs.recommended,
     reactHooksPlugin.configs.recommended,
   ];

--- a/packages/create-rstack/template-doc/rstack.config.ts
+++ b/packages/create-rstack/template-doc/rstack.config.ts
@@ -12,7 +12,7 @@ define.lint(async () => {
 
   return [
     js.configs.recommended,
-    ts.configs.recommended,
+    ts.configs.recommendedTypeChecked,
     reactPlugin.configs.recommended,
     reactHooksPlugin.configs.recommended,
   ];

--- a/packages/create-rstack/template-lib-node-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-node-ts/rstack.config.ts
@@ -13,7 +13,7 @@ define.test({
 define.lint(async () => {
   const { js, ts } = await import('rstack/lint');
 
-  return [js.configs.recommended, ts.configs.recommended];
+  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
 });
 
 define.fmt({

--- a/packages/create-rstack/template-lib-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-react-ts/rstack.config.ts
@@ -28,7 +28,7 @@ define.lint(async () => {
 
   return [
     js.configs.recommended,
-    ts.configs.recommended,
+    ts.configs.recommendedTypeChecked,
     reactPlugin.configs.recommended,
     reactHooksPlugin.configs.recommended,
   ];

--- a/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
@@ -78,7 +78,7 @@ define.test(async () => {
 define.lint(async () => {
   const { js, ts } = await import('rstack/lint');
 
-  return [js.configs.recommended, ts.configs.recommended];
+  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
 });
 
 define.fmt({

--- a/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
@@ -26,7 +26,7 @@ define.test({
 define.lint(async () => {
   const { js, ts } = await import('rstack/lint');
 
-  return [js.configs.recommended, ts.configs.recommended];
+  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
 });
 
 define.fmt({

--- a/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
@@ -25,7 +25,7 @@ define.test({
 define.lint(async () => {
   const { js, ts } = await import('rstack/lint');
 
-  return [js.configs.recommended, ts.configs.recommended];
+  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
 });
 
 define.fmt({

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -205,6 +205,9 @@ test.each(sourceTemplates)(
     if (template.startsWith('app-')) {
       files.push('README.md', '.gitignore');
     }
+    if (template === 'app-vue-ts') {
+      files.push('src/env.d.ts');
+    }
 
     await expectProjectSetup(projectDirectory, template, configExtension, hasTypeScript);
     await expectFiles(projectDirectory, files);


### PR DESCRIPTION
This PR enables type-aware Rslint rules across all TypeScript templates generated by create-rstack. It also adds a Vue SFC module declaration so generated Vue apps remain type-safe under these rules and covers the new declaration in template generation tests.