### PR TITLE
refactor(create-rstack): remove redundant test configs

### DIFF
--- a/packages/create-rstack/template-app-lit-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-lit-ts/rstack.config.ts
@@ -12,10 +12,6 @@ define.app({
   },
 });
 
-define.test({
-  testEnvironment: 'happy-dom',
-});
-
 define.lint(({ js, ts }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,

--- a/packages/create-rstack/template-app-lit/rstack.config.js
+++ b/packages/create-rstack/template-app-lit/rstack.config.js
@@ -13,10 +13,6 @@ define.app({
   },
 });
 
-define.test({
-  testEnvironment: 'happy-dom',
-});
-
 define.lint(({ js }) => [js.configs.recommended]);
 
 define.fmt({

--- a/packages/create-rstack/template-lib-node-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-node-ts/rstack.config.ts
@@ -6,10 +6,6 @@ define.lib({
   dts: true,
 });
 
-define.test({
-  // Configure Rstest
-});
-
 define.lint(({ js, ts }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,

--- a/packages/create-rstack/template-lib-node/rstack.config.js
+++ b/packages/create-rstack/template-lib-node/rstack.config.js
@@ -6,10 +6,6 @@ define.lib({
   syntax: ['node 22'],
 });
 
-define.test({
-  // Configure Rstest
-});
-
 define.lint(({ js }) => [js.configs.recommended]);
 
 define.fmt({

--- a/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
@@ -18,10 +18,6 @@ define.lib(async () => {
   };
 });
 
-define.test({
-  testEnvironment: 'happy-dom',
-});
-
 define.lint(({ js, ts }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,

--- a/packages/create-rstack/template-lib-svelte/rstack.config.js
+++ b/packages/create-rstack/template-lib-svelte/rstack.config.js
@@ -18,10 +18,6 @@ define.lib(async () => {
   };
 });
 
-define.test({
-  testEnvironment: 'happy-dom',
-});
-
 define.lint(({ js }) => [js.configs.recommended]);
 
 define.fmt({


### PR DESCRIPTION
This PR removes no-op or redundant `define.test()` blocks from the Lit, Node.js, and Svelte create-rstack templates. Tests continue to inherit the relevant `define.app()` or `define.lib()` configuration, including DOM environment selection, while templates with test-specific setup remain unchanged.