### PR TITLE
docs(skills): update lint migration guidance

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/SKILL.md
+++ b/.agents/skills/migrate-to-rstack-cli/SKILL.md
@@ -53,13 +53,21 @@ define.test({
 });
 ```
 
-Prefer async config functions and dynamic imports for runtime plugins and presets:
+Use dynamic imports in async config functions only for external plugins, presets, and other dependencies:
 
 ```ts
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-  return [js.configs.recommended, ts.configs.recommended];
+define.app(async () => {
+  const { pluginReact } = await import('@rsbuild/plugin-react');
+  return {
+    plugins: [pluginReact()],
+  };
 });
+```
+
+`define.lint` provides `@rslint/core` APIs to its config factory, so no manual import is needed:
+
+```ts
+define.lint(({ js }) => [js.configs.recommended]);
 ```
 
 Rstack loads TypeScript configs as native ESM. Preserve runtime-resolvable file extensions, replace CommonJS globals such as `__dirname`.

--- a/.agents/skills/migrate-to-rstack-cli/references/rslint.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rslint.md
@@ -5,21 +5,19 @@ Read this reference when the project uses `@rslint/core`, `rslint.config.*`, `rs
 ## Steps
 
 1. Replace the `rslint` executable prefix with `rs lint`. For example, replace `rslint --fix` with `rs lint --fix`.
-2. Move the old config into `define.lint`, replacing Rslint's `defineConfig()` wrapper and import. Dynamically import presets from `rstack/lint` inside an async config function.
-3. Replace direct config/API imports from `@rslint/core` with exports from `rstack/lint` where available.
-4. Replace custom `--config` paths with the migrated `rstack.config.*` path.
-5. Remove `@rslint/core` only when no uncovered direct runtime API remains. Delete `rslint.config.*`.
+2. Move the old config into `define.lint`, replacing Rslint's `defineConfig()` wrapper and import. Receive `@rslint/core` exports from the factory parameter.
+3. Replace custom `--config` paths with the migrated `rstack.config.*` path.
+4. Remove `@rslint/core` only when no uncovered direct runtime API remains. Delete `rslint.config.*`.
 
 ## Config Pattern
 
 ```ts
 import { define } from 'rstack';
 
-define.lint(async () => {
-  const { js, ts } = await import('rstack/lint');
-  return [js.configs.recommended, ts.configs.recommended];
-});
+define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
 ```
+
+Preserve existing presets and rules during migration.
 
 ## Script Pattern
 


### PR DESCRIPTION
## Summary

The migration skill still instructs agents to dynamically import lint presets even though `define.lint` now supplies the Rslint APIs to its config factory. This PR updates the general and Rslint-specific guidance to use the injected APIs while preserving existing presets and rules during migrations.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/352
- https://github.com/rstackjs/rstack-cli/pull/355