### PR TITLE
release: v0.6.1

### DIFF
--- a/packages/create-rstack/package.json
+++ b/packages/create-rstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rstack",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Create a new Rstack project",
   "homepage": "https://rstack.rs",
   "bugs": {

--- a/packages/create-rstack/template-app-lit-ts/package.json
+++ b/packages/create-rstack/template-app-lit-ts/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-app-lit/package.json
+++ b/packages/create-rstack/template-app-lit/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0"
+    "rstack": "^0.6.1"
   }
 }

--- a/packages/create-rstack/template-app-preact-ts/package.json
+++ b/packages/create-rstack/template-app-preact-ts/package.json
@@ -22,7 +22,7 @@
     "@testing-library/preact": "^3.2.4",
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-app-preact/package.json
+++ b/packages/create-rstack/template-app-preact/package.json
@@ -21,6 +21,6 @@
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/preact": "^3.2.4",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0"
+    "rstack": "^0.6.1"
   }
 }

--- a/packages/create-rstack/template-app-react-ts/package.json
+++ b/packages/create-rstack/template-app-react-ts/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-app-react/package.json
+++ b/packages/create-rstack/template-app-react/package.json
@@ -23,6 +23,6 @@
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0"
+    "rstack": "^0.6.1"
   }
 }

--- a/packages/create-rstack/template-app-solid-ts/package.json
+++ b/packages/create-rstack/template-app-solid-ts/package.json
@@ -23,7 +23,7 @@
     "@testing-library/jest-dom": "^7.0.1",
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-app-solid/package.json
+++ b/packages/create-rstack/template-app-solid/package.json
@@ -22,6 +22,6 @@
     "@solidjs/testing-library": "^0.8.10",
     "@testing-library/jest-dom": "^7.0.1",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0"
+    "rstack": "^0.6.1"
   }
 }

--- a/packages/create-rstack/template-app-svelte-ts/package.json
+++ b/packages/create-rstack/template-app-svelte-ts/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.2",
     "prettier-plugin-svelte": "^4.1.1",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "svelte-check": "^4.7.5",
     "typescript": "^6.0.3"
   }

--- a/packages/create-rstack/template-app-svelte/package.json
+++ b/packages/create-rstack/template-app-svelte/package.json
@@ -22,6 +22,6 @@
     "@testing-library/svelte": "^5.4.2",
     "happy-dom": "^20.11.2",
     "prettier-plugin-svelte": "^4.1.1",
-    "rstack": "^0.6.0"
+    "rstack": "^0.6.1"
   }
 }

--- a/packages/create-rstack/template-app-vanilla-ts/package.json
+++ b/packages/create-rstack/template-app-vanilla-ts/package.json
@@ -18,7 +18,7 @@
     "@testing-library/jest-dom": "^7.0.1",
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-app-vanilla/package.json
+++ b/packages/create-rstack/template-app-vanilla/package.json
@@ -17,6 +17,6 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.1",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0"
+    "rstack": "^0.6.1"
   }
 }

--- a/packages/create-rstack/template-app-vue-ts/package.json
+++ b/packages/create-rstack/template-app-vue-ts/package.json
@@ -22,7 +22,7 @@
     "@types/node": "^24.13.3",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "typescript": "^6.0.3",
     "vue-tsc": "^3.3.9"
   }

--- a/packages/create-rstack/template-app-vue/package.json
+++ b/packages/create-rstack/template-app-vue/package.json
@@ -21,6 +21,6 @@
     "@testing-library/jest-dom": "^7.0.1",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0"
+    "rstack": "^0.6.1"
   }
 }

--- a/packages/create-rstack/template-doc-i18n/package.json
+++ b/packages/create-rstack/template-doc-i18n/package.json
@@ -18,7 +18,7 @@
     "@types/react-dom": "^19.2.4",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-doc/package.json
+++ b/packages/create-rstack/template-doc/package.json
@@ -18,7 +18,7 @@
     "@types/react-dom": "^19.2.4",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/create-rstack/template-lib-node-ts/package.json
+++ b/packages/create-rstack/template-lib-node-ts/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.13.3",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "typescript": "^7.0.2"
   },
   "engines": {

--- a/packages/create-rstack/template-lib-node/package.json
+++ b/packages/create-rstack/template-lib-node/package.json
@@ -22,7 +22,7 @@
     "test:watch": "rs test --watch"
   },
   "devDependencies": {
-    "rstack": "^0.6.0"
+    "rstack": "^0.6.1"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/packages/create-rstack/template-lib-react-ts/package.json
+++ b/packages/create-rstack/template-lib-react-ts/package.json
@@ -33,7 +33,7 @@
     "happy-dom": "^20.11.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "typescript": "^7.0.2"
   },
   "peerDependencies": {

--- a/packages/create-rstack/template-lib-react/package.json
+++ b/packages/create-rstack/template-lib-react/package.json
@@ -29,7 +29,7 @@
     "happy-dom": "^20.11.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "rstack": "^0.6.0"
+    "rstack": "^0.6.1"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/create-rstack/template-lib-solid-ts/package.json
+++ b/packages/create-rstack/template-lib-solid-ts/package.json
@@ -30,7 +30,7 @@
     "@testing-library/jest-dom": "^7.0.1",
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "solid-js": "^1.9.14",
     "typescript": "^7.0.2"
   },

--- a/packages/create-rstack/template-lib-solid/package.json
+++ b/packages/create-rstack/template-lib-solid/package.json
@@ -27,7 +27,7 @@
     "@solidjs/testing-library": "^0.8.10",
     "@testing-library/jest-dom": "^7.0.1",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "solid-js": "^1.9.14"
   },
   "peerDependencies": {

--- a/packages/create-rstack/template-lib-svelte-ts/package.json
+++ b/packages/create-rstack/template-lib-svelte-ts/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^24.13.3",
     "happy-dom": "^20.11.2",
     "prettier-plugin-svelte": "^4.1.1",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "svelte": "^5.56.8",
     "svelte-check": "^4.7.5",
     "svelte2tsx": "^0.7.60",

--- a/packages/create-rstack/template-lib-svelte/package.json
+++ b/packages/create-rstack/template-lib-svelte/package.json
@@ -24,7 +24,7 @@
     "@rsbuild/plugin-svelte": "^2.0.1",
     "happy-dom": "^20.11.2",
     "prettier-plugin-svelte": "^4.1.1",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "svelte": "^5.56.8"
   },
   "peerDependencies": {

--- a/packages/create-rstack/template-lib-vue-ts/package.json
+++ b/packages/create-rstack/template-lib-vue-ts/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^24.13.3",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "typescript": "^6.0.3",
     "vue": "^3.5.41",
     "vue-tsc": "^3.3.9"

--- a/packages/create-rstack/template-lib-vue/package.json
+++ b/packages/create-rstack/template-lib-vue/package.json
@@ -25,7 +25,7 @@
     "@testing-library/jest-dom": "^7.0.1",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.2",
-    "rstack": "^0.6.0",
+    "rstack": "^0.6.1",
     "vue": "^3.5.41"
   },
   "peerDependencies": {

--- a/packages/rstack/binding.cjs
+++ b/packages/rstack/binding.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-android-arm64')
         const bindingPackageVersion = require('@rstackjs/cli-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-android-arm-eabi')
         const bindingPackageVersion = require('@rstackjs/cli-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-win32-x64-gnu')
         const bindingPackageVersion = require('@rstackjs/cli-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-win32-x64-msvc')
         const bindingPackageVersion = require('@rstackjs/cli-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-win32-ia32-msvc')
         const bindingPackageVersion = require('@rstackjs/cli-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-win32-arm64-msvc')
         const bindingPackageVersion = require('@rstackjs/cli-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@rstackjs/cli-darwin-universal')
       const bindingPackageVersion = require('@rstackjs/cli-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-darwin-x64')
         const bindingPackageVersion = require('@rstackjs/cli-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-darwin-arm64')
         const bindingPackageVersion = require('@rstackjs/cli-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-freebsd-x64')
         const bindingPackageVersion = require('@rstackjs/cli-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-freebsd-arm64')
         const bindingPackageVersion = require('@rstackjs/cli-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@rstackjs/cli-linux-x64-musl')
           const bindingPackageVersion = require('@rstackjs/cli-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@rstackjs/cli-linux-x64-gnu')
           const bindingPackageVersion = require('@rstackjs/cli-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@rstackjs/cli-linux-arm64-musl')
           const bindingPackageVersion = require('@rstackjs/cli-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@rstackjs/cli-linux-arm64-gnu')
           const bindingPackageVersion = require('@rstackjs/cli-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@rstackjs/cli-linux-arm-musleabihf')
           const bindingPackageVersion = require('@rstackjs/cli-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@rstackjs/cli-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@rstackjs/cli-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@rstackjs/cli-linux-loong64-musl')
           const bindingPackageVersion = require('@rstackjs/cli-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@rstackjs/cli-linux-loong64-gnu')
           const bindingPackageVersion = require('@rstackjs/cli-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@rstackjs/cli-linux-riscv64-musl')
           const bindingPackageVersion = require('@rstackjs/cli-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@rstackjs/cli-linux-riscv64-gnu')
           const bindingPackageVersion = require('@rstackjs/cli-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-linux-ppc64-gnu')
         const bindingPackageVersion = require('@rstackjs/cli-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-linux-s390x-gnu')
         const bindingPackageVersion = require('@rstackjs/cli-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-openharmony-arm64')
         const bindingPackageVersion = require('@rstackjs/cli-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-openharmony-x64')
         const bindingPackageVersion = require('@rstackjs/cli-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@rstackjs/cli-openharmony-arm')
         const bindingPackageVersion = require('@rstackjs/cli-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -648,8 +648,8 @@ if (!nativeBinding || forceWasi) {
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           const bindingPackageVersion = require('@rstackjs/cli-wasm32-wasi/package.json').version
-          if (bindingPackageVersion !== '0.6.0') {
-            throw new Error(`WASI binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.1') {
+            throw new Error(`WASI binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
         wasiBinding = require('@rstackjs/cli-wasm32-wasi')

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rstack",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "One CLI for JavaScript development, powered by Rstack.",
   "homepage": "https://rstack.rs",
   "bugs": {


### PR DESCRIPTION
## Summary

- release `rstack` 0.6.1
- bump `create-rstack` to 3.2.1
- update all create-rstack templates to `rstack@^0.6.1`
- regenerate the native binding loader

## Validation

- `pnpm --filter rstack build:native`
- `git diff --check`