### PR TITLE
fix(lib): restart on config changes

### DIFF
--- a/packages/rstack/src/rslibConfig.ts
+++ b/packages/rstack/src/rslibConfig.ts
@@ -1,3 +1,4 @@
+import type { WatchFiles } from '@rsbuild/core';
 import type { ConfigParams, RslibConfig, RslibConfigDefinition } from '@rslib/core';
 import { loadRstackConfig, type Configs } from './config.ts';
 
@@ -13,8 +14,29 @@ const resolveRslibConfig = async (configs: Configs, params: ConfigParams): Promi
 };
 
 const loadRslibConfig = (async (params: ConfigParams) => {
-  const { configs } = await loadRstackConfig();
-  return resolveRslibConfig(configs, params);
+  const { configs, filePath, dependencies } = await loadRstackConfig();
+  const config = await resolveRslibConfig(configs, params);
+
+  if (!filePath) {
+    return config;
+  }
+
+  const watchFiles = config.dev?.watchFiles;
+  const watchConfig: WatchFiles = {
+    paths: [filePath, ...dependencies],
+    type: 'restart',
+  };
+
+  return {
+    ...config,
+    dev: {
+      ...config.dev,
+      watchFiles: [
+        ...(watchFiles ? (Array.isArray(watchFiles) ? watchFiles : [watchFiles]) : []),
+        watchConfig,
+      ],
+    },
+  };
 }) as RslibConfigDefinition;
 
 export default loadRslibConfig;

--- a/packages/rstack/tests/config/reload-lib-config/index.test.ts
+++ b/packages/rstack/tests/config/reload-lib-config/index.test.ts
@@ -1,0 +1,90 @@
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { waitForFile } from '@rstackjs/test-utils';
+import { test } from '#test-helpers';
+
+test('should restart lib watch build when Rstack config changes', async ({
+  prepareDist,
+  execCliAsync,
+  logHelper,
+}) => {
+  const dist1 = await prepareDist();
+  const dist2 = await prepareDist('dist-2');
+  const configFile = path.join(import.meta.dirname, 'test-temp-rstack.config.ts');
+  const userWatchFile = path.join(import.meta.dirname, 'test-temp-user-watch.txt');
+
+  const writeConfig = (distPath: string) =>
+    writeFile(
+      configFile,
+      `import { define } from 'rstack';
+
+define.lib({
+  dev: {
+    watchFiles: {
+      paths: ${JSON.stringify(userWatchFile)},
+      type: 'restart',
+    },
+  },
+  output: {
+    distPath: '${distPath}',
+  },
+});
+`,
+    );
+
+  await writeFile(userWatchFile, 'initial\n');
+  await writeConfig('dist');
+
+  execCliAsync('lib --watch --config test-temp-rstack.config.ts');
+  await logHelper.expectLog('build completed, watching for changes...');
+  await waitForFile(path.join(dist1, 'index.js'));
+  logHelper.clearLogs();
+
+  await writeConfig('dist-2');
+
+  await logHelper.expectLog('restarting build as test-temp-rstack.config.ts changed');
+  await logHelper.expectLog('build completed, watching for changes...');
+  await waitForFile(path.join(dist2, 'index.js'));
+  logHelper.clearLogs();
+
+  await writeFile(userWatchFile, 'changed\n');
+
+  await logHelper.expectLog('restarting build as test-temp-user-watch.txt changed');
+  await logHelper.expectLog('build completed, watching for changes...');
+});
+
+test('should restart lib watch build when an imported config file changes', async ({
+  prepareDist,
+  execCliAsync,
+  logHelper,
+}) => {
+  const dist1 = await prepareDist('dist-import-1');
+  const dist2 = await prepareDist('dist-import-2');
+  const configFile = path.join(import.meta.dirname, 'test-temp-import.config.ts');
+  const importedFile = path.join(import.meta.dirname, 'test-temp-imported.ts');
+
+  await writeFile(importedFile, "export const distPath = 'dist-import-1';\n");
+  await writeFile(
+    configFile,
+    `import { define } from 'rstack';
+import { distPath } from './test-temp-imported.ts';
+
+define.lib({
+  output: {
+    distPath,
+  },
+});
+`,
+  );
+
+  execCliAsync('lib --watch --config test-temp-import.config.ts');
+  await logHelper.expectLog('build completed, watching for changes...');
+  await waitForFile(path.join(dist1, 'index.js'));
+  logHelper.clearLogs();
+
+  await writeFile(importedFile, "export const distPath = 'dist-import-2';\n");
+
+  await logHelper.expectLog('restarting build as test-temp-imported.ts changed');
+  await logHelper.expectLog('build completed, watching for changes...');
+  await waitForFile(path.join(dist2, 'index.js'));
+});

--- a/packages/rstack/tests/config/reload-lib-config/package.json
+++ b/packages/rstack/tests/config/reload-lib-config/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/rstack/tests/config/reload-lib-config/src/index.js
+++ b/packages/rstack/tests/config/reload-lib-config/src/index.js
@@ -1,0 +1,1 @@
+export const value = 'reload lib config';


### PR DESCRIPTION
## Summary

`rs lib --watch` and `rs lib mf-dev` currently watch Rstack's internal proxy config, so changes to `rstack.config.*` or its imported dependencies do not restart Rslib. This PR forwards the real config file and dependencies through `dev.watchFiles` while preserving user-defined watchers, and adds isolated regression coverage for main and imported config changes.