### PR TITLE
perf(fmt): compact cache options in place

### DIFF
--- a/packages/rstack/src/fmt/cacheStore.ts
+++ b/packages/rstack/src/fmt/cacheStore.ts
@@ -202,33 +202,34 @@ class FmtCacheStoreImpl implements FmtCacheStore {
     return index;
   }
 
+  /** Removes unreferenced option hashes and remaps file entries to the compacted indexes. */
   #compactUnusedOptions(): void {
     if (!this.#optionsUseCounts.includes(0)) {
       return;
     }
 
     const { files, options } = this.#cache;
-    const nextOptions: string[] = [];
-    const nextUseCounts: number[] = [];
-    const remappedIndexes = new Int32Array(options.length).fill(-1);
-    for (let index = 0; index < options.length; index++) {
-      const useCount = this.#optionsUseCounts[index];
-      if (useCount > 0) {
-        remappedIndexes[index] = nextOptions.length;
-        nextOptions.push(options[index]);
-        nextUseCounts.push(useCount);
-      }
-    }
-    for (let offset = 0; offset < files.length; offset += fileEntryWidth) {
-      const currentIndex = files[offset + optionsIndexOffset] as number;
-      files[offset + optionsIndexOffset] = remappedIndexes[currentIndex];
-    }
-
-    options.splice(0, options.length, ...nextOptions);
-    this.#optionsUseCounts.splice(0, this.#optionsUseCounts.length, ...nextUseCounts);
+    const counts = this.#optionsUseCounts;
+    const remap = new Int32Array(options.length).fill(-1);
+    let nextIndex = 0;
     this.#optionsIndexes.clear();
     for (let index = 0; index < options.length; index++) {
-      this.#optionsIndexes.set(options[index], index);
+      const count = counts[index];
+      if (count > 0) {
+        const option = options[index];
+        remap[index] = nextIndex;
+        options[nextIndex] = option;
+        counts[nextIndex] = count;
+        this.#optionsIndexes.set(option, nextIndex);
+        nextIndex++;
+      }
+    }
+    options.length = nextIndex;
+    counts.length = nextIndex;
+
+    for (let offset = 0; offset < files.length; offset += fileEntryWidth) {
+      const index = files[offset + optionsIndexOffset] as number;
+      files[offset + optionsIndexOffset] = remap[index];
     }
   }
 


### PR DESCRIPTION
This PR prevents formatter cache saves from exceeding JavaScript's argument limit when the options table grows large. Unused option hashes are now compacted in place, which also avoids allocating replacement options and usage-count arrays.