### PR TITLE
refactor(config): use injected lint exports

### DIFF
--- a/examples/app-react/rstack.config.ts
+++ b/examples/app-react/rstack.config.ts
@@ -12,12 +12,9 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(async () => {
-  const { js, ts, reactPlugin, reactHooksPlugin } = await import('rstack/lint');
-  return [
-    js.configs.recommended,
-    ts.configs.recommended,
-    reactPlugin.configs.recommended,
-    reactHooksPlugin.configs.recommended,
-  ];
-});
+define.lint(({ js, ts, reactPlugin, reactHooksPlugin }) => [
+  js.configs.recommended,
+  ts.configs.recommended,
+  reactPlugin.configs.recommended,
+  reactHooksPlugin.configs.recommended,
+]);

--- a/examples/app-vanilla/rstack.config.ts
+++ b/examples/app-vanilla/rstack.config.ts
@@ -6,7 +6,4 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-  return [js.configs.recommended, ts.configs.recommended];
-});
+define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommended]);

--- a/examples/documentation/rstack.config.ts
+++ b/examples/documentation/rstack.config.ts
@@ -7,12 +7,9 @@ define.doc({
   title: 'My Site',
 });
 
-define.lint(async () => {
-  const { js, ts, reactPlugin, reactHooksPlugin } = await import('rstack/lint');
-  return [
-    js.configs.recommended,
-    ts.configs.recommended,
-    reactPlugin.configs.recommended,
-    reactHooksPlugin.configs.recommended,
-  ];
-});
+define.lint(({ js, ts, reactPlugin, reactHooksPlugin }) => [
+  js.configs.recommended,
+  ts.configs.recommended,
+  reactPlugin.configs.recommended,
+  reactHooksPlugin.configs.recommended,
+]);

--- a/examples/lib-node/rstack.config.ts
+++ b/examples/lib-node/rstack.config.ts
@@ -6,7 +6,4 @@ define.lib({
   syntax: ['node 22'],
 });
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-  return [js.configs.recommended, ts.configs.recommended];
-});
+define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommended]);

--- a/examples/lib-react/rstack.config.ts
+++ b/examples/lib-react/rstack.config.ts
@@ -22,12 +22,9 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(async () => {
-  const { js, ts, reactPlugin, reactHooksPlugin } = await import('rstack/lint');
-  return [
-    js.configs.recommended,
-    ts.configs.recommended,
-    reactPlugin.configs.recommended,
-    reactHooksPlugin.configs.recommended,
-  ];
-});
+define.lint(({ js, ts, reactPlugin, reactHooksPlugin }) => [
+  js.configs.recommended,
+  ts.configs.recommended,
+  reactPlugin.configs.recommended,
+  reactHooksPlugin.configs.recommended,
+]);

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -1,9 +1,8 @@
 // Rstack configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
-define.lint(async () => {
+define.lint(async ({ js, ts }) => {
   const { default: globals } = await import('globals');
-  const { js, ts } = await import('rstack/lint');
   return [
     js.configs.recommended,
     ts.configs.recommendedTypeChecked,


### PR DESCRIPTION
## Summary

Repository examples and the root Rstack configuration still manually import `rstack/lint`, obscuring the new injected factory exports. This PR adopts the injected lint exports across those configurations, removing unnecessary dynamic imports while preserving all lint rules and keeping the root callback asynchronous for `globals`.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/352
- https://github.com/rstackjs/rstack-cli/pull/353