### PR TITLE
feat(lint): inject lint exports into config factory

### DIFF
--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -11,6 +11,10 @@ import type { StagedConfig } from './staged.ts';
 export type RslintConfigDefinition = RslintConfig | (() => Promise<RslintConfig>);
 export type RspressConfigDefinition = UserConfig | UserConfigAsyncFn;
 
+type RslintConfigFactory = (
+  lint: typeof import('@rslint/core'),
+) => RslintConfig | Promise<RslintConfig>;
+
 export type Configs = {
   app?: RsbuildConfigDefinition;
   lib?: RslibConfigDefinition;
@@ -125,10 +129,11 @@ type Define = {
    * Defines the Rslint config for linting.
    *
    * This config is used by the `rs lint` command.
+   * A config factory receives the exports from `rstack/lint`.
    *
    * @see {@link https://rstack.rs/config | Rstack configuration guide}
    */
-  lint: (config: RslintConfig | (() => Promise<RslintConfig>)) => void;
+  lint: (config: RslintConfig | RslintConfigFactory) => void;
   /**
    * Defines the Prettier config for formatting.
    *
@@ -165,7 +170,11 @@ export const define: Define = {
   lib: (config) => setConfig('lib', config),
   doc: (config) => setConfig('doc', config),
   test: (config) => setConfig('test', config),
-  lint: (config) => setConfig('lint', config),
+  lint: (config) =>
+    setConfig(
+      'lint',
+      typeof config === 'function' ? async () => config(await import('@rslint/core')) : config,
+    ),
   fmt: (config) => setConfig('fmt', config),
   staged: (config) => setConfig('staged', config),
 };

--- a/packages/rstack/src/rslintConfig.ts
+++ b/packages/rstack/src/rslintConfig.ts
@@ -2,15 +2,15 @@ import { loadRstackConfig } from './config.ts';
 import type { RslintConfig } from '@rslint/core';
 
 const { configs } = await loadRstackConfig();
-const lintExports = configs.lint ?? [];
+const lintDefinition = configs.lint ?? [];
 
 let lintConfig: RslintConfig;
 
 // TODO: support function in Rslint core
-if (typeof lintExports === 'function') {
-  lintConfig = await lintExports();
+if (typeof lintDefinition === 'function') {
+  lintConfig = await lintDefinition();
 } else {
-  lintConfig = lintExports;
+  lintConfig = lintDefinition;
 }
 
 export default lintConfig;

--- a/packages/rstack/tests/types/resolution-bundler/index.ts
+++ b/packages/rstack/tests/types/resolution-bundler/index.ts
@@ -11,11 +11,12 @@ import {
   type LoadRstackConfigOptions,
 } from 'rstack/config';
 import { defineConfig as defineLibConfig } from 'rstack/lib';
-import { js, ts } from 'rstack/lint';
+import { defineConfig as defineLintConfig } from 'rstack/lint';
 import { expect as importedExpect, test as importedTest } from 'rstack/test';
 
 const appConfig = defineAppConfig({});
 const libConfig = defineLibConfig({});
+const lintConfig = defineLintConfig([]);
 const loadOptions: LoadRstackConfigOptions = { configFilePath: 'rstack.config.ts' };
 const loadedConfig: Promise<LoadedRstackConfig> = loadRstackConfig(loadOptions);
 const configs: Configs = {};
@@ -26,9 +27,10 @@ void configs;
 void createRsbuild({ config: appConfig });
 define.app(appConfig);
 define.lib(libConfig);
+define.lint(lintConfig);
+define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
 define.doc({});
 define.test({});
-define.lint([js.configs.recommended, ts.configs.recommended]);
 define.staged({});
 
 importedTest('exposes the Rstest APIs', () => {

--- a/packages/rstack/tests/types/resolution-nodenext/index.ts
+++ b/packages/rstack/tests/types/resolution-nodenext/index.ts
@@ -1,4 +1,4 @@
-// This folder checks Rstack's exports and APIs with NodeNext resolution.
+// This folder checks Rstack's exports and APIs with bundler resolution.
 import 'rstack/test/globals';
 import 'rstack/test/importMeta';
 import 'rstack/types';
@@ -11,11 +11,12 @@ import {
   type LoadRstackConfigOptions,
 } from 'rstack/config';
 import { defineConfig as defineLibConfig } from 'rstack/lib';
-import { js, ts } from 'rstack/lint';
+import { defineConfig as defineLintConfig } from 'rstack/lint';
 import { expect as importedExpect, test as importedTest } from 'rstack/test';
 
 const appConfig = defineAppConfig({});
 const libConfig = defineLibConfig({});
+const lintConfig = defineLintConfig([]);
 const loadOptions: LoadRstackConfigOptions = { configFilePath: 'rstack.config.ts' };
 const loadedConfig: Promise<LoadedRstackConfig> = loadRstackConfig(loadOptions);
 const configs: Configs = {};
@@ -26,9 +27,10 @@ void configs;
 void createRsbuild({ config: appConfig });
 define.app(appConfig);
 define.lib(libConfig);
+define.lint(lintConfig);
+define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
 define.doc({});
 define.test({});
-define.lint([js.configs.recommended, ts.configs.recommended]);
 define.staged({});
 
 importedTest('exposes the Rstest APIs', () => {


### PR DESCRIPTION
## Summary

`define.lint` currently requires users to write an async callback and manually import `rstack/lint` when using bundled presets. This PR injects the lazily loaded Rslint exports into lint configuration factories, enabling concise synchronous callbacks while preserving direct configurations and existing no-argument factories.