### PR TITLE
refactor(create-rstack): simplify lint configuration

### DIFF
--- a/packages/create-rstack/template-app-lit-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-lit-ts/rstack.config.ts
@@ -16,11 +16,10 @@ define.test({
   testEnvironment: 'happy-dom',
 });
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
-});
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-lit/rstack.config.js
+++ b/packages/create-rstack/template-app-lit/rstack.config.js
@@ -17,11 +17,7 @@ define.test({
   testEnvironment: 'happy-dom',
 });
 
-define.lint(async () => {
-  const { js } = await import('rstack/lint');
-
-  return [js.configs.recommended];
-});
+define.lint(({ js }) => [js.configs.recommended]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-preact-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-preact-ts/rstack.config.ts
@@ -13,16 +13,12 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(async () => {
-  const { js, ts, reactHooksPlugin, reactPlugin } = await import('rstack/lint');
-
-  return [
-    js.configs.recommended,
-    ts.configs.recommendedTypeChecked,
-    reactPlugin.configs.recommended,
-    reactHooksPlugin.configs.recommended,
-  ];
-});
+define.lint(({ js, ts, reactHooksPlugin, reactPlugin }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+  reactPlugin.configs.recommended,
+  reactHooksPlugin.configs.recommended,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-preact/rstack.config.js
+++ b/packages/create-rstack/template-app-preact/rstack.config.js
@@ -14,15 +14,11 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(async () => {
-  const { js, reactHooksPlugin, reactPlugin } = await import('rstack/lint');
-
-  return [
-    js.configs.recommended,
-    reactPlugin.configs.recommended,
-    reactHooksPlugin.configs.recommended,
-  ];
-});
+define.lint(({ js, reactHooksPlugin, reactPlugin }) => [
+  js.configs.recommended,
+  reactPlugin.configs.recommended,
+  reactHooksPlugin.configs.recommended,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-react-ts/rstack.config.ts
@@ -13,16 +13,12 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(async () => {
-  const { js, ts, reactPlugin, reactHooksPlugin } = await import('rstack/lint');
-
-  return [
-    js.configs.recommended,
-    ts.configs.recommendedTypeChecked,
-    reactPlugin.configs.recommended,
-    reactHooksPlugin.configs.recommended,
-  ];
-});
+define.lint(({ js, ts, reactPlugin, reactHooksPlugin }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+  reactPlugin.configs.recommended,
+  reactHooksPlugin.configs.recommended,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-react/rstack.config.js
+++ b/packages/create-rstack/template-app-react/rstack.config.js
@@ -14,15 +14,11 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(async () => {
-  const { js, reactHooksPlugin, reactPlugin } = await import('rstack/lint');
-
-  return [
-    js.configs.recommended,
-    reactPlugin.configs.recommended,
-    reactHooksPlugin.configs.recommended,
-  ];
-});
+define.lint(({ js, reactHooksPlugin, reactPlugin }) => [
+  js.configs.recommended,
+  reactPlugin.configs.recommended,
+  reactHooksPlugin.configs.recommended,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-solid-ts/rstack.config.ts
@@ -19,11 +19,10 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
-});
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-solid/rstack.config.js
+++ b/packages/create-rstack/template-app-solid/rstack.config.js
@@ -20,11 +20,7 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(async () => {
-  const { js } = await import('rstack/lint');
-
-  return [js.configs.recommended];
-});
+define.lint(({ js }) => [js.configs.recommended]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
@@ -13,11 +13,10 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
-});
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 
 define.fmt({
   plugins: ['prettier-plugin-svelte'],

--- a/packages/create-rstack/template-app-svelte/rstack.config.js
+++ b/packages/create-rstack/template-app-svelte/rstack.config.js
@@ -14,11 +14,7 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(async () => {
-  const { js } = await import('rstack/lint');
-
-  return [js.configs.recommended];
-});
+define.lint(({ js }) => [js.configs.recommended]);
 
 define.fmt({
   plugins: ['prettier-plugin-svelte'],

--- a/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
@@ -9,11 +9,10 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
-});
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-vanilla/rstack.config.js
+++ b/packages/create-rstack/template-app-vanilla/rstack.config.js
@@ -10,11 +10,7 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(async () => {
-  const { js } = await import('rstack/lint');
-
-  return [js.configs.recommended];
-});
+define.lint(({ js }) => [js.configs.recommended]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vue-ts/rstack.config.ts
@@ -13,11 +13,10 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
-});
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-vue/rstack.config.js
+++ b/packages/create-rstack/template-app-vue/rstack.config.js
@@ -14,11 +14,7 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(async () => {
-  const { js } = await import('rstack/lint');
-
-  return [js.configs.recommended];
-});
+define.lint(({ js }) => [js.configs.recommended]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-doc-i18n/rstack.config.ts
+++ b/packages/create-rstack/template-doc-i18n/rstack.config.ts
@@ -23,16 +23,12 @@ define.doc({
   ],
 });
 
-define.lint(async () => {
-  const { js, ts, reactPlugin, reactHooksPlugin } = await import('rstack/lint');
-
-  return [
-    js.configs.recommended,
-    ts.configs.recommendedTypeChecked,
-    reactPlugin.configs.recommended,
-    reactHooksPlugin.configs.recommended,
-  ];
-});
+define.lint(({ js, ts, reactPlugin, reactHooksPlugin }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+  reactPlugin.configs.recommended,
+  reactHooksPlugin.configs.recommended,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-doc/rstack.config.ts
+++ b/packages/create-rstack/template-doc/rstack.config.ts
@@ -7,16 +7,12 @@ define.doc({
   title: 'My Site',
 });
 
-define.lint(async () => {
-  const { js, ts, reactPlugin, reactHooksPlugin } = await import('rstack/lint');
-
-  return [
-    js.configs.recommended,
-    ts.configs.recommendedTypeChecked,
-    reactPlugin.configs.recommended,
-    reactHooksPlugin.configs.recommended,
-  ];
-});
+define.lint(({ js, ts, reactPlugin, reactHooksPlugin }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+  reactPlugin.configs.recommended,
+  reactHooksPlugin.configs.recommended,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-lib-node-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-node-ts/rstack.config.ts
@@ -10,11 +10,10 @@ define.test({
   // Configure Rstest
 });
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
-});
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-lib-node/rstack.config.js
+++ b/packages/create-rstack/template-lib-node/rstack.config.js
@@ -10,11 +10,7 @@ define.test({
   // Configure Rstest
 });
 
-define.lint(async () => {
-  const { js } = await import('rstack/lint');
-
-  return [js.configs.recommended];
-});
+define.lint(({ js }) => [js.configs.recommended]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-lib-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-react-ts/rstack.config.ts
@@ -23,16 +23,12 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(async () => {
-  const { js, ts, reactPlugin, reactHooksPlugin } = await import('rstack/lint');
-
-  return [
-    js.configs.recommended,
-    ts.configs.recommendedTypeChecked,
-    reactPlugin.configs.recommended,
-    reactHooksPlugin.configs.recommended,
-  ];
-});
+define.lint(({ js, ts, reactPlugin, reactHooksPlugin }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+  reactPlugin.configs.recommended,
+  reactHooksPlugin.configs.recommended,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-lib-react/rstack.config.js
+++ b/packages/create-rstack/template-lib-react/rstack.config.js
@@ -23,15 +23,11 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(async () => {
-  const { js, reactHooksPlugin, reactPlugin } = await import('rstack/lint');
-
-  return [
-    js.configs.recommended,
-    reactPlugin.configs.recommended,
-    reactHooksPlugin.configs.recommended,
-  ];
-});
+define.lint(({ js, reactHooksPlugin, reactPlugin }) => [
+  js.configs.recommended,
+  reactPlugin.configs.recommended,
+  reactHooksPlugin.configs.recommended,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
@@ -75,11 +75,10 @@ define.test(async () => {
   };
 });
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
-});
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-lib-solid/rstack.config.js
+++ b/packages/create-rstack/template-lib-solid/rstack.config.js
@@ -75,11 +75,7 @@ define.test(async () => {
   };
 });
 
-define.lint(async () => {
-  const { js } = await import('rstack/lint');
-
-  return [js.configs.recommended];
-});
+define.lint(({ js }) => [js.configs.recommended]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
@@ -23,11 +23,10 @@ define.test({
   testEnvironment: 'happy-dom',
 });
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
-});
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 
 define.fmt({
   plugins: ['prettier-plugin-svelte'],

--- a/packages/create-rstack/template-lib-svelte/rstack.config.js
+++ b/packages/create-rstack/template-lib-svelte/rstack.config.js
@@ -23,11 +23,7 @@ define.test({
   testEnvironment: 'happy-dom',
 });
 
-define.lint(async () => {
-  const { js } = await import('rstack/lint');
-
-  return [js.configs.recommended];
-});
+define.lint(({ js }) => [js.configs.recommended]);
 
 define.fmt({
   plugins: ['prettier-plugin-svelte'],

--- a/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
@@ -22,11 +22,10 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommendedTypeChecked];
-});
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-lib-vue/rstack.config.js
+++ b/packages/create-rstack/template-lib-vue/rstack.config.js
@@ -23,11 +23,7 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(async () => {
-  const { js } = await import('rstack/lint');
-
-  return [js.configs.recommended];
-});
+define.lint(({ js }) => [js.configs.recommended]);
 
 define.fmt({
   singleQuote: true,


### PR DESCRIPTION
## Summary

create-rstack templates currently use async configuration factories solely to import `rstack/lint`. This PR adopts the injected lint exports introduced by #352 across all application, library, and documentation templates, keeping generated configurations synchronous and concise without changing enabled presets or plugins.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/352