### PR TITLE
chore: align async config formatting

### DIFF
--- a/packages/create-rstack/template-app-preact-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-preact-ts/rstack.config.ts
@@ -3,7 +3,6 @@ import { define } from 'rstack';
 
 define.app(async () => {
   const { pluginPreact } = await import('@rsbuild/plugin-preact');
-
   return {
     plugins: [pluginPreact()],
   };

--- a/packages/create-rstack/template-app-preact/rstack.config.js
+++ b/packages/create-rstack/template-app-preact/rstack.config.js
@@ -4,7 +4,6 @@ import { define } from 'rstack';
 
 define.app(async () => {
   const { pluginPreact } = await import('@rsbuild/plugin-preact');
-
   return {
     plugins: [pluginPreact()],
   };

--- a/packages/create-rstack/template-app-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-react-ts/rstack.config.ts
@@ -3,7 +3,6 @@ import { define } from 'rstack';
 
 define.app(async () => {
   const { pluginReact } = await import('@rsbuild/plugin-react');
-
   return {
     plugins: [pluginReact()],
   };

--- a/packages/create-rstack/template-app-react/rstack.config.js
+++ b/packages/create-rstack/template-app-react/rstack.config.js
@@ -4,7 +4,6 @@ import { define } from 'rstack';
 
 define.app(async () => {
   const { pluginReact } = await import('@rsbuild/plugin-react');
-
   return {
     plugins: [pluginReact()],
   };

--- a/packages/create-rstack/template-app-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-solid-ts/rstack.config.ts
@@ -4,7 +4,6 @@ import { define } from 'rstack';
 define.app(async () => {
   const { pluginBabel } = await import('@rsbuild/plugin-babel');
   const { pluginSolid } = await import('@rsbuild/plugin-solid');
-
   return {
     plugins: [
       pluginBabel({

--- a/packages/create-rstack/template-app-solid/rstack.config.js
+++ b/packages/create-rstack/template-app-solid/rstack.config.js
@@ -5,7 +5,6 @@ import { define } from 'rstack';
 define.app(async () => {
   const { pluginBabel } = await import('@rsbuild/plugin-babel');
   const { pluginSolid } = await import('@rsbuild/plugin-solid');
-
   return {
     plugins: [
       pluginBabel({

--- a/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
@@ -3,7 +3,6 @@ import { define } from 'rstack';
 
 define.app(async () => {
   const { pluginSvelte } = await import('@rsbuild/plugin-svelte');
-
   return {
     plugins: [pluginSvelte()],
   };

--- a/packages/create-rstack/template-app-svelte/rstack.config.js
+++ b/packages/create-rstack/template-app-svelte/rstack.config.js
@@ -4,7 +4,6 @@ import { define } from 'rstack';
 
 define.app(async () => {
   const { pluginSvelte } = await import('@rsbuild/plugin-svelte');
-
   return {
     plugins: [pluginSvelte()],
   };

--- a/packages/create-rstack/template-app-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vue-ts/rstack.config.ts
@@ -3,7 +3,6 @@ import { define } from 'rstack';
 
 define.app(async () => {
   const { pluginVue } = await import('@rsbuild/plugin-vue');
-
   return {
     plugins: [pluginVue()],
   };

--- a/packages/create-rstack/template-app-vue/rstack.config.js
+++ b/packages/create-rstack/template-app-vue/rstack.config.js
@@ -4,7 +4,6 @@ import { define } from 'rstack';
 
 define.app(async () => {
   const { pluginVue } = await import('@rsbuild/plugin-vue');
-
   return {
     plugins: [pluginVue()],
   };

--- a/packages/create-rstack/template-lib-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-react-ts/rstack.config.ts
@@ -3,7 +3,6 @@ import { define } from 'rstack';
 
 define.lib(async () => {
   const { pluginReact } = await import('@rsbuild/plugin-react');
-
   return {
     bundle: false,
     dts: true,

--- a/packages/create-rstack/template-lib-react/rstack.config.js
+++ b/packages/create-rstack/template-lib-react/rstack.config.js
@@ -4,7 +4,6 @@ import { define } from 'rstack';
 
 define.lib(async () => {
   const { pluginReact } = await import('@rsbuild/plugin-react');
-
   return {
     bundle: false,
     source: {

--- a/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
@@ -4,7 +4,6 @@ import { define } from 'rstack';
 define.lib(async () => {
   const { pluginBabel } = await import('@rsbuild/plugin-babel');
   const { pluginSolid } = await import('@rsbuild/plugin-solid');
-
   return {
     lib: [
       {
@@ -63,7 +62,6 @@ define.lib(async () => {
 define.test(async () => {
   const { pluginBabel } = await import('@rsbuild/plugin-babel');
   const { pluginSolid } = await import('@rsbuild/plugin-solid');
-
   return {
     setupFiles: ['./tests/rstest.setup.ts'],
     plugins: [

--- a/packages/create-rstack/template-lib-solid/rstack.config.js
+++ b/packages/create-rstack/template-lib-solid/rstack.config.js
@@ -5,7 +5,6 @@ import { define } from 'rstack';
 define.lib(async () => {
   const { pluginBabel } = await import('@rsbuild/plugin-babel');
   const { pluginSolid } = await import('@rsbuild/plugin-solid');
-
   return {
     lib: [
       {
@@ -63,7 +62,6 @@ define.lib(async () => {
 define.test(async () => {
   const { pluginBabel } = await import('@rsbuild/plugin-babel');
   const { pluginSolid } = await import('@rsbuild/plugin-solid');
-
   return {
     setupFiles: ['./tests/rstest.setup.js'],
     plugins: [

--- a/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
@@ -4,7 +4,6 @@ import { svelteDtsPlugin } from './scripts/rslib-plugin-svelte-dts.ts';
 
 define.lib(async () => {
   const { pluginSvelte } = await import('@rsbuild/plugin-svelte');
-
   return {
     bundle: false,
     source: {

--- a/packages/create-rstack/template-lib-svelte/rstack.config.js
+++ b/packages/create-rstack/template-lib-svelte/rstack.config.js
@@ -4,7 +4,6 @@ import { define } from 'rstack';
 
 define.lib(async () => {
   const { pluginSvelte } = await import('@rsbuild/plugin-svelte');
-
   return {
     bundle: false,
     source: {

--- a/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
@@ -3,7 +3,6 @@ import { define } from 'rstack';
 
 define.lib(async () => {
   const { pluginVue } = await import('@rsbuild/plugin-vue');
-
   return {
     bundle: false,
     source: {

--- a/packages/create-rstack/template-lib-vue/rstack.config.js
+++ b/packages/create-rstack/template-lib-vue/rstack.config.js
@@ -4,7 +4,6 @@ import { define } from 'rstack';
 
 define.lib(async () => {
   const { pluginVue } = await import('@rsbuild/plugin-vue');
-
   return {
     bundle: false,
     source: {

--- a/website/docs/en/guide/configuration.mdx
+++ b/website/docs/en/guide/configuration.mdx
@@ -55,7 +55,6 @@ import { define } from 'rstack';
 
 define.app(async () => {
   const { pluginReact } = await import('@rsbuild/plugin-react');
-
   return {
     plugins: [pluginReact()],
   };

--- a/website/docs/en/guide/monorepo.mdx
+++ b/website/docs/en/guide/monorepo.mdx
@@ -109,7 +109,6 @@ import { define } from 'rstack';
 
 define.app(async () => {
   const { pluginReact } = await import('@rsbuild/plugin-react');
-
   return {
     plugins: [pluginReact()],
   };

--- a/website/docs/zh/guide/configuration.mdx
+++ b/website/docs/zh/guide/configuration.mdx
@@ -55,7 +55,6 @@ import { define } from 'rstack';
 
 define.app(async () => {
   const { pluginReact } = await import('@rsbuild/plugin-react');
-
   return {
     plugins: [pluginReact()],
   };

--- a/website/docs/zh/guide/monorepo.mdx
+++ b/website/docs/zh/guide/monorepo.mdx
@@ -109,7 +109,6 @@ import { define } from 'rstack';
 
 define.app(async () => {
   const { pluginReact } = await import('@rsbuild/plugin-react');
-
   return {
     plugins: [pluginReact()],
   };


### PR DESCRIPTION
This PR aligns async configuration examples with the repository formatter by removing redundant blank lines after dynamic plugin imports. The change updates create-rstack application and library templates together with the corresponding English and Chinese documentation, with no runtime behavior changes.