### PR TITLE
docs: clarify Rstack CLI terminology

### DIFF
--- a/packages/create-rstack/README.md
+++ b/packages/create-rstack/README.md
@@ -53,7 +53,7 @@ npx create-rstack --dir my-project --template app-vanilla-ts --no-git
 
 ## Documentation
 
-See the [Rstack documentation](https://rstack.rs).
+See the [Rstack CLI documentation](https://rstack.rs).
 
 ## License
 

--- a/packages/create-rstack/template-common/README.md
+++ b/packages/create-rstack/template-common/README.md
@@ -21,5 +21,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
-- [Rstack GitHub repository](https://github.com/rstackjs/rstack-cli)
+- [Rstack CLI documentation](https://rstack.rs)
+- [Rstack CLI GitHub repository](https://github.com/rstackjs/rstack-cli)

--- a/packages/create-rstack/template-doc-i18n/README.md
+++ b/packages/create-rstack/template-doc-i18n/README.md
@@ -19,5 +19,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
+- [Rstack CLI documentation](https://rstack.rs)
 - [Rspress documentation](https://rspress.rs)

--- a/packages/create-rstack/template-doc/README.md
+++ b/packages/create-rstack/template-doc/README.md
@@ -19,5 +19,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
+- [Rstack CLI documentation](https://rstack.rs)
 - [Rspress documentation](https://rspress.rs)

--- a/packages/create-rstack/template-lib-node-ts/README.md
+++ b/packages/create-rstack/template-lib-node-ts/README.md
@@ -20,5 +20,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
+- [Rstack CLI documentation](https://rstack.rs)
 - [Rslib documentation](https://rslib.rs)

--- a/packages/create-rstack/template-lib-node/README.md
+++ b/packages/create-rstack/template-lib-node/README.md
@@ -20,5 +20,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
+- [Rstack CLI documentation](https://rstack.rs)
 - [Rslib documentation](https://rslib.rs)

--- a/packages/create-rstack/template-lib-react-ts/README.md
+++ b/packages/create-rstack/template-lib-react-ts/README.md
@@ -20,5 +20,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
+- [Rstack CLI documentation](https://rstack.rs)
 - [Rslib documentation](https://rslib.rs)

--- a/packages/create-rstack/template-lib-react/README.md
+++ b/packages/create-rstack/template-lib-react/README.md
@@ -20,5 +20,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
+- [Rstack CLI documentation](https://rstack.rs)
 - [Rslib documentation](https://rslib.rs)

--- a/packages/create-rstack/template-lib-solid-ts/README.md
+++ b/packages/create-rstack/template-lib-solid-ts/README.md
@@ -20,5 +20,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
+- [Rstack CLI documentation](https://rstack.rs)
 - [Rslib documentation](https://rslib.rs)

--- a/packages/create-rstack/template-lib-solid/README.md
+++ b/packages/create-rstack/template-lib-solid/README.md
@@ -20,5 +20,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
+- [Rstack CLI documentation](https://rstack.rs)
 - [Rslib documentation](https://rslib.rs)

--- a/packages/create-rstack/template-lib-svelte-ts/README.md
+++ b/packages/create-rstack/template-lib-svelte-ts/README.md
@@ -20,5 +20,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
+- [Rstack CLI documentation](https://rstack.rs)
 - [Rslib documentation](https://rslib.rs)

--- a/packages/create-rstack/template-lib-svelte/README.md
+++ b/packages/create-rstack/template-lib-svelte/README.md
@@ -20,5 +20,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
+- [Rstack CLI documentation](https://rstack.rs)
 - [Rslib documentation](https://rslib.rs)

--- a/packages/create-rstack/template-lib-vue-ts/README.md
+++ b/packages/create-rstack/template-lib-vue-ts/README.md
@@ -20,5 +20,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
+- [Rstack CLI documentation](https://rstack.rs)
 - [Rslib documentation](https://rslib.rs)

--- a/packages/create-rstack/template-lib-vue/README.md
+++ b/packages/create-rstack/template-lib-vue/README.md
@@ -20,5 +20,5 @@ Install the dependencies:
 
 ## Learn more
 
-- [Rstack documentation](https://rstack.rs)
+- [Rstack CLI documentation](https://rstack.rs)
 - [Rslib documentation](https://rslib.rs)

--- a/website/docs/en/guide/api-reference.mdx
+++ b/website/docs/en/guide/api-reference.mdx
@@ -1,12 +1,12 @@
 # API reference
 
-Rstack provides a unified configuration API and re-exports the public APIs of Rsbuild, Rslib, Rstest, and Rslint through dedicated subpaths. Prefer these subpaths to direct imports from each tool's core package so that dependency entry points and tool versions remain aligned with Rstack.
+Rstack CLI provides a unified configuration API and re-exports the public APIs of Rsbuild, Rslib, Rstest, and Rslint through dedicated subpaths. Prefer these subpaths to direct imports from each tool's core package so that dependency entry points stay unified and APIs match the tool versions integrated by Rstack CLI.
 
 ## Import paths
 
 | Import path              | Contents                                          | Use case                                |
 | ------------------------ | ------------------------------------------------- | --------------------------------------- |
-| `rstack`                 | Rstack configuration API                          | Register tool configurations            |
+| `rstack`                 | Rstack CLI configuration API                      | Register tool configurations            |
 | `rstack/app`             | Public APIs from `@rsbuild/core`                  | Build applications and extend Rsbuild   |
 | `rstack/lib`             | Public APIs from `@rslib/core`                    | Build libraries and extend Rslib        |
 | `rstack/test`            | Public APIs from `@rstest/core`                   | Write tests and configure test projects |
@@ -23,7 +23,7 @@ Import `define` from `rstack` to register tool configurations in `rstack.config.
 
 ## Re-exports
 
-The tool-specific subpaths below re-export the public APIs from their corresponding core packages. Using these Rstack entry points keeps dependency entry points and tool versions aligned with the toolchain integrated by Rstack.
+The tool-specific subpaths below re-export the public APIs from their corresponding core packages. Using these entry points keeps imports unified and APIs aligned with the tool versions integrated by Rstack CLI.
 
 ### `rstack/app`
 

--- a/website/docs/en/guide/cli/setup.mdx
+++ b/website/docs/en/guide/cli/setup.mdx
@@ -99,7 +99,7 @@ Files next to `_` are repository hook scripts. The `_` directory contains genera
 
 ## Supported hooks
 
-Rstack supports these client-side Git hooks:
+Rstack CLI supports these client-side Git hooks:
 
 - `pre-commit`
 - `pre-merge-commit`
@@ -120,7 +120,7 @@ Create a file with the matching name next to the `_` directory.
 
 ## Hook runtime
 
-Rstack runs hook scripts with POSIX `sh -e`, forwards Git's arguments and standard input, and returns the hook's exit code. Before running a hook, it changes to the project that installed the hooks and prepends that project's `node_modules/.bin` to `PATH`.
+Rstack CLI runs hook scripts with POSIX `sh -e`, forwards Git's arguments and standard input, and returns the hook's exit code. Before running a hook, it changes to the project that installed the hooks and prepends that project's `node_modules/.bin` to `PATH`.
 
 ### Disable and debug
 
@@ -130,7 +130,7 @@ Set `RSTACK_HOOKS=0` to skip installation or hook execution:
 RSTACK_HOOKS=0 git commit -m "Skip hooks"
 ```
 
-Set `RSTACK_HOOKS=2` to trace Rstack's hook runtime, including how it invokes the hook script and handles its exit code; to trace commands inside the hook script, add `set -x` to the script:
+Set `RSTACK_HOOKS=2` to trace the Rstack CLI hook runtime, including how it invokes the hook script and handles its exit code; to trace commands inside the hook script, add `set -x` to the script:
 
 ```bash
 RSTACK_HOOKS=2 git commit -m "Trace hooks"
@@ -138,7 +138,7 @@ RSTACK_HOOKS=2 git commit -m "Trace hooks"
 
 ### Configure the hook environment
 
-Before running a hook script, Rstack loads this optional POSIX shell file:
+Before running a hook script, Rstack CLI loads this optional POSIX shell file:
 
 ```text
 ${XDG_CONFIG_HOME:-$HOME/.config}/rstack/hooks-init.sh
@@ -148,7 +148,7 @@ Use it to initialize a Node.js version manager, update `PATH`, or set `RSTACK_HO
 
 ## Monorepo
 
-In a monorepo, the project that provides Rstack may be located in a subdirectory such as `frontend/`. Running `rs setup` from that directory still installs hooks at the Git repository root:
+In a monorepo, the project that provides Rstack CLI may be located in a subdirectory such as `frontend/`. Running `rs setup` from that directory still installs hooks at the Git repository root:
 
 ```text
 repo/.rstack/hooks/
@@ -156,7 +156,7 @@ repo/.rstack/hooks/_/
 core.hooksPath=.rstack/hooks/_
 ```
 
-Rstack records `frontend` as the project that owns the hooks. Hook scripts remain at the repository root, but run from `frontend`, so they can use its configuration and dependencies without an explicit `cd`:
+Rstack CLI records `frontend` as the project that owns the hooks. Hook scripts remain at the repository root, but run from `frontend`, so they can use its configuration and dependencies without an explicit `cd`:
 
 ```sh title=".rstack/hooks/pre-commit"
 rs staged
@@ -168,7 +168,7 @@ To change the owner, remove `rs setup` from the previous project's `prepare` scr
 
 ## Remove hooks
 
-To remove Rstack-managed hooks:
+To remove hooks managed by Rstack CLI:
 
 1. Remove `rs setup` from the `prepare` script.
 2. Unset the repository's hooks path:
@@ -188,13 +188,13 @@ To remove Rstack-managed hooks:
 - Rerun `rs setup` to restore generated files and executable permissions.
 - Check that `RSTACK_HOOKS` is not set to `0` in the environment or initialization file.
 - If another hooks setup is reported, migrate or remove the conflicting setup before rerunning the command.
-- If another Rstack owner is reported, follow the ownership transfer steps in [Monorepo](#monorepo).
+- If another project is reported as the hooks owner, follow the ownership transfer steps in [Monorepo](#monorepo).
 
-Hook scripts do not need to be executable because Rstack runs them with `sh`.
+Hook scripts do not need to be executable because Rstack CLI runs them with `sh`.
 
 ### Command not found
 
-For exit code 127, Rstack prints the effective `PATH`. If a GUI Git client cannot find Node.js or the package manager, initialize them in `hooks-init.sh`.
+For exit code 127, Rstack CLI prints the effective `PATH`. If a GUI Git client cannot find Node.js or the package manager, initialize them in `hooks-init.sh`.
 
 ### Windows and Yarn
 

--- a/website/docs/en/guide/configuration.mdx
+++ b/website/docs/en/guide/configuration.mdx
@@ -2,7 +2,7 @@
 
 import { PackageManagerTabs } from '@rspress/core/theme';
 
-Rstack centralizes the configuration for your project's tools in a single file. Define only the configurations your project needs with the `define.*()` APIs.
+Rstack CLI centralizes the configuration for your project's tools in a single file. Define only the configurations your project needs with the `define.*()` APIs.
 
 ## Configuration file
 
@@ -31,7 +31,7 @@ define.fmt({
 
 The configuration file does not require a default export. Each `define.*()` API can be called at most once; defining the same configuration type more than once throws an error.
 
-By default, Rstack looks for a file with one of the following names:
+By default, Rstack CLI looks for a file with one of the following names:
 
 - `rstack.config.ts`
 - `rstack.config.js`
@@ -64,7 +64,7 @@ define.app(async () => {
 
 ## Configuration APIs
 
-Configuration options follow the formats of the underlying tools. When using APIs and helpers that Rstack re-exports, prefer the `rstack/app`, `rstack/lib`, `rstack/test`, and `rstack/lint` entry points.
+Configuration options follow the formats of the underlying tools. When using APIs and helpers that Rstack CLI re-exports, prefer the `rstack/app`, `rstack/lib`, `rstack/test`, and `rstack/lint` entry points.
 
 | API                                 | Tool                                                                    | Commands                                                                        |
 | ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
@@ -121,7 +121,7 @@ define.doc({
 });
 ```
 
-`@rspress/core` is an optional dependency of Rstack. Install it in every project that uses the `rs doc` command:
+`@rspress/core` is an optional dependency of Rstack CLI. Install it in every project that uses the `rs doc` command:
 
 <PackageManagerTabs command="install -D @rspress/core" />
 
@@ -142,9 +142,9 @@ define.test({
 });
 ```
 
-When `extends` is omitted, Rstack automatically connects the test configuration to `define.app()` through the Rsbuild adapter. If no application configuration is defined, it falls back to `define.lib()` through the Rslib adapter. The application configuration takes precedence when both are defined. Set `extends` explicitly to opt out of this automatic inheritance.
+When `extends` is omitted, Rstack CLI automatically connects the test configuration to `define.app()` through the Rsbuild adapter. If no application configuration is defined, it falls back to `define.lib()` through the Rslib adapter. The application configuration takes precedence when both are defined. Set `extends` explicitly to opt out of this automatic inheritance.
 
-If the root test configuration does not define `extends` and contains `projects`, Rstack applies automatic inheritance to each inline project that omits its own `extends`. A function-based application or library configuration is resolved once and shared by those projects. String project entries are passed to Rstest unchanged; they load their external configurations independently and do not inherit the current application or library configuration.
+If the root test configuration does not define `extends` and contains `projects`, Rstack CLI applies automatic inheritance to each inline project that omits its own `extends`. A function-based application or library configuration is resolved once and shared by those projects. String project entries are passed to Rstest unchanged; they load their external configurations independently and do not inherit the current application or library configuration.
 
 > For more guidance on testing, see [Testing](./testing).
 

--- a/website/docs/en/guide/formatting.mdx
+++ b/website/docs/en/guide/formatting.mdx
@@ -43,7 +43,7 @@ define.fmt({
 });
 ```
 
-In addition to Prettier options and `overrides`, Rstack provides two options:
+In addition to Prettier options and `overrides`, Rstack CLI provides two options:
 
 - [`ignorePatterns`](#ignore-files): exclude files with Gitignore-compatible patterns.
 - [`sortPackageJson`](#sort-package-json): sort fields in `package.json` files. The default value is `false`.
@@ -196,7 +196,7 @@ You can safely delete `.rstack/cache` to clear cached results. Do not treat the 
 
 ## Prettier plugins
 
-To add formatting capabilities that are not built into Rstack, install the corresponding [Prettier plugin](https://prettier.io/docs/plugins) and add it to `plugins`. Plugins can be referenced by package name, file path, or URL. Package names and relative paths are resolved from the directory containing the Rstack configuration file.
+To add formatting capabilities that are not built into Rstack CLI, install the corresponding [Prettier plugin](https://prettier.io/docs/plugins) and add it to `plugins`. Plugins can be referenced by package name, file path, or URL. Package names and relative paths are resolved from the directory containing the Rstack configuration file.
 
 Because `rs fmt` loads plugins in workers, plugin objects cannot be passed directly. Reference each plugin by package name, path, or URL instead. For example, install and enable [`prettier-plugin-tailwindcss`](https://github.com/tailwindlabs/prettier-plugin-tailwindcss):
 

--- a/website/docs/en/guide/monorepo.mdx
+++ b/website/docs/en/guide/monorepo.mdx
@@ -1,18 +1,18 @@
 ---
-description: 'Configure shared Rstack checks, formatting, staged tasks, and project workflows in a monorepo.'
+description: 'Use Rstack CLI to configure shared checks, formatting, staged tasks, and project workflows in a monorepo.'
 ---
 
 # Monorepo
 
 This guide explains how to use Rstack CLI in a monorepo, including how it works with task orchestrators such as [Turborepo](https://turborepo.com/docs) and [Nx](https://nx.dev/docs/getting-started/intro).
 
-It covers managing Rstack dependencies, configuring lint, formatting, and staged-file tasks at the root, and defining separate configurations for web applications and libraries.
+It covers managing the Rstack CLI dependency, configuring lint, formatting, and staged-file tasks at the root, and defining separate configurations for web applications and libraries.
 
 ## Project structure
 
 The recommended setup has two levels:
 
-- The root manages the shared Rstack version, lint and formatting rules, and staged-file tasks.
+- The root manages the shared Rstack CLI version, lint and formatting rules, and staged-file tasks.
 - Each application or library has its own [Rstack configuration](./configuration) for build, test, or documentation configuration.
 
 ```text
@@ -29,13 +29,13 @@ The recommended setup has two levels:
         └── rstack.config.ts
 ```
 
-This structure keeps the Rstack version in one place while keeping build and test configuration close to the project that uses it.
+This structure keeps the Rstack CLI version in one place while keeping build and test configuration close to the project that uses it.
 
-## Rstack dependency management
+## Rstack CLI dependency management \{#rstack-dependency-management}
 
-Declare Rstack in the root `package.json` so projects use one version by default. See [Quick start](./quick-start#install-rstack) for installation instructions.
+Declare the `rstack` package in the root `package.json` so projects use one Rstack CLI version by default. See [Quick start](./quick-start#install-rstack) for installation instructions.
 
-If a project needs a different Rstack version from the root, declare that version as a dependency of the project.
+If a project needs a different Rstack CLI version from the root, declare that version as a dependency of the project.
 
 Project-specific dependencies, such as Rsbuild plugins and testing libraries, should be declared in the projects that use them.
 
@@ -104,9 +104,9 @@ define.lint(async () => {
 
 ## Project configuration
 
-For each project that uses [Rstack commands](./quick-start#cli-commands), create a [`rstack.config.ts`](./configuration#configuration-file) and register only the configuration that project needs.
+For each project that uses [Rstack CLI commands](./quick-start#cli-commands), create a [`rstack.config.ts`](./configuration#configuration-file) and register only the configuration that project needs.
 
-Rstack loads the configuration from the current working directory. It does not merge a project's configuration with the root configuration.
+Rstack CLI loads the configuration from the current working directory. It does not merge a project's configuration with the root configuration.
 
 ### Web application
 

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -6,11 +6,11 @@ description: 'Create a Rstack project or add Rstack CLI to an existing project a
 
 import { PackageManagerTabs } from '@rspress/core/theme';
 
-Rstack CLI brings the Rstack toolchain together with one CLI and one configuration file. This guide shows how to create a new Rstack project or add Rstack to an existing project, and introduces the available workflows.
+Rstack CLI brings the Rstack toolchain together with one CLI and one configuration file. This guide shows how to create a new Rstack project or add Rstack CLI to an existing project, and introduces the available workflows.
 
 ## Environment preparation
 
-Rstack supports using [Node.js](https://nodejs.org/), [Deno](https://deno.com/), or [Bun](https://bun.sh/) as the JavaScript runtime.
+Rstack CLI supports using [Node.js](https://nodejs.org/), [Deno](https://deno.com/), or [Bun](https://bun.sh/) as the JavaScript runtime.
 
 Use one of the following installation guides to set up a runtime:
 
@@ -20,7 +20,7 @@ Use one of the following installation guides to set up a runtime:
 
 :::tip Version requirements
 
-Rstack requires Node.js 22.12.0 or higher when using Node.js as the runtime.
+Rstack CLI requires Node.js 22.12.0 or higher when using Node.js as the runtime.
 
 :::
 
@@ -104,7 +104,7 @@ Options:
 Available templates: app-vanilla, app-vanilla-ts, app-react, app-react-ts, app-preact, app-preact-ts, app-vue, app-vue-ts, app-lit, app-lit-ts, app-svelte, app-svelte-ts, app-solid, app-solid-ts, lib-node, lib-node-ts, lib-react, lib-react-ts, lib-vue, lib-vue-ts, lib-svelte, lib-svelte-ts, lib-solid, lib-solid-ts, doc, doc-i18n
 ```
 
-## Install Rstack
+## Install Rstack CLI \{#install-rstack}
 
 Install [`rstack`](https://www.npmjs.com/package/rstack) as a development dependency in a project that has a `package.json`:
 
@@ -135,7 +135,7 @@ Add the commands your project needs to the `scripts` field in `package.json`. Fo
 }
 ```
 
-Package scripts use the project-local `rs` binary, so Rstack does not need to be installed globally.
+Package scripts use the project-local `rs` binary, so Rstack CLI does not need to be installed globally.
 
 The following commands are available:
 
@@ -151,7 +151,7 @@ The following commands are available:
 - [`rs setup`](./cli/setup): Install repository-level Git hooks.
 - [`rs staged`](./cli/staged): Run tasks against files staged in Git with lint-staged.
 
-## Configure Rstack
+## Configure Rstack CLI \{#configure-rstack}
 
 Create `rstack.config.ts` in the project root and register the configurations your project needs. The following is a minimal example for an application with testing and linting:
 

--- a/website/docs/en/guide/testing.mdx
+++ b/website/docs/en/guide/testing.mdx
@@ -1,6 +1,6 @@
 # Testing
 
-Rstack uses [Rstest](https://rstest.rs/) to run tests.
+Rstack CLI uses [Rstest](https://rstest.rs/) to run tests.
 
 ```bash
 rs test
@@ -44,7 +44,7 @@ define.test({
 });
 ```
 
-When `extends` is omitted, Rstack uses the Rsbuild adapter to extend the test configuration from `define.app()`. If no application configuration is defined, it uses the Rslib adapter with `define.lib()` instead. `define.app()` takes precedence when both are defined.
+When `extends` is omitted, Rstack CLI uses the Rsbuild adapter to extend the test configuration from `define.app()`. If no application configuration is defined, it uses the Rslib adapter with `define.lib()` instead. `define.app()` takes precedence when both are defined.
 
 ## Multiple projects
 
@@ -78,7 +78,7 @@ define.test({
 });
 ```
 
-Rstack applies the corresponding adapter to each inline project that omits `extends`. A function-based `define.app()` or `define.lib()` configuration is resolved once, then shared by those inline projects.
+Rstack CLI applies the corresponding adapter to each inline project that omits `extends`. A function-based `define.app()` or `define.lib()` configuration is resolved once, then shared by those inline projects.
 
 Run one project by name:
 
@@ -100,7 +100,7 @@ define.test({
 });
 ```
 
-Rstack passes string entries to Rstest unchanged. External projects load their own configuration and do not inherit the current `define.app()` or `define.lib()` configuration. Use external projects when each project manages its configuration independently.
+Rstack CLI passes string entries to Rstest unchanged. External projects load their own configuration and do not inherit the current `define.app()` or `define.lib()` configuration. Use external projects when each project manages its configuration independently.
 
 ## Customize inheritance
 

--- a/website/docs/zh/guide/api-reference.mdx
+++ b/website/docs/zh/guide/api-reference.mdx
@@ -1,12 +1,12 @@
 # API 参考 \{#api-reference}
 
-Rstack 提供统一的配置 API，并通过专用子路径重导出 Rsbuild、Rslib、Rstest 和 Rslint 的公开 API。建议优先从这些子路径导入，以统一依赖入口，并确保 API 与 Rstack 集成的工具版本保持一致。
+Rstack CLI 提供统一的配置 API，并通过专用子路径重导出 Rsbuild、Rslib、Rstest 和 Rslint 的公开 API。建议优先从这些子路径导入，而不是直接从各工具的 core 包导入，以统一依赖入口，并确保 API 与 Rstack CLI 集成的工具版本匹配。
 
 ## 导入路径 \{#import-paths}
 
 | 导入路径                 | 内容                                      | 使用场景                 |
 | ------------------------ | ----------------------------------------- | ------------------------ |
-| `rstack`                 | Rstack 配置 API                           | 注册各项工具配置         |
+| `rstack`                 | Rstack CLI 配置 API                       | 注册各项工具配置         |
 | `rstack/app`             | `@rsbuild/core` 的公开 API                | 构建应用及扩展 Rsbuild   |
 | `rstack/lib`             | `@rslib/core` 的公开 API                  | 构建库及扩展 Rslib       |
 | `rstack/test`            | `@rstest/core` 的公开 API                 | 编写测试及配置测试项目   |
@@ -23,7 +23,7 @@ Rstack 提供统一的配置 API，并通过专用子路径重导出 Rsbuild、R
 
 ## 重导出 \{#re-exports}
 
-以下工具子路径均会重导出对应 core 包的公开 API。通过这些 Rstack 入口导入，可以让依赖入口和工具版本与 Rstack 集成的工具链保持一致。
+以下工具子路径均会重导出对应 core 包的公开 API。通过这些入口导入，可以统一依赖入口，并确保 API 与 Rstack CLI 集成的工具版本匹配。
 
 ### `rstack/app`
 

--- a/website/docs/zh/guide/cli/setup.mdx
+++ b/website/docs/zh/guide/cli/setup.mdx
@@ -99,7 +99,7 @@ rs setup --help
 
 ## 支持的 hooks \{#supported-hooks}
 
-Rstack 支持以下客户端 Git hooks：
+Rstack CLI 支持以下客户端 Git hooks：
 
 - `pre-commit`
 - `pre-merge-commit`
@@ -120,7 +120,7 @@ Rstack 支持以下客户端 Git hooks：
 
 ## Hook 运行时 \{#hook-runtime}
 
-Rstack 使用 POSIX `sh -e` 运行 hook 脚本，并转发 Git 提供的参数和标准输入，同时返回 hook 的退出码。运行 hook 前，Rstack 会切换到安装 hooks 的项目，并将该项目的 `node_modules/.bin` 添加到 `PATH` 开头。
+Rstack CLI 使用 POSIX `sh -e` 运行 hook 脚本，并转发 Git 提供的参数和标准输入，同时返回 hook 的退出码。运行 hook 前，Rstack CLI 会切换到安装 hooks 的项目，并将该项目的 `node_modules/.bin` 添加到 `PATH` 开头。
 
 ### 禁用与调试 \{#disable-and-debug}
 
@@ -130,7 +130,7 @@ Rstack 使用 POSIX `sh -e` 运行 hook 脚本，并转发 Git 提供的参数�
 RSTACK_HOOKS=0 git commit -m "Skip hooks"
 ```
 
-将 `RSTACK_HOOKS` 设为 `2`，可以跟踪 Rstack hook 运行时，包括调用 hook 脚本和处理退出码等步骤；如需跟踪 hook 脚本内部的命令，请在脚本中添加 `set -x`：
+将 `RSTACK_HOOKS` 设为 `2`，可以跟踪 Rstack CLI 的 hook 运行时，包括调用 hook 脚本和处理退出码等步骤；如需跟踪 hook 脚本内部的命令，请在脚本中添加 `set -x`：
 
 ```bash
 RSTACK_HOOKS=2 git commit -m "Trace hooks"
@@ -138,7 +138,7 @@ RSTACK_HOOKS=2 git commit -m "Trace hooks"
 
 ### 配置 hook 运行环境 \{#configure-the-hook-environment}
 
-运行 hook 脚本前，Rstack 会加载以下可选的 POSIX shell 文件：
+运行 hook 脚本前，Rstack CLI 会加载以下可选的 POSIX shell 文件：
 
 ```text
 ${XDG_CONFIG_HOME:-$HOME/.config}/rstack/hooks-init.sh
@@ -148,7 +148,7 @@ ${XDG_CONFIG_HOME:-$HOME/.config}/rstack/hooks-init.sh
 
 ## Monorepo \{#monorepo}
 
-在 monorepo 中，提供 Rstack 的项目可能位于 `frontend/` 等子目录。从该目录运行 `rs setup` 时，hooks 仍会安装到 Git 仓库根目录：
+在 monorepo 中，提供 Rstack CLI 的项目可能位于 `frontend/` 等子目录。从该目录运行 `rs setup` 时，hooks 仍会安装到 Git 仓库根目录：
 
 ```text
 repo/.rstack/hooks/
@@ -156,7 +156,7 @@ repo/.rstack/hooks/_/
 core.hooksPath=.rstack/hooks/_
 ```
 
-Rstack 会将 `frontend` 记录为负责管理 hooks 的项目。hook 脚本仍位于仓库根目录，但会从 `frontend` 目录运行，因此可以直接使用其中的配置和依赖，无需显式执行 `cd`：
+Rstack CLI 会将 `frontend` 记录为负责管理 hooks 的项目。hook 脚本仍位于仓库根目录，但会从 `frontend` 目录运行，因此可以直接使用其中的配置和依赖，无需显式执行 `cd`：
 
 ```sh title=".rstack/hooks/pre-commit"
 rs staged
@@ -168,7 +168,7 @@ rs staged
 
 ## 移除 hooks \{#remove-hooks}
 
-如需移除由 Rstack 管理的 hooks：
+如需移除由 Rstack CLI 管理的 hooks：
 
 1. 从 `prepare` 脚本中移除 `rs setup`。
 2. 删除仓库的 hooks 路径配置：
@@ -188,13 +188,13 @@ rs staged
 - 重新运行 `rs setup`，恢复生成文件及其可执行权限。
 - 检查环境变量或初始化文件中是否设置了 `RSTACK_HOOKS=0`。
 - 如果命令提示存在其他 hooks 配置，请先迁移或移除冲突配置，再重新运行该命令。
-- 如果命令提示存在其他 Rstack owner，请按照 [Monorepo](#monorepo) 中的步骤转移 owner。
+- 如果命令提示其他项目是 hooks owner，请按照 [Monorepo](#monorepo) 中的步骤转移 owner。
 
-hook 脚本不需要可执行权限，因为 Rstack 会使用 `sh` 运行它。
+hook 脚本不需要可执行权限，因为 Rstack CLI 会使用 `sh` 运行它。
 
 ### 找不到命令 \{#command-not-found}
 
-退出码为 127 时，Rstack 会打印实际生效的 `PATH`。如果 GUI Git 客户端找不到 Node.js 或包管理器，请在 `hooks-init.sh` 中初始化相关环境。
+退出码为 127 时，Rstack CLI 会打印实际生效的 `PATH`。如果 GUI Git 客户端找不到 Node.js 或包管理器，请在 `hooks-init.sh` 中初始化相关环境。
 
 ### Windows 与 Yarn \{#windows-and-yarn}
 

--- a/website/docs/zh/guide/configuration.mdx
+++ b/website/docs/zh/guide/configuration.mdx
@@ -2,7 +2,7 @@
 
 import { PackageManagerTabs } from '@rspress/core/theme';
 
-Rstack 将项目所用工具的配置集中到一份文件中。通过 `define.*()` API 定义项目实际需要的配置即可。
+Rstack CLI 将项目所用工具的配置集中到一份文件中。通过 `define.*()` API 定义项目实际需要的配置即可。
 
 ## 配置文件 \{#configuration-file}
 
@@ -31,7 +31,7 @@ define.fmt({
 
 配置文件无需默认导出。每个 `define.*()` API 最多调用一次；重复定义同一类型的配置会抛出错误。
 
-Rstack 默认会查找使用以下任一文件名的配置文件：
+Rstack CLI 默认会查找使用以下任一文件名的配置文件：
 
 - `rstack.config.ts`
 - `rstack.config.js`
@@ -46,7 +46,7 @@ rs build --config ./configs/rstack.config.ts
 
 ## 按需加载依赖 \{#loading-dependencies-on-demand}
 
-每次执行 `rs` 命令时，Rstack 都会加载并执行配置文件，然后只解析当前命令需要的配置函数。
+每次执行 `rs` 命令时，Rstack CLI 都会加载并执行配置文件，然后只解析当前命令需要的配置函数。
 
 如果配置需要导入插件或其他工具专属依赖，请使用异步配置函数，并在函数内通过动态 `import()` 加载这些依赖。这样只有解析该配置时才会加载相关依赖。
 
@@ -64,7 +64,7 @@ define.app(async () => {
 
 ## 配置 API \{#configuration-apis}
 
-各 API 沿用底层工具的配置格式。使用 Rstack 已重导出的 API 和辅助函数时，推荐从 `rstack/app`、`rstack/lib`、`rstack/test` 和 `rstack/lint` 入口导入。
+各 API 沿用底层工具的配置格式。使用 Rstack CLI 已重导出的 API 和辅助函数时，推荐从 `rstack/app`、`rstack/lib`、`rstack/test` 和 `rstack/lint` 入口导入。
 
 | API                                 | 底层工具                                                                | 对应命令                                                                        |
 | ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
@@ -121,7 +121,7 @@ define.doc({
 });
 ```
 
-`@rspress/core` 是 Rstack 的可选依赖。每个使用 `rs doc` 命令的项目都需要安装该依赖：
+`@rspress/core` 是 Rstack CLI 的可选依赖。每个使用 `rs doc` 命令的项目都需要安装该依赖：
 
 <PackageManagerTabs command="install -D @rspress/core" />
 
@@ -142,9 +142,9 @@ define.test({
 });
 ```
 
-未设置 `extends` 时，Rstack 会通过 Rsbuild 适配器让测试配置自动继承 `define.app()`；如果未定义应用配置，则通过 Rslib 适配器回退到 `define.lib()`。二者同时存在时，应用配置的优先级更高。显式设置 `extends` 可关闭自动继承。
+未设置 `extends` 时，Rstack CLI 会通过 Rsbuild 适配器让测试配置自动继承 `define.app()`；如果未定义应用配置，则通过 Rslib 适配器回退到 `define.lib()`。二者同时存在时，应用配置的优先级更高。显式设置 `extends` 可关闭自动继承。
 
-如果测试根配置未定义 `extends` 且包含 `projects`，Rstack 会为每个未自行设置 `extends` 的内联项目应用自动继承。函数形式的应用或库配置只会解析一次，并由这些项目共享。字符串形式的项目会原样传给 Rstest；它们会独立加载外部配置，不继承当前应用或库的配置。
+如果测试根配置未定义 `extends` 且包含 `projects`，Rstack CLI 会为每个未自行设置 `extends` 的内联项目应用自动继承。函数形式的应用或库配置只会解析一次，并由这些项目共享。字符串形式的项目会原样传给 Rstest；它们会独立加载外部配置，不继承当前应用或库的配置。
 
 > 如需了解更多测试相关用法，请参阅[测试](./testing)。
 

--- a/website/docs/zh/guide/formatting.mdx
+++ b/website/docs/zh/guide/formatting.mdx
@@ -43,7 +43,7 @@ define.fmt({
 });
 ```
 
-除了 Prettier 选项和 `overrides`，Rstack 还提供两个选项：
+除了 Prettier 选项和 `overrides`，Rstack CLI 还提供两个选项：
 
 - [`ignorePatterns`](#ignore-files)：使用兼容 Gitignore 的模式排除文件。
 - [`sortPackageJson`](#sort-package-json)：对 `package.json` 中的字段排序，默认值为 `false`。
@@ -167,7 +167,7 @@ define.fmt({
 
 ### 合并顺序 \{#merge-order}
 
-如果同一文件匹配多条 override 规则，Rstack 会按声明顺序合并配置，后面的值优先。下面的 `README.md` 会同时匹配两条规则，因此最终的 `printWidth` 为 `80`：
+如果同一文件匹配多条 override 规则，Rstack CLI 会按声明顺序合并配置，后面的值优先。下面的 `README.md` 会同时匹配两条规则，因此最终的 `printWidth` 为 `80`：
 
 ```ts
 define.fmt({
@@ -196,7 +196,7 @@ rs fmt --no-cache
 
 ## Prettier 插件 \{#prettier-plugins}
 
-如果需要使用 Rstack 未内置的格式化能力，可以安装相应的 [Prettier 插件](https://prettier.io/docs/plugins)，并添加到 `plugins` 中。插件支持通过包名、文件路径或 URL 引用，其中包名和相对路径基于 Rstack 配置文件所在的目录解析。
+如果需要使用 Rstack CLI 未内置的格式化能力，可以安装相应的 [Prettier 插件](https://prettier.io/docs/plugins)，并添加到 `plugins` 中。插件支持通过包名、文件路径或 URL 引用，其中包名和相对路径基于 Rstack 配置文件所在的目录解析。
 
 由于 `rs fmt` 会在 worker 中加载插件，因此不支持直接传入插件对象。请通过包名、路径或 URL 引用插件。例如，安装并启用 [`prettier-plugin-tailwindcss`](https://github.com/tailwindlabs/prettier-plugin-tailwindcss)：
 

--- a/website/docs/zh/guide/monorepo.mdx
+++ b/website/docs/zh/guide/monorepo.mdx
@@ -1,18 +1,18 @@
 ---
-description: '在 Monorepo 中配置共享的 Rstack 检查、格式化、暂存文件任务和项目工作流。'
+description: '在 Monorepo 中使用 Rstack CLI 配置共享检查、格式化、暂存文件任务和项目工作流。'
 ---
 
 # Monorepo
 
 本指南介绍如何在 Monorepo 中使用 Rstack CLI，以及如何让它与 [Turborepo](https://turborepo.com/docs)、[Nx](https://nx.dev/docs/getting-started/intro) 等任务编排工具协同工作。
 
-主要内容包括管理 Rstack 依赖、在根目录统一配置代码检查、格式化和暂存文件任务，以及为 Web 应用和库项目定义独立配置。
+主要内容包括管理 Rstack CLI 依赖、在根目录统一配置代码检查、格式化和暂存文件任务，以及为 Web 应用和库项目定义独立配置。
 
 ## 目录结构 \{#project-structure}
 
 推荐使用两层配置：
 
-- 根目录统一管理 Rstack 版本、lint 和格式化规则，以及暂存文件任务。
+- 根目录统一管理 Rstack CLI 版本、lint 和格式化规则，以及暂存文件任务。
 - 每个应用或库使用自己的 [Rstack 配置](./configuration)，定义构建、测试或文档配置。
 
 ```text
@@ -29,13 +29,13 @@ description: '在 Monorepo 中配置共享的 Rstack 检查、格式化、暂存
         └── rstack.config.ts
 ```
 
-这种结构既能统一 Rstack 版本，也能让构建和测试配置靠近实际使用它们的项目。
+这种结构既能统一 Rstack CLI 版本，也能让构建和测试配置靠近实际使用它们的项目。
 
-## Rstack 依赖管理 \{#rstack-dependency-management}
+## Rstack CLI 依赖管理 \{#rstack-dependency-management}
 
-在根目录的 `package.json` 中声明 Rstack，让各个项目默认使用同一个版本。安装方法请参考[快速上手](./quick-start#install-rstack)。
+在根目录的 `package.json` 中声明 `rstack` 包，让各个项目默认使用同一个 Rstack CLI 版本。安装方法请参考[快速上手](./quick-start#install-rstack)。
 
-如果子项目需要使用与根目录不同版本的 `rstack`，可以在该项目中单独声明对应版本的 `rstack` 依赖。
+如果子项目需要使用与根目录不同版本的 Rstack CLI，可以在该项目中单独声明对应版本的 `rstack` 依赖。
 
 Rsbuild 插件、测试库等项目专属依赖，建议定义在实际使用它们的子项目中。
 
@@ -104,9 +104,9 @@ define.lint(async () => {
 
 ## 子项目配置 \{#project-configuration}
 
-为每个使用 [Rstack 命令](./quick-start#cli-commands)的子项目创建 [`rstack.config.ts`](./configuration#configuration-file)，并且只配置该项目需要的功能。
+为每个使用 [Rstack CLI 命令](./quick-start#cli-commands)的子项目创建 [`rstack.config.ts`](./configuration#configuration-file)，并且只配置该项目需要的功能。
 
-Rstack 会加载当前工作目录中的配置，不会将子项目配置与根配置自动合并。
+Rstack CLI 会加载当前工作目录中的配置，不会将子项目配置与根配置自动合并。
 
 ### Web 应用 \{#web-application}
 

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -6,11 +6,11 @@ description: '创建 Rstack 项目，或在现有项目中安装 Rstack CLI 并�
 
 import { PackageManagerTabs } from '@rspress/core/theme';
 
-Rstack CLI 通过统一的命令行和配置文件整合 Rstack 工具链。本指南将介绍如何创建新的 Rstack 项目或在现有项目中添加 Rstack，以及可以使用的工作流。
+Rstack CLI 通过统一的命令行和配置文件整合 Rstack 工具链。本指南将介绍如何创建新的 Rstack 项目或在现有项目中添加 Rstack CLI，以及可以使用的工作流。
 
 ## 环境准备 \{#environment-preparation}
 
-Rstack 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 或 [Bun](https://bun.sh/) 作为 JavaScript 运行时。
+Rstack CLI 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 或 [Bun](https://bun.sh/) 作为 JavaScript 运行时。
 
 参考以下安装指南，选择一种运行时：
 
@@ -20,7 +20,7 @@ Rstack 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) �
 
 :::tip 版本要求
 
-使用 Node.js 作为运行时时，Rstack 要求 Node.js 版本为 22.12.0 或更高版本。
+使用 Node.js 作为运行时时，Rstack CLI 要求 Node.js 版本为 22.12.0 或更高版本。
 
 :::
 
@@ -104,7 +104,7 @@ Options:
 Available templates: app-vanilla, app-vanilla-ts, app-react, app-react-ts, app-preact, app-preact-ts, app-vue, app-vue-ts, app-lit, app-lit-ts, app-svelte, app-svelte-ts, app-solid, app-solid-ts, lib-node, lib-node-ts, lib-react, lib-react-ts, lib-vue, lib-vue-ts, lib-svelte, lib-svelte-ts, lib-solid, lib-solid-ts, doc, doc-i18n
 ```
 
-## 安装 Rstack \{#install-rstack}
+## 安装 Rstack CLI \{#install-rstack}
 
 在已有 `package.json` 的项目中，将 [`rstack`](https://www.npmjs.com/package/rstack) 安装为开发依赖：
 
@@ -135,9 +135,9 @@ Available templates: app-vanilla, app-vanilla-ts, app-react, app-react-ts, app-p
 }
 ```
 
-package scripts 会使用项目本地安装的 `rs` 命令，因此无需全局安装 Rstack。
+package scripts 会使用项目本地安装的 `rs` 命令，因此无需全局安装 Rstack CLI。
 
-Rstack 提供以下命令：
+Rstack CLI 提供以下命令：
 
 - [`rs dev`](./cli/dev)：启动应用开发服务器。
 - [`rs build`](./cli/build)：构建应用的生产版本。
@@ -151,7 +151,7 @@ Rstack 提供以下命令：
 - [`rs setup`](./cli/setup)：安装仓库级 Git hooks。
 - [`rs staged`](./cli/staged)：使用 lint-staged 对 Git 暂存区中的文件运行任务。
 
-## 配置 Rstack \{#configure-rstack}
+## 配置 Rstack CLI \{#configure-rstack}
 
 在项目根目录创建 `rstack.config.ts`，并注册项目所需的配置。以下是一个包含应用、测试和代码检查的最小示例：
 

--- a/website/docs/zh/guide/testing.mdx
+++ b/website/docs/zh/guide/testing.mdx
@@ -1,6 +1,6 @@
 # 测试 \{#testing}
 
-Rstack 使用 [Rstest](https://rstest.rs/zh/) 运行测试。
+Rstack CLI 使用 [Rstest](https://rstest.rs/zh/) 运行测试。
 
 ```bash
 rs test
@@ -44,7 +44,7 @@ define.test({
 });
 ```
 
-未设置 `extends` 时，Rstack 会通过 Rsbuild 适配器让测试配置继承 `define.app()`。如果没有应用配置，则通过 Rslib 适配器回退到 `define.lib()`。同时定义两者时，`define.app()` 的优先级更高。
+未设置 `extends` 时，Rstack CLI 会通过 Rsbuild 适配器让测试配置继承 `define.app()`。如果没有应用配置，则通过 Rslib 适配器回退到 `define.lib()`。同时定义两者时，`define.app()` 的优先级更高。
 
 ## 多项目 \{#multiple-projects}
 
@@ -78,7 +78,7 @@ define.test({
 });
 ```
 
-Rstack 会将对应的适配器应用到每个未设置 `extends` 的内联项目。函数形式的 `define.app()` 或 `define.lib()` 配置只会解析一次，再由这些内联项目共享。
+Rstack CLI 会将对应的适配器应用到每个未设置 `extends` 的内联项目。函数形式的 `define.app()` 或 `define.lib()` 配置只会解析一次，再由这些内联项目共享。
 
 按项目名称运行单个项目：
 
@@ -100,7 +100,7 @@ define.test({
 });
 ```
 
-Rstack 会将字符串形式的项目原样传给 Rstest。外部项目会加载自己的配置，不会继承当前的 `define.app()` 或 `define.lib()` 配置。每个项目需要独立管理配置时，请使用外部项目。
+Rstack CLI 会将字符串形式的项目原样传给 Rstest。外部项目会加载自己的配置，不会继承当前的 `define.app()` 或 `define.lib()` 配置。每个项目需要独立管理配置时，请使用外部项目。
 
 ## 自定义继承 \{#customize-inheritance}
 


### PR DESCRIPTION
Rstack CLI is the current project, while Rstack names the broader JavaScript toolchain. This PR updates the English and Chinese documentation to distinguish those terms consistently while retaining Rstack configuration as the established configuration name. It also updates create-rstack templates to link explicitly to the Rstack CLI documentation and repository.