### PR TITLE
chore(deps): disable TypeScript updates for Vue and Svelte templates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>rstackjs/renovate"]
+  "extends": ["github>rstackjs/renovate"],
+  "packageRules": [
+    {
+      "description": "Disable TypeScript updates in Svelte and Vue templates until svelte-check, svelte2tsx, and vue-tsc support TypeScript 7",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "matchFileNames": [
+        "packages/create-rstack/template-app-svelte-ts/package.json",
+        "packages/create-rstack/template-app-vue-ts/package.json",
+        "packages/create-rstack/template-lib-svelte-ts/package.json",
+        "packages/create-rstack/template-lib-vue-ts/package.json"
+      ],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

TypeScript 7 currently breaks `svelte-check`, `svelte2tsx`, and `vue-tsc` in the generated Svelte and Vue templates. This PR disables Renovate TypeScript updates only for those four template manifests until the toolchain supports TypeScript 7.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/365