### PR TITLE
chore(ci): serialize Windows package tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,5 +69,10 @@ jobs:
         run: git diff --exit-code -- packages/rstack/binding.cjs packages/rstack/binding.d.cts
 
       - name: Run Test
-        if: steps.changes.outputs.changed == 'true'
+        if: steps.changes.outputs.changed == 'true' && runner.os != 'Windows'
         run: node --run test
+
+      # Run package tests serially on Windows to avoid resource contention between nested test workers.
+      - name: Run Test (Windows)
+        if: steps.changes.outputs.changed == 'true' && runner.os == 'Windows'
+        run: pnpm --workspace-concurrency=1 --filter "./packages/**" test


### PR DESCRIPTION
Windows CI can run package-level Rstest suites alongside nested formatter workers, causing transient resource contention and test timeouts. This PR keeps package tests parallel on Linux and macOS, but runs them sequentially on Windows to avoid oversubscribing the hosted runner.