### PR TITLE
docs: simplify configuration guide comments

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/SKILL.md
+++ b/.agents/skills/migrate-to-rstack-cli/SKILL.md
@@ -41,7 +41,7 @@ Use one of the default names: `rstack.config.ts`, `.js`, `.mts`, or `.mjs`.
 Use `rs -c <path>` or `rs --config <path>` only for a custom path.
 
 ```ts
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/examples/app-react/rstack.config.ts
+++ b/examples/app-react/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/examples/app-vanilla/rstack.config.ts
+++ b/examples/app-vanilla/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.test({

--- a/examples/documentation/rstack.config.ts
+++ b/examples/documentation/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 import path from 'node:path';
 

--- a/examples/lib-node/rstack.config.ts
+++ b/examples/lib-node/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib({

--- a/examples/lib-react/rstack.config.ts
+++ b/examples/lib-react/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib(async () => {

--- a/examples/test-inline-projects/rstack.config.ts
+++ b/examples/test-inline-projects/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/packages/create-rstack/rstack.config.ts
+++ b/packages/create-rstack/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib({

--- a/packages/create-rstack/template-app-lit-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-lit-ts/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/packages/create-rstack/template-app-lit/rstack.config.js
+++ b/packages/create-rstack/template-app-lit/rstack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/packages/create-rstack/template-app-preact-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-preact-ts/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/packages/create-rstack/template-app-preact/rstack.config.js
+++ b/packages/create-rstack/template-app-preact/rstack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/packages/create-rstack/template-app-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-react-ts/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/packages/create-rstack/template-app-react/rstack.config.js
+++ b/packages/create-rstack/template-app-react/rstack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/packages/create-rstack/template-app-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-solid-ts/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/packages/create-rstack/template-app-solid/rstack.config.js
+++ b/packages/create-rstack/template-app-solid/rstack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/packages/create-rstack/template-app-svelte/rstack.config.js
+++ b/packages/create-rstack/template-app-svelte/rstack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/packages/create-rstack/template-app-vanilla/rstack.config.js
+++ b/packages/create-rstack/template-app-vanilla/rstack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/packages/create-rstack/template-app-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vue-ts/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/packages/create-rstack/template-app-vue/rstack.config.js
+++ b/packages/create-rstack/template-app-vue/rstack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/packages/create-rstack/template-doc-i18n/rstack.config.ts
+++ b/packages/create-rstack/template-doc-i18n/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import path from 'node:path';
 import { define } from 'rstack';
 

--- a/packages/create-rstack/template-doc/rstack.config.ts
+++ b/packages/create-rstack/template-doc/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import path from 'node:path';
 import { define } from 'rstack';
 

--- a/packages/create-rstack/template-lib-node-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-node-ts/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib({

--- a/packages/create-rstack/template-lib-node/rstack.config.js
+++ b/packages/create-rstack/template-lib-node/rstack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib({

--- a/packages/create-rstack/template-lib-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-react-ts/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib(async () => {

--- a/packages/create-rstack/template-lib-react/rstack.config.js
+++ b/packages/create-rstack/template-lib-react/rstack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib(async () => {

--- a/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib(async () => {

--- a/packages/create-rstack/template-lib-solid/rstack.config.js
+++ b/packages/create-rstack/template-lib-solid/rstack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib(async () => {

--- a/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 import { svelteDtsPlugin } from './scripts/rslib-plugin-svelte-dts.ts';
 

--- a/packages/create-rstack/template-lib-svelte/rstack.config.js
+++ b/packages/create-rstack/template-lib-svelte/rstack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib(async () => {

--- a/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib(async () => {

--- a/packages/create-rstack/template-lib-vue/rstack.config.js
+++ b/packages/create-rstack/template-lib-vue/rstack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lib(async () => {

--- a/packages/rstack/rstack.config.ts
+++ b/packages/rstack/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.test(async () => {

--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -94,7 +94,7 @@ type Define = {
    *
    * This config is used by the `rs dev`, `rs build`, and `rs preview` commands.
    *
-   * @see {@link https://rstack.rs/config | Rstack configuration guide}
+   * @see {@link https://rstack.rs/config | Configuration guide}
    */
   app: (config: RsbuildConfigDefinition) => void;
   /**
@@ -102,7 +102,7 @@ type Define = {
    *
    * This config is used by the `rs lib` command.
    *
-   * @see {@link https://rstack.rs/config | Rstack configuration guide}
+   * @see {@link https://rstack.rs/config | Configuration guide}
    */
   lib: (config: RslibConfigDefinition) => void;
   /**
@@ -110,7 +110,7 @@ type Define = {
    *
    * This config is used by the `rs doc` command.
    *
-   * @see {@link https://rstack.rs/config | Rstack configuration guide}
+   * @see {@link https://rstack.rs/config | Configuration guide}
    */
   doc: (config: RspressConfigDefinition) => void;
   /**
@@ -122,7 +122,7 @@ type Define = {
    * falls back to `define.lib`. For multi-project configs, this applies to every inline
    * project without an explicit `extends`. The app config takes precedence when both are defined.
    *
-   * @see {@link https://rstack.rs/config | Rstack configuration guide}
+   * @see {@link https://rstack.rs/config | Configuration guide}
    */
   test: (config: RstestConfigExport) => void;
   /**
@@ -131,7 +131,7 @@ type Define = {
    * This config is used by the `rs lint` command.
    * A config factory receives the exports from `rstack/lint`.
    *
-   * @see {@link https://rstack.rs/config | Rstack configuration guide}
+   * @see {@link https://rstack.rs/config | Configuration guide}
    */
   lint: (config: RslintConfig | RslintConfigFactory) => void;
   /**
@@ -139,7 +139,7 @@ type Define = {
    *
    * This config will be used by the `rs fmt` command.
    *
-   * @see {@link https://rstack.rs/config | Rstack configuration guide}
+   * @see {@link https://rstack.rs/config | Configuration guide}
    */
   fmt: (config: FmtConfigDefinition) => void;
   /**
@@ -147,7 +147,7 @@ type Define = {
    *
    * This config is used by the `rs staged` command.
    *
-   * @see {@link https://rstack.rs/config | Rstack configuration guide}
+   * @see {@link https://rstack.rs/config | Configuration guide}
    */
   staged: (config: StagedConfig) => void;
 };

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.lint(async ({ js, ts }) => {

--- a/website/docs/en/guide/configuration.mdx
+++ b/website/docs/en/guide/configuration.mdx
@@ -9,7 +9,7 @@ Rstack CLI centralizes the configuration for your project's tools in a single fi
 Create `rstack.config.ts` in the project root and call the relevant `define.*()` APIs:
 
 ```ts title="rstack.config.ts"
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -156,7 +156,7 @@ The following commands are available:
 Create `rstack.config.ts` in the project root and register the configurations your project needs. The following is a minimal example for an application with testing and linting:
 
 ```ts title="rstack.config.ts"
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/website/docs/zh/guide/configuration.mdx
+++ b/website/docs/zh/guide/configuration.mdx
@@ -9,7 +9,7 @@ Rstack CLI 将项目所用工具的配置集中到一份文件中。通过 `defi
 在项目根目录创建 `rstack.config.ts`，并调用对应的 `define.*()` API：
 
 ```ts title="rstack.config.ts"
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -156,7 +156,7 @@ Rstack CLI 提供以下命令：
 在项目根目录创建 `rstack.config.ts`，并注册项目所需的配置。以下是一个包含应用、测试和代码检查的最小示例：
 
 ```ts title="rstack.config.ts"
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app({

--- a/website/rstack.config.ts
+++ b/website/rstack.config.ts
@@ -1,4 +1,4 @@
-// Rstack configuration guide: https://rstack.rs/config
+// Configuration guide: https://rstack.rs/config
 import path from 'node:path';
 import { define } from 'rstack';
 


### PR DESCRIPTION
This PR removes the redundant `Rstack` prefix from configuration guide comments across config files, create-rstack templates, documentation examples, migration guidance, and API doc links. All references now consistently use `Configuration guide` while preserving the existing URL.