### PR TITLE
docs: simplify lint configuration examples

### DIFF
--- a/website/docs/en/guide/cli/lint.mdx
+++ b/website/docs/en/guide/cli/lint.mdx
@@ -29,14 +29,10 @@ rs lint --type-check
 
 ## Configuration
 
-Configure linting through [`define.lint()`](../configuration#define-lint) in the [Rstack configuration file](/guide/configuration#configuration-file). It accepts the standard [Rslint configuration](https://rslint.rs/config/). Presets and plugins can be imported from `rstack/lint` on demand:
+Configure linting through [`define.lint()`](../configuration#define-lint) in the [Rstack configuration file](/guide/configuration#configuration-file). It accepts the standard [Rslint configuration](https://rslint.rs/config/). A configuration function receives all exports from `rstack/lint`, so presets and plugins do not need to be imported manually:
 
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommended];
-});
+define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
 ```

--- a/website/docs/en/guide/configuration.mdx
+++ b/website/docs/en/guide/configuration.mdx
@@ -150,16 +150,12 @@ If the root test configuration does not define `extends` and contains `projects`
 
 ### `define.lint()` \{#define-lint}
 
-Defines the [Rslint configuration](https://rslint.rs/config/). Pass the configuration directly, or use an async function to load presets and plugins from `rstack/lint` on demand.
+Defines the [Rslint configuration](https://rslint.rs/config/). Pass the configuration directly, or use a synchronous or asynchronous function. The function receives all exports from `rstack/lint`, so presets and plugins do not need to be imported manually.
 
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommended];
-});
+define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
 ```
 
 ### `define.fmt()` \{#define-fmt}

--- a/website/docs/en/guide/monorepo.mdx
+++ b/website/docs/en/guide/monorepo.mdx
@@ -46,11 +46,7 @@ Use [`define.lint()`](./configuration#define-lint), [`define.fmt()`](./configura
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommended];
-});
+define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
 
 define.fmt({
   singleQuote: true,
@@ -86,20 +82,16 @@ If some projects need different lint rules, use [`files`](https://rslint.rs/conf
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [
-    js.configs.recommended,
-    ts.configs.recommended,
-    {
-      files: ['apps/web/**/*.{ts,tsx}'],
-      rules: {
-        '@typescript-eslint/no-explicit-any': 'off',
-      },
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+  {
+    files: ['apps/web/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
     },
-  ];
-});
+  },
+]);
 ```
 
 ## Project configuration

--- a/website/docs/zh/guide/cli/lint.mdx
+++ b/website/docs/zh/guide/cli/lint.mdx
@@ -29,14 +29,10 @@ rs lint --type-check
 
 ## 配置 \{#configuration}
 
-在 [Rstack 配置文件](/guide/configuration#configuration-file)中通过 [`define.lint()`](../configuration#define-lint) 配置代码检查。该 API 支持标准的 [Rslint 配置](https://rslint.rs/config/)。预设和插件可以从 `rstack/lint` 按需导入：
+在 [Rstack 配置文件](/guide/configuration#configuration-file)中通过 [`define.lint()`](../configuration#define-lint) 配置代码检查。该 API 支持标准的 [Rslint 配置](https://rslint.rs/config/)。配置函数会接收 `rstack/lint` 的全部导出，因此无需手动导入预设和插件：
 
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommended];
-});
+define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
 ```

--- a/website/docs/zh/guide/configuration.mdx
+++ b/website/docs/zh/guide/configuration.mdx
@@ -150,16 +150,12 @@ define.test({
 
 ### `define.lint()` \{#define-lint}
 
-定义 [Rslint 配置](https://rslint.rs/config/)。可以直接传入配置，也可以使用异步函数，按需从 `rstack/lint` 加载预设和插件。
+定义 [Rslint 配置](https://rslint.rs/config/)。可以直接传入配置，也可以传入同步或异步函数。函数会接收 `rstack/lint` 的全部导出，因此无需手动导入预设和插件。
 
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommended];
-});
+define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
 ```
 
 ### `define.fmt()` \{#define-fmt}

--- a/website/docs/zh/guide/monorepo.mdx
+++ b/website/docs/zh/guide/monorepo.mdx
@@ -46,11 +46,7 @@ Rsbuild 插件、测试库等项目专属依赖，建议定义在实际使用它
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [js.configs.recommended, ts.configs.recommended];
-});
+define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
 
 define.fmt({
   singleQuote: true,
@@ -86,20 +82,16 @@ define.staged({
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-
-  return [
-    js.configs.recommended,
-    ts.configs.recommended,
-    {
-      files: ['apps/web/**/*.{ts,tsx}'],
-      rules: {
-        '@typescript-eslint/no-explicit-any': 'off',
-      },
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+  {
+    files: ['apps/web/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
     },
-  ];
-});
+  },
+]);
 ```
 
 ## 子项目配置 \{#project-configuration}


### PR DESCRIPTION
## Summary

The documentation still shows manual dynamic imports for `rstack/lint`, which obscures the injected exports added in #352. This PR updates the English and Chinese examples to use synchronous `define.lint()` callbacks and switches the TypeScript preset to `ts.configs.recommendedTypeChecked`.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/352
- https://github.com/rstackjs/rstack-cli/pull/354