### PR TITLE
docs: refine documentation theme styles

### DIFF
--- a/website/theme/index.scss
+++ b/website/theme/index.scss
@@ -1,11 +1,5 @@
 :root {
-  --rp-c-brand: #ff5e00;
-  --rp-c-brand-dark: var(--rp-c-brand);
-  --rp-c-brand-darker: #ff704d;
-  --rp-c-brand-light: #ff7524;
-  --rp-c-brand-lighter: #ff7524;
-  --rp-c-link: var(--rp-c-brand);
-  --rp-c-brand-tint: rgba(255, 94, 0, 0.07);
+  --rp-c-text-code: var(--rp-c-text-1);
 }
 
 .dark {
@@ -16,5 +10,33 @@
 @media (min-width: 1280px) {
   .rp-doc-layout__sidebar-placeholder {
     width: 10vw !important;
+  }
+}
+
+.rp-doc {
+  .rp-link,
+  .rp-link code {
+    color: inherit;
+    text-decoration-line: underline;
+    text-underline-offset: 2px;
+    text-decoration-color: rgba(0, 0, 0, 0.25);
+
+    &:hover {
+      opacity: 1;
+      text-decoration-color: currentColor;
+      border-bottom: none !important;
+    }
+  }
+}
+
+.dark {
+  .rp-doc {
+    .rp-link {
+      text-decoration-color: rgba(255, 255, 255, 0.5);
+    }
+
+    &:hover {
+      text-decoration-color: currentColor;
+    }
   }
 }

--- a/website/theme/index.scss
+++ b/website/theme/index.scss
@@ -33,10 +33,10 @@
   .rp-doc {
     .rp-link {
       text-decoration-color: rgba(255, 255, 255, 0.5);
-    }
 
-    &:hover {
-      text-decoration-color: currentColor;
+      &:hover {
+        text-decoration-color: currentColor;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR refines the documentation theme to improve inline code and link readability. It uses the primary text color for inline code, lets document links inherit surrounding text color, and adds consistent underlines in light and dark themes. It also removes the custom brand color overrides so the site follows the default Rspress palette.