### PR TITLE
chore(fmt): use default print width

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/references/rslint.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rslint.md
@@ -14,7 +14,10 @@ Read this reference when the project uses `@rslint/core`, `rslint.config.*`, `rs
 ```ts
 import { define } from 'rstack';
 
-define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 ```
 
 Preserve existing presets and rules during migration.

--- a/examples/test-inline-projects/tests/dom.test.tsx
+++ b/examples/test-inline-projects/tests/dom.test.tsx
@@ -5,5 +5,7 @@ import App from '../src/App';
 test('renders the app in a DOM environment', () => {
   render(<App />);
 
-  expect(screen.getByRole('heading', { name: 'Rstack React SSR' })).toBeTruthy();
+  expect(
+    screen.getByRole('heading', { name: 'Rstack React SSR' }),
+  ).toBeTruthy();
 });

--- a/packages/create-rstack/src/index.ts
+++ b/packages/create-rstack/src/index.ts
@@ -5,7 +5,13 @@ import {
   create,
   select,
 } from '@rstackjs/create-toolkit';
-import { access, appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import {
+  access,
+  appendFile,
+  mkdir,
+  readFile,
+  writeFile,
+} from 'node:fs/promises';
 import path from 'node:path';
 
 const packageRoot = path.join(import.meta.dirname, '..');
@@ -87,12 +93,15 @@ const getTemplateName = async ({ template }: Argv): Promise<string> => {
       }),
     );
 
-    return resolveTemplateName(documentationType === 'basic' ? 'doc' : 'doc-i18n');
+    return resolveTemplateName(
+      documentationType === 'basic' ? 'doc' : 'doc-i18n',
+    );
   }
 
   const templateType = checkCancel<string>(
     await select({
-      message: projectType === 'app' ? 'Select framework' : 'Select library type',
+      message:
+        projectType === 'app' ? 'Select framework' : 'Select library type',
       options:
         projectType === 'app'
           ? [
@@ -129,12 +138,32 @@ const getTemplateName = async ({ template }: Argv): Promise<string> => {
 };
 
 const getStagedConfig = (templateName: string): string => {
-  const scriptExtensions = ['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs', 'mts', 'cts'];
-  const formatExtensions = ['json', 'jsonc', 'md', 'mdx', 'css', 'html', 'yml', 'yaml'];
+  const scriptExtensions = [
+    'js',
+    'jsx',
+    'ts',
+    'tsx',
+    'mjs',
+    'cjs',
+    'mts',
+    'cts',
+  ];
+  const formatExtensions = [
+    'json',
+    'jsonc',
+    'md',
+    'mdx',
+    'css',
+    'html',
+    'yml',
+    'yaml',
+  ];
   const componentExtensions = ['svelte', 'vue'];
   const templateFormatExtensions = [
     ...formatExtensions,
-    ...componentExtensions.filter((extension) => templateName.includes(extension)),
+    ...componentExtensions.filter((extension) =>
+      templateName.includes(extension),
+    ),
   ];
 
   return [
@@ -157,7 +186,9 @@ const injectStagedSetup = async ({
     return;
   }
 
-  const configExtension = await access(path.join(distFolder, 'rstack.config.ts')).then(
+  const configExtension = await access(
+    path.join(distFolder, 'rstack.config.ts'),
+  ).then(
     () => 'ts',
     () => 'js',
   );
@@ -167,8 +198,8 @@ const injectStagedSetup = async ({
   };
 
   packageJson.scripts = Object.fromEntries(
-    Object.entries({ ...packageJson.scripts, prepare: 'rs setup' }).sort(([left], [right]) =>
-      left.localeCompare(right),
+    Object.entries({ ...packageJson.scripts, prepare: 'rs setup' }).sort(
+      ([left], [right]) => left.localeCompare(right),
     ),
   );
 

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -31,29 +31,65 @@ type SourceTemplate = {
 
 const sourceTemplates: SourceTemplate[] = [
   { template: 'app-vanilla', sourceExtension: 'js', testFile: 'dom.test.js' },
-  { template: 'app-vanilla-ts', sourceExtension: 'ts', testFile: 'dom.test.ts' },
+  {
+    template: 'app-vanilla-ts',
+    sourceExtension: 'ts',
+    testFile: 'dom.test.ts',
+  },
   { template: 'app-react', sourceExtension: 'jsx', testFile: 'index.test.jsx' },
-  { template: 'app-react-ts', sourceExtension: 'tsx', testFile: 'index.test.tsx' },
-  { template: 'app-preact', sourceExtension: 'jsx', testFile: 'index.test.jsx' },
-  { template: 'app-preact-ts', sourceExtension: 'tsx', testFile: 'index.test.tsx' },
+  {
+    template: 'app-react-ts',
+    sourceExtension: 'tsx',
+    testFile: 'index.test.tsx',
+  },
+  {
+    template: 'app-preact',
+    sourceExtension: 'jsx',
+    testFile: 'index.test.jsx',
+  },
+  {
+    template: 'app-preact-ts',
+    sourceExtension: 'tsx',
+    testFile: 'index.test.tsx',
+  },
   { template: 'app-vue', sourceExtension: 'js', testFile: 'index.test.js' },
   { template: 'app-vue-ts', sourceExtension: 'ts', testFile: 'index.test.ts' },
   { template: 'app-lit', sourceExtension: 'js', testFile: 'index.test.js' },
   { template: 'app-lit-ts', sourceExtension: 'ts', testFile: 'index.test.ts' },
   { template: 'app-svelte', sourceExtension: 'js', testFile: 'index.test.js' },
-  { template: 'app-svelte-ts', sourceExtension: 'ts', testFile: 'index.test.ts' },
+  {
+    template: 'app-svelte-ts',
+    sourceExtension: 'ts',
+    testFile: 'index.test.ts',
+  },
   { template: 'app-solid', sourceExtension: 'jsx', testFile: 'index.test.jsx' },
-  { template: 'app-solid-ts', sourceExtension: 'tsx', testFile: 'index.test.tsx' },
+  {
+    template: 'app-solid-ts',
+    sourceExtension: 'tsx',
+    testFile: 'index.test.tsx',
+  },
   { template: 'lib-node', sourceExtension: 'js', testFile: 'index.test.js' },
   { template: 'lib-node-ts', sourceExtension: 'ts', testFile: 'index.test.ts' },
   { template: 'lib-react', sourceExtension: 'jsx', testFile: 'index.test.jsx' },
-  { template: 'lib-react-ts', sourceExtension: 'tsx', testFile: 'index.test.tsx' },
+  {
+    template: 'lib-react-ts',
+    sourceExtension: 'tsx',
+    testFile: 'index.test.tsx',
+  },
   { template: 'lib-vue', sourceExtension: 'js', testFile: 'index.test.js' },
   { template: 'lib-vue-ts', sourceExtension: 'ts', testFile: 'index.test.ts' },
   { template: 'lib-svelte', sourceExtension: 'js', testFile: 'index.test.js' },
-  { template: 'lib-svelte-ts', sourceExtension: 'ts', testFile: 'index.test.ts' },
+  {
+    template: 'lib-svelte-ts',
+    sourceExtension: 'ts',
+    testFile: 'index.test.ts',
+  },
   { template: 'lib-solid', sourceExtension: 'jsx', testFile: 'index.test.jsx' },
-  { template: 'lib-solid-ts', sourceExtension: 'tsx', testFile: 'index.test.tsx' },
+  {
+    template: 'lib-solid-ts',
+    sourceExtension: 'tsx',
+    testFile: 'index.test.tsx',
+  },
 ];
 
 const docTemplates = [
@@ -74,14 +110,25 @@ const docTemplates = [
 ];
 
 const getCheckScript = (template: string, hasTypeScript: boolean): string =>
-  hasTypeScript && !templatesWithoutTypeCheck.has(template) ? typeCheckScript : checkScript;
+  hasTypeScript && !templatesWithoutTypeCheck.has(template)
+    ? typeCheckScript
+    : checkScript;
 
-const readProjectPackage = async (projectDirectory: string): Promise<ProjectPackage> =>
-  JSON.parse(await readFile(path.join(projectDirectory, 'package.json'), 'utf8')) as ProjectPackage;
+const readProjectPackage = async (
+  projectDirectory: string,
+): Promise<ProjectPackage> =>
+  JSON.parse(
+    await readFile(path.join(projectDirectory, 'package.json'), 'utf8'),
+  ) as ProjectPackage;
 
-const expectFiles = async (projectDirectory: string, files: string[]): Promise<void> => {
+const expectFiles = async (
+  projectDirectory: string,
+  files: string[],
+): Promise<void> => {
   for (const file of files) {
-    await expect(access(path.join(projectDirectory, file))).resolves.toBeUndefined();
+    await expect(
+      access(path.join(projectDirectory, file)),
+    ).resolves.toBeUndefined();
   }
 };
 
@@ -92,10 +139,16 @@ const expectStagedSetup = async (
 ): Promise<void> => {
   expect(scripts.prepare).toBe('rs setup');
   expect(
-    await readFile(path.join(projectDirectory, '.rstack', 'hooks', 'pre-commit'), 'utf8'),
+    await readFile(
+      path.join(projectDirectory, '.rstack', 'hooks', 'pre-commit'),
+      'utf8',
+    ),
   ).toBe('rs staged\n');
   expect(
-    await readFile(path.join(projectDirectory, `rstack.config.${configExtension}`), 'utf8'),
+    await readFile(
+      path.join(projectDirectory, `rstack.config.${configExtension}`),
+      'utf8',
+    ),
   ).toContain('define.staged({');
 };
 
@@ -109,7 +162,10 @@ const expectNoStagedSetup = async (
     access(path.join(projectDirectory, '.rstack', 'hooks', 'pre-commit')),
   ).rejects.toThrow();
   expect(
-    await readFile(path.join(projectDirectory, `rstack.config.${configExtension}`), 'utf8'),
+    await readFile(
+      path.join(projectDirectory, `rstack.config.${configExtension}`),
+      'utf8',
+    ),
   ).not.toContain('define.staged({');
 };
 
@@ -122,8 +178,14 @@ const expectProjectSetup = async (
   const packageJson = await readProjectPackage(projectDirectory);
 
   expect(packageJson.name).toBe('my-app');
-  expect(packageJson.scripts.check).toBe(getCheckScript(template, hasTypeScript));
-  await expectStagedSetup(projectDirectory, configExtension, packageJson.scripts);
+  expect(packageJson.scripts.check).toBe(
+    getCheckScript(template, hasTypeScript),
+  );
+  await expectStagedSetup(
+    projectDirectory,
+    configExtension,
+    packageJson.scripts,
+  );
 
   const tsconfig = access(path.join(projectDirectory, 'tsconfig.json'));
   if (hasTypeScript) {
@@ -135,7 +197,9 @@ const expectProjectSetup = async (
 
 afterEach(async () => {
   await Promise.all(
-    tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+    tempDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
   );
 });
 
@@ -154,7 +218,8 @@ const createProject = async (
   tempDirectories.push(tempDirectory);
 
   if (initializeGitIn) {
-    const gitDirectory = initializeGitIn === 'project' ? projectDirectory : tempDirectory;
+    const gitDirectory =
+      initializeGitIn === 'project' ? projectDirectory : tempDirectory;
     await mkdir(gitDirectory, { recursive: true });
     await execFileAsync('git', ['init', '--quiet'], { cwd: gitDirectory });
   }
@@ -209,14 +274,22 @@ test.each(sourceTemplates)(
       files.push('src/env.d.ts');
     }
 
-    await expectProjectSetup(projectDirectory, template, configExtension, hasTypeScript);
+    await expectProjectSetup(
+      projectDirectory,
+      template,
+      configExtension,
+      hasTypeScript,
+    );
     await expectFiles(projectDirectory, files);
   },
 );
 
-test.each(docTemplates)('creates the $template template', async ({ template, files }) => {
-  const projectDirectory = await createProject(template);
+test.each(docTemplates)(
+  'creates the $template template',
+  async ({ template, files }) => {
+    const projectDirectory = await createProject(template);
 
-  await expectProjectSetup(projectDirectory, template, 'ts', true);
-  await expectFiles(projectDirectory, files);
-});
+    await expectProjectSetup(projectDirectory, template, 'ts', true);
+    await expectFiles(projectDirectory, files);
+  },
+);

--- a/packages/rstack/rslib.config.ts
+++ b/packages/rstack/rslib.config.ts
@@ -2,7 +2,8 @@ import { defineConfig } from '@rslib/core';
 import prettierPkgJson from 'prettier/package.json' with { type: 'json' };
 import pkgJson from './package.json' with { type: 'json' };
 
-const fullyMinifiedChunks = /(?:fmt(?:Lsp|Plugins)?|sortPackageJsonPlugin|staged)\.js$/;
+const fullyMinifiedChunks =
+  /(?:fmt(?:Lsp|Plugins)?|sortPackageJsonPlugin|staged)\.js$/;
 
 export default defineConfig({
   dts: true,

--- a/packages/rstack/src/cli/args.ts
+++ b/packages/rstack/src/cli/args.ts
@@ -5,7 +5,10 @@ import {
   type ParseArgsOptionsConfig,
 } from 'node:util';
 
-type ParseArgsOptionDescriptor = Omit<NodeParseArgsOptionDescriptor, 'default'> & {
+type ParseArgsOptionDescriptor = Omit<
+  NodeParseArgsOptionDescriptor,
+  'default'
+> & {
   default?: never;
 };
 
@@ -13,11 +16,14 @@ type ParseArgsConfig = Omit<NodeParseArgsConfig, 'options'> & {
   options?: Record<string, ParseArgsOptionDescriptor>;
 };
 
-type CamelCase<Value extends string> = Value extends `${infer Head}-${infer Tail}`
-  ? `${Head}${Capitalize<CamelCase<Tail>>}`
-  : Value;
+type CamelCase<Value extends string> =
+  Value extends `${infer Head}-${infer Tail}`
+    ? `${Head}${Capitalize<CamelCase<Tail>>}`
+    : Value;
 
-type NodeParseArgsResult<Config extends ParseArgsConfig> = ReturnType<typeof nodeParseArgs<Config>>;
+type NodeParseArgsResult<Config extends ParseArgsConfig> = ReturnType<
+  typeof nodeParseArgs<Config>
+>;
 
 type ParseArgsResult<Config extends ParseArgsConfig> = Omit<
   NodeParseArgsResult<Config>,
@@ -25,7 +31,9 @@ type ParseArgsResult<Config extends ParseArgsConfig> = Omit<
 > & {
   values: {
     [
-      Name in keyof NodeParseArgsResult<Config>['values'] as CamelCase<Name & string>
+      Name in keyof NodeParseArgsResult<Config>['values'] as CamelCase<
+        Name & string
+      >
     ]: NodeParseArgsResult<Config>['values'][Name];
   };
 };
@@ -34,16 +42,20 @@ const KEBAB_CASE_REGEXP = /-([a-z])/g;
 
 const toCamelCase = (value: string): string =>
   value.includes('-')
-    ? value.replace(KEBAB_CASE_REGEXP, (_, character: string) => character.toUpperCase())
+    ? value.replace(KEBAB_CASE_REGEXP, (_, character: string) =>
+        character.toUpperCase(),
+      )
     : value;
 
-export function parseArgs<const Config extends ParseArgsConfig = ParseArgsConfig>(
-  config?: Config,
-): ParseArgsResult<Config> {
+export function parseArgs<
+  const Config extends ParseArgsConfig = ParseArgsConfig,
+>(config?: Config): ParseArgsResult<Config> {
   const options: ParseArgsOptionsConfig = {};
   const optionNames: [originalName: string, camelName: string][] = [];
 
-  for (const [originalName, descriptor] of Object.entries(config?.options ?? {})) {
+  for (const [originalName, descriptor] of Object.entries(
+    config?.options ?? {},
+  )) {
     const camelName = toCamelCase(originalName);
     optionNames.push([originalName, camelName]);
     options[originalName] = descriptor;
@@ -61,7 +73,8 @@ export function parseArgs<const Config extends ParseArgsConfig = ParseArgsConfig
 
   for (const [originalName, camelName] of optionNames) {
     const originalValue = parsed.values[originalName];
-    const camelValue = camelName === originalName ? undefined : parsed.values[camelName];
+    const camelValue =
+      camelName === originalName ? undefined : parsed.values[camelName];
     const value =
       Array.isArray(originalValue) && Array.isArray(camelValue)
         ? [...originalValue, ...camelValue]
@@ -134,7 +147,11 @@ export function parseCliArgs(args: string[]): ParsedRstackArgs {
   };
 }
 
-export function insertConfigArg(args: string[], option: string, configPath: string): string[] {
+export function insertConfigArg(
+  args: string[],
+  option: string,
+  configPath: string,
+): string[] {
   // Keep the injected config before `--`; arguments after it must remain positional for the child CLI.
   const terminatorIndex = args.indexOf('--');
 
@@ -142,5 +159,10 @@ export function insertConfigArg(args: string[], option: string, configPath: stri
     return [...args, option, configPath];
   }
 
-  return [...args.slice(0, terminatorIndex), option, configPath, ...args.slice(terminatorIndex)];
+  return [
+    ...args.slice(0, terminatorIndex),
+    option,
+    configPath,
+    ...args.slice(terminatorIndex),
+  ];
 }

--- a/packages/rstack/src/cli/commandHelp.ts
+++ b/packages/rstack/src/cli/commandHelp.ts
@@ -47,24 +47,47 @@ export type HelpTopic =
   | 'staged'
   | 'setup';
 
-const CONFIG_OPTION: HelpItem = ['-c, --config <path>', 'Specify Rstack config file path'];
+const CONFIG_OPTION: HelpItem = [
+  '-c, --config <path>',
+  'Specify Rstack config file path',
+];
 const HELP_OPTION: HelpItem = ['-h, --help', 'Display this help message'];
 const VERSION_OPTION: HelpItem = ['-v, --version', 'Display version number'];
 const CONFIG_HELP_OPTIONS = [CONFIG_OPTION, HELP_OPTION];
 
-const OPEN_OPTION: HelpItem = ['-o, --open [url]', 'Open the page in browser on startup'];
-const PORT_OPTION: HelpItem = ['--port <port>', 'Set the port number for the server'];
+const OPEN_OPTION: HelpItem = [
+  '-o, --open [url]',
+  'Open the page in browser on startup',
+];
+const PORT_OPTION: HelpItem = [
+  '--port <port>',
+  'Set the port number for the server',
+];
 const STRICT_PORT_OPTION: HelpItem = [
   '--strict-port',
   'Exit if the specified port is already in use',
 ];
-const HOST_OPTION: HelpItem = ['--host [host]', 'Set the host that the server listens to'];
-const BASE_OPTION: HelpItem = ['--base <base>', 'Set the base path and override config.base'];
-const SERVER_OPTIONS = [OPEN_OPTION, PORT_OPTION, STRICT_PORT_OPTION, HOST_OPTION];
+const HOST_OPTION: HelpItem = [
+  '--host [host]',
+  'Set the host that the server listens to',
+];
+const BASE_OPTION: HelpItem = [
+  '--base <base>',
+  'Set the base path and override config.base',
+];
+const SERVER_OPTIONS = [
+  OPEN_OPTION,
+  PORT_OPTION,
+  STRICT_PORT_OPTION,
+  HOST_OPTION,
+];
 
 const TEST_UPDATE_OPTION: HelpItem = ['-u, --update', 'Update snapshot files'];
 const TEST_COVERAGE_OPTION: HelpItem = ['--coverage', 'Enable code coverage'];
-const TEST_PROJECT_OPTION: HelpItem = ['--project <name>', 'Filter test projects by name'];
+const TEST_PROJECT_OPTION: HelpItem = [
+  '--project <name>',
+  'Filter test projects by name',
+];
 const TEST_NAME_OPTION: HelpItem = [
   '-t, --test-name-pattern <pattern>',
   'Run tests with names matching the pattern',
@@ -76,8 +99,14 @@ const TEST_OPTIONS = [
   TEST_NAME_OPTION,
 ];
 
-const LIB_WATCH_OPTION: HelpItem = ['-w, --watch', 'Enable watch mode and rebuild on changes'];
-const LIB_DTS_OPTION: HelpItem = ['--dts', 'Emit declaration files (use --no-dts to disable)'];
+const LIB_WATCH_OPTION: HelpItem = [
+  '-w, --watch',
+  'Enable watch mode and rebuild on changes',
+];
+const LIB_DTS_OPTION: HelpItem = [
+  '--dts',
+  'Emit declaration files (use --no-dts to disable)',
+];
 const LIB_BUILD_OPTIONS = [LIB_WATCH_OPTION, LIB_DTS_OPTION];
 
 const commandHint = (command: string): HelpSection => ({
@@ -123,7 +152,10 @@ const HELP_DEFINITIONS = {
     sections: [
       {
         title: 'Options',
-        items: [['--type-check', 'Enable TypeScript type checking'], ...CONFIG_HELP_OPTIONS],
+        items: [
+          ['--type-check', 'Enable TypeScript type checking'],
+          ...CONFIG_HELP_OPTIONS,
+        ],
       },
     ],
   },
@@ -144,7 +176,10 @@ const HELP_DEFINITIONS = {
       {
         title: 'Options',
         items: [
-          ['-w, --watch', 'Enable watch mode to automatically rebuild on file changes'],
+          [
+            '-w, --watch',
+            'Enable watch mode to automatically rebuild on file changes',
+          ],
           ['--dist-path <dir>', 'Set the root directory of output files'],
           ['--source-map', 'Enable source map'],
           ...CONFIG_HELP_OPTIONS,
@@ -228,7 +263,11 @@ const HELP_DEFINITIONS = {
       commandHint('test'),
       {
         title: 'Options',
-        items: [['-w, --watch', 'Enable watch mode'], ...TEST_OPTIONS, ...CONFIG_HELP_OPTIONS],
+        items: [
+          ['-w, --watch', 'Enable watch mode'],
+          ...TEST_OPTIONS,
+          ...CONFIG_HELP_OPTIONS,
+        ],
       },
     ],
   },
@@ -273,7 +312,10 @@ const HELP_DEFINITIONS = {
           ['--print-location', 'Print test locations'],
           ['--summary', 'Print a summary'],
           TEST_PROJECT_OPTION,
-          ['-t, --test-name-pattern <pattern>', 'List tests with names matching the pattern'],
+          [
+            '-t, --test-name-pattern <pattern>',
+            'List tests with names matching the pattern',
+          ],
           ...CONFIG_HELP_OPTIONS,
         ],
       },
@@ -339,7 +381,10 @@ const HELP_DEFINITIONS = {
       {
         title: 'Options',
         items: [
-          ['--output <path>', 'Set the output path for inspection results (default: .rsbuild)'],
+          [
+            '--output <path>',
+            'Set the output path for inspection results (default: .rsbuild)',
+          ],
           ['--verbose', 'Show complete function definitions in output'],
           ...CONFIG_HELP_OPTIONS,
         ],
@@ -366,9 +411,15 @@ const HELP_DEFINITIONS = {
           ['--fix', 'Automatically fix problems'],
           ['--type-check', 'Enable TypeScript type checking'],
           ['--type-check-only', 'Run only TypeScript type checking'],
-          ['--format <format>', 'Set output format (default | jsonline | github | gitlab)'],
+          [
+            '--format <format>',
+            'Set output format (default | jsonline | github | gitlab)',
+          ],
           ['--quiet', 'Report errors only'],
-          ['--timing [all|N]', 'Print a per-rule timing table (all rules or top N)'],
+          [
+            '--timing [all|N]',
+            'Print a per-rule timing table (all rules or top N)',
+          ],
           ['--max-warnings <count>', 'Set the maximum number of warnings'],
           ['--rule <rule>', 'Override a rule (repeatable)'],
           ['--no-color', 'Disable colored output'],
@@ -388,14 +439,23 @@ const HELP_DEFINITIONS = {
           ['-w, --write', 'Write formatted files in place (default)'],
           ['--check', 'Check whether files are formatted'],
           ['-l, --list-different', 'Print paths of unformatted files'],
-          ['--ignore-path <path>', 'Path to an additional ignore file (repeatable)'],
+          [
+            '--ignore-path <path>',
+            'Path to an additional ignore file (repeatable)',
+          ],
           ['-u, --ignore-unknown', 'Ignore unknown files'],
           ['--no-cache', 'Disable the formatting cache'],
           ['--cache-location <path>', 'Path to the formatting cache directory'],
-          ['--no-error-on-unmatched-pattern', 'Do not error when no files match'],
+          [
+            '--no-error-on-unmatched-pattern',
+            'Do not error when no files match',
+          ],
           ['--with-node-modules', 'Process files inside node_modules'],
           ['--parallel-workers <count>', 'Number of parallel workers'],
-          ['--stdin-filepath <path>', 'Format stdin as if it were saved at <path>'],
+          [
+            '--stdin-filepath <path>',
+            'Format stdin as if it were saved at <path>',
+          ],
           ['--lsp', 'Run a language server on stdio'],
           ...CONFIG_HELP_OPTIONS,
         ],
@@ -409,7 +469,10 @@ const HELP_DEFINITIONS = {
       {
         title: 'Options',
         items: [
-          ['--allow-empty', 'Allow empty commits when tasks revert all staged changes'],
+          [
+            '--allow-empty',
+            'Allow empty commits when tasks revert all staged changes',
+          ],
           [
             '-p, --concurrent <number|boolean>',
             'The number of tasks to run concurrently, or false for serial',
@@ -435,7 +498,10 @@ const HELP_DEFINITIONS = {
       {
         title: 'Options',
         items: [
-          ['--hooks-dir <path>', 'Specify hooks directory relative to the Git repository root'],
+          [
+            '--hooks-dir <path>',
+            'Specify hooks directory relative to the Git repository root',
+          ],
           HELP_OPTION,
         ],
       },
@@ -444,10 +510,15 @@ const HELP_DEFINITIONS = {
 } satisfies Record<HelpTopic, HelpDefinition>;
 
 const renderItems = (items: readonly HelpItem[]): string => {
-  const labelWidth = items.reduce((width, [label]) => Math.max(width, label.length), 0);
+  const labelWidth = items.reduce(
+    (width, [label]) => Math.max(width, label.length),
+    0,
+  );
 
   return items
-    .map(([label, description]) => `  ${label.padEnd(labelWidth)}  ${description}`)
+    .map(
+      ([label, description]) => `  ${label.padEnd(labelWidth)}  ${description}`,
+    )
     .join('\n');
 };
 
@@ -459,7 +530,11 @@ const renderSection = (section: HelpSection): string => {
   return section.dim ? color.dim(section.content) : section.content;
 };
 
-const renderHelp = ({ usage, description, sections = [] }: HelpDefinition): string => {
+const renderHelp = ({
+  usage,
+  description,
+  sections = [],
+}: HelpDefinition): string => {
   const blocks = [
     color.bold(`Rstack v${RSTACK_VERSION}`),
     `${color.cyan('Usage')}:\n${color.yellow(`  $ ${usage}`)}`,
@@ -474,4 +549,5 @@ const renderHelp = ({ usage, description, sections = [] }: HelpDefinition): stri
   return blocks.join('\n\n');
 };
 
-export const renderCommandHelp = (topic: HelpTopic): string => renderHelp(HELP_DEFINITIONS[topic]);
+export const renderCommandHelp = (topic: HelpTopic): string =>
+  renderHelp(HELP_DEFINITIONS[topic]);

--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -18,7 +18,11 @@ async function runRsbuildCLI(args: string[]): Promise<void> {
   const argv = [
     process.execPath,
     'rsbuild',
-    ...insertConfigArg(args, '--config', join(import.meta.dirname, 'rsbuildConfig.js')),
+    ...insertConfigArg(
+      args,
+      '--config',
+      join(import.meta.dirname, 'rsbuildConfig.js'),
+    ),
   ];
 
   const { runCLI } = await import('@rsbuild/core');
@@ -46,7 +50,11 @@ async function runRstestCLI(args: string[]): Promise<void> {
   const argv = [
     process.execPath,
     'rstest',
-    ...insertConfigArg(args, '--config', join(import.meta.dirname, 'rstestConfig.js')),
+    ...insertConfigArg(
+      args,
+      '--config',
+      join(import.meta.dirname, 'rstestConfig.js'),
+    ),
   ];
 
   const { runCLI } = await import('@rstest/core');
@@ -70,7 +78,11 @@ async function runRslibCLI(args: string[]): Promise<void> {
   const argv = [
     process.execPath,
     'rslib',
-    ...insertConfigArg(args, '--config', join(import.meta.dirname, 'rslibConfig.js')),
+    ...insertConfigArg(
+      args,
+      '--config',
+      join(import.meta.dirname, 'rslibConfig.js'),
+    ),
   ];
 
   const { runCLI } = await import('@rslib/core');
@@ -83,7 +95,9 @@ const isMissingRspressCoreError = (error: unknown): boolean => {
   }
 
   const code = 'code' in error ? error.code : undefined;
-  return code === 'ERR_MODULE_NOT_FOUND' && error.message.includes('@rspress/core');
+  return (
+    code === 'ERR_MODULE_NOT_FOUND' && error.message.includes('@rspress/core')
+  );
 };
 
 async function runRspressCLI(args: string[]): Promise<void> {
@@ -103,7 +117,11 @@ async function runRspressCLI(args: string[]): Promise<void> {
   const argv = [
     process.execPath,
     'rspress',
-    ...insertConfigArg(args, '--config', join(import.meta.dirname, 'rspressConfig.js')),
+    ...insertConfigArg(
+      args,
+      '--config',
+      join(import.meta.dirname, 'rspressConfig.js'),
+    ),
   ];
 
   try {
@@ -128,7 +146,11 @@ async function runRslintCLI(args: string[]): Promise<void> {
   const argv = [
     process.execPath,
     'rslint',
-    ...insertConfigArg(args, '--config', join(import.meta.dirname, 'rslintConfig.js')),
+    ...insertConfigArg(
+      args,
+      '--config',
+      join(import.meta.dirname, 'rslintConfig.js'),
+    ),
   ];
 
   const { runCLI } = await import('@rslint/core');
@@ -171,7 +193,8 @@ export async function setupCommands(): Promise<void> {
   // when the config is later loaded from another directory. The motivating case
   // is `rs fmt --lsp`, which loads the config from the LSP workspace root the
   // client reports, and that root need not be the process working directory.
-  getConfigState().configPath = configPath === undefined ? undefined : resolve(configPath);
+  getConfigState().configPath =
+    configPath === undefined ? undefined : resolve(configPath);
 
   if (!command || command === '-h' || command === '--help') {
     return printCommandHelp('root');

--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -8,7 +8,8 @@ import type { RstestConfigExport } from '@rstest/core';
 import type { FmtConfigDefinition } from './fmt/types.ts';
 import type { StagedConfig } from './staged.ts';
 
-export type RslintConfigDefinition = RslintConfig | (() => Promise<RslintConfig>);
+export type RslintConfigDefinition =
+  RslintConfig | (() => Promise<RslintConfig>);
 export type RspressConfigDefinition = UserConfig | UserConfigAsyncFn;
 
 type RslintConfigFactory = (
@@ -62,7 +63,8 @@ type ConfigState = {
 
 declare global {
   // rslint-disable-next-line no-var
-  var __rstackConfigSessionStorage: AsyncLocalStorage<ConfigSession> | undefined;
+  var __rstackConfigSessionStorage:
+    AsyncLocalStorage<ConfigSession> | undefined;
   // rslint-disable-next-line no-var
   var __rstackCliState: ConfigState | undefined;
 }
@@ -72,7 +74,8 @@ const getConfigSessionStorage = (): AsyncLocalStorage<ConfigSession> => {
   // imports the internal Rstack config. Keep the storage on globalThis so
   // every module instance reads and writes the same active session.
   if (!globalThis.__rstackConfigSessionStorage) {
-    globalThis.__rstackConfigSessionStorage = new AsyncLocalStorage<ConfigSession>();
+    globalThis.__rstackConfigSessionStorage =
+      new AsyncLocalStorage<ConfigSession>();
   }
 
   return globalThis.__rstackConfigSessionStorage;
@@ -152,11 +155,16 @@ type Define = {
   staged: (config: StagedConfig) => void;
 };
 
-const setConfig = <T extends keyof Configs>(type: T, config: Configs[T]): void => {
+const setConfig = <T extends keyof Configs>(
+  type: T,
+  config: Configs[T],
+): void => {
   const session = getConfigSessionStorage().getStore();
 
   if (!session?.active) {
-    throw new Error(`The "${type}" config must be defined while loading an Rstack config.`);
+    throw new Error(
+      `The "${type}" config must be defined while loading an Rstack config.`,
+    );
   }
 
   if (type in session.configs) {
@@ -173,7 +181,9 @@ export const define: Define = {
   lint: (config) =>
     setConfig(
       'lint',
-      typeof config === 'function' ? async () => config(await import('@rslint/core')) : config,
+      typeof config === 'function'
+        ? async () => config(await import('@rslint/core'))
+        : config,
     ),
   fmt: (config) => setConfig('fmt', config),
   staged: (config) => setConfig('staged', config),

--- a/packages/rstack/src/fmt/cacheIdentity.ts
+++ b/packages/rstack/src/fmt/cacheIdentity.ts
@@ -17,7 +17,11 @@ const createCacheHash = (content: string | Uint8Array): string =>
   createDigest('sha256', content, 'base64url').slice(0, cacheHashLength);
 
 /** Identifies formatter behavior shared by all cache entries in this process. */
-const cacheNamespace: string = JSON.stringify([fmtCacheVersion, RSTACK_VERSION, PRETTIER_VERSION]);
+const cacheNamespace: string = JSON.stringify([
+  fmtCacheVersion,
+  RSTACK_VERSION,
+  PRETTIER_VERSION,
+]);
 
 /** Creates project-relative POSIX cache keys without repeating path setup. */
 const createCacheKeyResolver = (rootPath: string): CacheKeyResolver => {
@@ -30,7 +34,9 @@ const createCacheKeyResolver = (rootPath: string): CacheKeyResolver => {
 };
 
 /** Hashes final per-file options and memoizes option objects shared by many files. */
-const createOptionsHasher = (pluginFingerprints?: PluginFingerprints): OptionsHasher => {
+const createOptionsHasher = (
+  pluginFingerprints?: PluginFingerprints,
+): OptionsHasher => {
   const hashes = new WeakMap<ResolvedFmtOptions, string | null>();
 
   return (options) => {
@@ -47,8 +53,13 @@ const createOptionsHasher = (pluginFingerprints?: PluginFingerprints): OptionsHa
         const fingerprints: string[] = [];
         for (const plugin of plugins) {
           const key =
-            plugin instanceof URL ? plugin.href : typeof plugin === 'string' ? plugin : undefined;
-          const fingerprint = key === undefined ? undefined : pluginFingerprints?.get(key);
+            plugin instanceof URL
+              ? plugin.href
+              : typeof plugin === 'string'
+                ? plugin
+                : undefined;
+          const fingerprint =
+            key === undefined ? undefined : pluginFingerprints?.get(key);
           if (fingerprint === undefined) {
             hashes.set(options, null);
             return undefined;

--- a/packages/rstack/src/fmt/cacheStore.ts
+++ b/packages/rstack/src/fmt/cacheStore.ts
@@ -21,7 +21,11 @@ const fmtCacheStateIds = {
 } as const satisfies Record<FmtCacheState, FmtCacheStateId>;
 
 type FmtCacheFileValue = string | number;
-type FmtCacheEntry = readonly [contentHash: string, optionsHash: string, state: FmtCacheState];
+type FmtCacheEntry = readonly [
+  contentHash: string,
+  optionsHash: string,
+  state: FmtCacheState,
+];
 
 interface FmtCacheFile {
   version: typeof fmtCacheVersion;
@@ -106,7 +110,8 @@ const parseCacheFile = (
   };
 };
 
-const serializeCache = (cache: FmtCacheFile): string => `${JSON.stringify(cache)}\n`;
+const serializeCache = (cache: FmtCacheFile): string =>
+  `${JSON.stringify(cache)}\n`;
 
 const isFileNotFoundError = (error: unknown): error is NodeJS.ErrnoException =>
   error instanceof Error && 'code' in error && error.code === 'ENOENT';
@@ -150,7 +155,8 @@ class FmtCacheStoreImpl implements FmtCacheStore {
     const { files, options } = this.#cache;
     const contentHash = files[offset + contentHashOffset] as string;
     const optionsHash = options[files[offset + optionsIndexOffset] as number];
-    const state = fmtCacheStates[files[offset + stateOffset] as FmtCacheStateId];
+    const state =
+      fmtCacheStates[files[offset + stateOffset] as FmtCacheStateId];
     return [contentHash, optionsHash, state];
   }
 
@@ -261,7 +267,10 @@ class FmtCacheStoreImpl implements FmtCacheStore {
   }
 }
 
-const loadFmtCacheStore = async (filePath: string, namespace: string): Promise<FmtCacheStore> => {
+const loadFmtCacheStore = async (
+  filePath: string,
+  namespace: string,
+): Promise<FmtCacheStore> => {
   const emptyCache = createEmptyCache(namespace);
 
   try {

--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -35,15 +35,25 @@ const parseMaxWorkers = (value: string | undefined): number | undefined => {
   }
 
   const maxWorkers = Number(value);
-  if (!/^\d+$/.test(value) || !Number.isSafeInteger(maxWorkers) || maxWorkers < 1) {
-    throw new Error('The --parallel-workers option must be a positive integer.');
+  if (
+    !/^\d+$/.test(value) ||
+    !Number.isSafeInteger(maxWorkers) ||
+    maxWorkers < 1
+  ) {
+    throw new Error(
+      'The --parallel-workers option must be a positive integer.',
+    );
   }
 
   return maxWorkers;
 };
 
 /** Rejects the mode flags and file arguments that a server-like option replaces. */
-const assertExclusiveMode = (option: string, hasMode: boolean, positionals: string[]): void => {
+const assertExclusiveMode = (
+  option: string,
+  hasMode: boolean,
+  positionals: string[],
+): void => {
   if (hasMode) {
     throw new Error(
       `The ${option} option cannot be used with --write, --check, or --list-different.`,
@@ -82,7 +92,9 @@ const parseFmtArgs = (args: string[]): ParsedFmtCLIArgs => {
   const listDifferent = values.listDifferent;
   const modes = [write, check, listDifferent].filter(Boolean);
   if (modes.length > 1) {
-    throw new Error('The --write, --check, and --list-different options cannot be used together.');
+    throw new Error(
+      'The --write, --check, and --list-different options cannot be used together.',
+    );
   }
 
   const mode = check ? 'check' : listDifferent ? 'list-different' : 'write';
@@ -130,14 +142,17 @@ const parseFmtArgs = (args: string[]): ParsedFmtCLIArgs => {
   };
 };
 
-const createDisplayPathResolver = (cwd: string): ((filePath: string) => string) => {
+const createDisplayPathResolver = (
+  cwd: string,
+): ((filePath: string) => string) => {
   const resolveRelativePath = createRelativePathResolver(cwd);
 
   return (filePath) => toPosixPath(resolveRelativePath(filePath));
 };
 
 const prettyTime = (seconds: number): string => {
-  const format = (time: string, unit: 'm' | 's') => color.bold(`${time}${unit}`);
+  const format = (time: string, unit: 'm' | 's') =>
+    color.bold(`${time}${unit}`);
 
   if (seconds < 10) {
     const digits = seconds >= 0.01 ? 2 : 3;
@@ -156,7 +171,10 @@ const prettyTime = (seconds: number): string => {
     return minutesLabel;
   }
 
-  const secondsLabel = format(remainingSeconds.toFixed(remainingSeconds % 1 === 0 ? 0 : 1), 's');
+  const secondsLabel = format(
+    remainingSeconds.toFixed(remainingSeconds % 1 === 0 ? 0 : 1),
+    's',
+  );
 
   return `${minutesLabel} ${secondsLabel}`;
 };
@@ -171,7 +189,9 @@ const reportNoSupportedFiles = (patterns: string[]): void => {
   const targets = (patterns.length ? patterns : ['.'])
     .map((pattern) => color.cyan(JSON.stringify(pattern)))
     .join(', ');
-  logger.error(`No supported files matched ${targets}, or all matching files were ignored.`);
+  logger.error(
+    `No supported files matched ${targets}, or all matching files were ignored.`,
+  );
   process.exitCode = 2;
 };
 
@@ -303,7 +323,9 @@ const runFmtCLI = async (args: string[]): Promise<void> => {
       return;
     }
 
-    const cacheDirPath = cacheLocation ? path.resolve(cwd, cacheLocation) : undefined;
+    const cacheDirPath = cacheLocation
+      ? path.resolve(cwd, cacheLocation)
+      : undefined;
     if (cacheDirPath) {
       const cacheDirPrefix = cacheDirPath.endsWith(path.sep)
         ? cacheDirPath
@@ -327,7 +349,8 @@ const runFmtCLI = async (args: string[]): Promise<void> => {
 
     if (files.length === 0) {
       // Staged tasks may pass only paths excluded by formatter ignore rules.
-      const allowUnmatched = noErrorOnUnmatchedPattern || process.env.RSTACK_STAGED === '1';
+      const allowUnmatched =
+        noErrorOnUnmatchedPattern || process.env.RSTACK_STAGED === '1';
       if (allowUnmatched) {
         return;
       }

--- a/packages/rstack/src/fmt/config.ts
+++ b/packages/rstack/src/fmt/config.ts
@@ -26,7 +26,9 @@ type OptionsCacheNode = {
   options: ResolvedFmtOptions;
 };
 
-const createOptionsCacheNode = (options: ResolvedFmtOptions): OptionsCacheNode => ({
+const createOptionsCacheNode = (
+  options: ResolvedFmtOptions,
+): OptionsCacheNode => ({
   children: new WeakMap(),
   options,
 });
@@ -52,7 +54,9 @@ const compileMatchers = (
     return micromatch.matcher(patterns[0], options);
   }
 
-  const matchers = patterns.map((pattern) => micromatch.matcher(pattern, options));
+  const matchers = patterns.map((pattern) =>
+    micromatch.matcher(pattern, options),
+  );
 
   return (filePath) => {
     for (const matches of matchers) {
@@ -79,7 +83,11 @@ const createPathMatcher = (
     }
   }
 
-  const basenameMatcher = compileMatchers(basenamePatterns, excludedPatterns, true);
+  const basenameMatcher = compileMatchers(
+    basenamePatterns,
+    excludedPatterns,
+    true,
+  );
   const pathMatcher = compileMatchers(pathPatterns, excludedPatterns, false);
 
   if (!basenameMatcher || !pathMatcher) {
@@ -89,7 +97,10 @@ const createPathMatcher = (
 };
 
 /** Splits a flat config into project-level formatting options and rules. */
-const normalizeFmtConfig = (config: FmtConfig | undefined, rootPath: string): ResolvedFmtConfig => {
+const normalizeFmtConfig = (
+  config: FmtConfig | undefined,
+  rootPath: string,
+): ResolvedFmtConfig => {
   const { ignorePatterns = [], overrides = [], ...baseOptions } = config ?? {};
 
   return {
@@ -104,7 +115,9 @@ const normalizeFmtConfig = (config: FmtConfig | undefined, rootPath: string): Re
 };
 
 /** Creates a reusable resolver for applying per-file formatter overrides. */
-const createOptionsResolver = (config: ResolvedFmtConfig): FmtOptionsResolver => {
+const createOptionsResolver = (
+  config: ResolvedFmtConfig,
+): FmtOptionsResolver => {
   if (config.overrides.length === 0) {
     return () => config.baseOptions;
   }
@@ -124,7 +137,10 @@ const createOptionsResolver = (config: ResolvedFmtConfig): FmtOptionsResolver =>
       // Reuse the merged result for this override after the current matched sequence.
       let nextCacheNode = cacheNode.children.get(override.options);
       if (!nextCacheNode) {
-        nextCacheNode = createOptionsCacheNode({ ...cacheNode.options, ...override.options });
+        nextCacheNode = createOptionsCacheNode({
+          ...cacheNode.options,
+          ...override.options,
+        });
         cacheNode.children.set(override.options, nextCacheNode);
       }
       cacheNode = nextCacheNode;
@@ -140,7 +156,8 @@ const resolveFmtConfig = async ({
   configFilePath,
   cwd,
 }: ResolveFmtConfigOptions): Promise<ResolvedFmtConfig> => {
-  const config = typeof definition === 'function' ? await definition() : definition;
+  const config =
+    typeof definition === 'function' ? await definition() : definition;
   const rootPath = configFilePath ? dirname(configFilePath) : cwd;
 
   return normalizeFmtConfig(config, rootPath);

--- a/packages/rstack/src/fmt/discoverPaths.ts
+++ b/packages/rstack/src/fmt/discoverPaths.ts
@@ -142,7 +142,10 @@ class GitIgnoreFiles {
   }
 
   /** Matches one directory's entries in a single native call. */
-  matchDirents(parentPath: string, dirents: Dirent[]): boolean | number | Uint8Array | undefined {
+  matchDirents(
+    parentPath: string,
+    dirents: Dirent[],
+  ): boolean | number | Uint8Array | undefined {
     if (!this.#hasRules || dirents.length === 0) {
       return;
     }
@@ -156,7 +159,11 @@ class GitIgnoreFiles {
 
     if (dirents.length === 1) {
       const dirent = dirents[0];
-      return this.#matcher!.isIgnoredChild(relativeParent, dirent.name, dirent.isDirectory());
+      return this.#matcher!.isIgnoredChild(
+        relativeParent,
+        dirent.name,
+        dirent.isDirectory(),
+      );
     }
 
     const names = new Array<string>(dirents.length);
@@ -168,7 +175,11 @@ class GitIgnoreFiles {
         names[index] = dirent.name;
         directoryMask |= Number(dirent.isDirectory()) << index;
       }
-      return this.#matcher!.isIgnoredBatchMask(relativeParent, names, directoryMask >>> 0);
+      return this.#matcher!.isIgnoredBatchMask(
+        relativeParent,
+        names,
+        directoryMask >>> 0,
+      );
     }
 
     const directoryFlags = new Uint8Array(dirents.length);
@@ -188,9 +199,14 @@ class GitIgnoreFiles {
     }
 
     // Ignore files may disappear or become unreadable during traversal.
-    const loading = readFile(path.join(directoryPath, '.gitignore'), 'utf8').then(
+    const loading = readFile(
+      path.join(directoryPath, '.gitignore'),
+      'utf8',
+    ).then(
       (content) => {
-        const relativePath = toPosixPath(this.#resolveRelativePath(directoryPath));
+        const relativePath = toPosixPath(
+          this.#resolveRelativePath(directoryPath),
+        );
         this.#matcher ??= new (loadNativeBinding().GitIgnoreMatcher)();
         this.#hasRules = this.#matcher.addSource(relativePath, content);
       },
@@ -222,7 +238,8 @@ const createTraversalOptions = (
 
       if (dirent.isDirectory()) {
         return (
-          (dirent as GitIgnoreDirent)[gitIgnored] === true || isIgnored?.(targetPath, true) === true
+          (dirent as GitIgnoreDirent)[gitIgnored] === true ||
+          isIgnored?.(targetPath, true) === true
         );
       }
 
@@ -298,7 +315,14 @@ const discoverDirectoryFiles = async (
 
   const result = await readdir(
     rootPath,
-    createTraversalOptions(gitIgnore, ignoredDirNames, signal, onError, isIncluded, isIgnored),
+    createTraversalOptions(
+      gitIgnore,
+      ignoredDirNames,
+      signal,
+      onError,
+      isIncluded,
+      isIgnored,
+    ),
   );
 
   // tiny-readdir only handles fulfilled onDirents promises, so rethrow after its counter settles.
@@ -310,7 +334,9 @@ const discoverDirectoryFiles = async (
 };
 
 const normalizeGlob = (cwd: string, pattern: string): string => {
-  const relativePattern = path.isAbsolute(pattern) ? path.relative(cwd, pattern) : pattern;
+  const relativePattern = path.isAbsolute(pattern)
+    ? path.relative(cwd, pattern)
+    : pattern;
   return toPosixPath(relativePattern);
 };
 
@@ -334,7 +360,10 @@ const classifyPatterns = async (
   const entries = await Promise.all(
     patterns.map(async (pattern): Promise<PatternEntry | undefined> => {
       if (pattern.startsWith('!')) {
-        return { kind: 'negative-glob', value: normalizeGlob(cwd, pattern.slice(1)) };
+        return {
+          kind: 'negative-glob',
+          value: normalizeGlob(cwd, pattern.slice(1)),
+        };
       }
 
       const filePath = path.resolve(cwd, pattern);
@@ -344,7 +373,9 @@ const classifyPatterns = async (
 
       const stats = await lstatSafe(filePath);
       if (stats?.isFile()) {
-        return isBinaryPath(filePath) ? undefined : { kind: 'file', value: filePath };
+        return isBinaryPath(filePath)
+          ? undefined
+          : { kind: 'file', value: filePath };
       }
       if (stats?.isDirectory()) {
         return { kind: 'directory', value: filePath };
@@ -389,11 +420,15 @@ const classifyPatterns = async (
 };
 
 const getOutermostPaths = (paths: string[]): string[] => {
-  const sortedPaths = [...new Set(paths)].sort((left, right) => left.length - right.length);
+  const sortedPaths = [...new Set(paths)].sort(
+    (left, right) => left.length - right.length,
+  );
   const outermostPaths: string[] = [];
 
   for (const filePath of sortedPaths) {
-    if (!outermostPaths.some((parentPath) => isPathInside(parentPath, filePath))) {
+    if (
+      !outermostPaths.some((parentPath) => isPathInside(parentPath, filePath))
+    ) {
       outermostPaths.push(filePath);
     }
   }
@@ -402,8 +437,14 @@ const getOutermostPaths = (paths: string[]): string[] => {
 };
 
 /** Merges overlapping roots; micromatch remains responsible for glob syntax. */
-const getTraversalRoots = (cwd: string, directories: string[], globs: string[]): string[] => {
-  const globRoots = globs.map((pattern) => path.resolve(cwd, micromatch.scan(pattern).base || '.'));
+const getTraversalRoots = (
+  cwd: string,
+  directories: string[],
+  globs: string[],
+): string[] => {
+  const globRoots = globs.map((pattern) =>
+    path.resolve(cwd, micromatch.scan(pattern).base || '.'),
+  );
 
   return getOutermostPaths([...directories, ...globRoots]);
 };
@@ -431,9 +472,13 @@ const discoverFmtPaths = async ({
     negativeGlobs,
   } = await classifyPatterns(cwd, patterns, ignoredDirNames);
   const directoryRoots = getOutermostPaths(directories);
-  const globMatchers = globs.map((pattern) => micromatch.matcher(pattern, { dot: true }));
+  const globMatchers = globs.map((pattern) =>
+    micromatch.matcher(pattern, { dot: true }),
+  );
   const candidates = new Set(
-    isIgnored ? explicitFiles.filter((filePath) => !isIgnored(filePath, false)) : explicitFiles,
+    isIgnored
+      ? explicitFiles.filter((filePath) => !isIgnored(filePath, false))
+      : explicitFiles,
   );
   const traversalRoots = getTraversalRoots(cwd, directoryRoots, globs);
 
@@ -447,7 +492,10 @@ const discoverFmtPaths = async ({
         }
 
         await gitIgnore.loadThrough(rootPath);
-        if (gitIgnore.isIgnored(rootPath, true) || isIgnored?.(rootPath, true) === true) {
+        if (
+          gitIgnore.isIgnored(rootPath, true) ||
+          isIgnored?.(rootPath, true) === true
+        ) {
           return [];
         }
 
@@ -457,7 +505,11 @@ const discoverFmtPaths = async ({
         const isIncluded = includesAll
           ? undefined
           : (filePath: string): boolean => {
-              if (directoryRoots.some((directoryPath) => isPathInside(directoryPath, filePath))) {
+              if (
+                directoryRoots.some((directoryPath) =>
+                  isPathInside(directoryPath, filePath),
+                )
+              ) {
                 return true;
               }
 
@@ -465,7 +517,13 @@ const discoverFmtPaths = async ({
               return globMatchers.some((matches) => matches(relativePath));
             };
 
-        return discoverDirectoryFiles(rootPath, gitIgnore, ignoredDirNames, isIncluded, isIgnored);
+        return discoverDirectoryFiles(
+          rootPath,
+          gitIgnore,
+          ignoredDirNames,
+          isIncluded,
+          isIgnored,
+        );
       }),
     );
 

--- a/packages/rstack/src/fmt/discovery.ts
+++ b/packages/rstack/src/fmt/discovery.ts
@@ -19,7 +19,9 @@ const discoverFmtFiles = async ({
   config,
 }: DiscoverFmtFilesOptions): Promise<FmtFileRequest[]> => {
   const isIgnored = await createIgnoreMatcher({ config, cwd, ignorePaths });
-  const isExcluded = excludedDirPath ? createDirMatcher(excludedDirPath) : undefined;
+  const isExcluded = excludedDirPath
+    ? createDirMatcher(excludedDirPath)
+    : undefined;
   const shouldIgnore = isExcluded
     ? (filePath: string, isDirectory = false) =>
         isExcluded(filePath) || isIgnored(filePath, isDirectory)

--- a/packages/rstack/src/fmt/fileResolver.ts
+++ b/packages/rstack/src/fmt/fileResolver.ts
@@ -16,7 +16,9 @@ const createFmtFileResolver = (config: ResolvedFmtConfig): FmtFileResolver => {
       pluginResolver ??= import(
         /* rspackChunkName: 'fmtPlugins' */
         './plugins.ts'
-      ).then(({ createPluginResolver }) => createPluginResolver(config.rootPath));
+      ).then(({ createPluginResolver }) =>
+        createPluginResolver(config.rootPath),
+      );
       options = (await pluginResolver)(options);
     }
 

--- a/packages/rstack/src/fmt/format.ts
+++ b/packages/rstack/src/fmt/format.ts
@@ -12,7 +12,8 @@ import type { FmtFileRequest } from './types.ts';
 type PrettierPlugins = NonNullable<PrettierOptions['plugins']>;
 
 type FormatFmtSourceResult =
-  { status: 'unsupported' } | { status: 'formatted'; source: string; formatted: string };
+  | { status: 'unsupported' }
+  | { status: 'formatted'; source: string; formatted: string };
 
 const fileInfoOptions = {
   ignorePath: [],

--- a/packages/rstack/src/fmt/ignore.ts
+++ b/packages/rstack/src/fmt/ignore.ts
@@ -29,10 +29,14 @@ const createDefaultMatcher = (): IgnorePredicate => {
 
 const createSourceMatcher = (sources: IgnoreSource[]): IgnorePredicate => {
   const matcher = new (loadNativeBinding().IgnoreMatcher)(sources);
-  return (filePath, isDirectory = false) => matcher.isIgnored(filePath, isDirectory);
+  return (filePath, isDirectory = false) =>
+    matcher.isIgnored(filePath, isDirectory);
 };
 
-const loadIgnoreSource = async (cwd: string, ignorePath: string): Promise<IgnoreSource> => {
+const loadIgnoreSource = async (
+  cwd: string,
+  ignorePath: string,
+): Promise<IgnoreSource> => {
   const filePath = path.resolve(cwd, ignorePath);
   let patterns: string;
 

--- a/packages/rstack/src/fmt/lsp/minimalEdit.ts
+++ b/packages/rstack/src/fmt/lsp/minimalEdit.ts
@@ -8,8 +8,10 @@ interface MinimalEdit {
 const CARRIAGE_RETURN = 0x0d;
 const LINE_FEED = 0x0a;
 
-const isHighSurrogate = (code: number): boolean => code >= 0xd800 && code <= 0xdbff;
-const isLowSurrogate = (code: number): boolean => code >= 0xdc00 && code <= 0xdfff;
+const isHighSurrogate = (code: number): boolean =>
+  code >= 0xd800 && code <= 0xdbff;
+const isLowSurrogate = (code: number): boolean =>
+  code >= 0xdc00 && code <= 0xdfff;
 
 /**
  * True when `index` splits a unit that occupies a single position: a surrogate
@@ -33,7 +35,10 @@ const splitsIndivisibleUnit = (text: string, index: number): boolean => {
  * ends instead of replacing the whole document, which keeps selections, folds,
  * and undo history intact. Offsets are converted to positions by the caller.
  */
-const computeMinimalEdit = (source: string, formatted: string): MinimalEdit | undefined => {
+const computeMinimalEdit = (
+  source: string,
+  formatted: string,
+): MinimalEdit | undefined => {
   if (source === formatted) {
     return undefined;
   }
@@ -109,7 +114,10 @@ interface MinimalTextEdit {
  * `\r\n`, or a lone `\r`, like the protocol's. `computeMinimalEdit` keeping
  * boundaries out of surrogate pairs and `\r\n` is what makes the mapping exact.
  */
-const computeMinimalTextEdit = (source: string, formatted: string): MinimalTextEdit | undefined => {
+const computeMinimalTextEdit = (
+  source: string,
+  formatted: string,
+): MinimalTextEdit | undefined => {
   const edit = computeMinimalEdit(source, formatted);
   if (!edit) {
     return undefined;

--- a/packages/rstack/src/fmt/lsp/server.ts
+++ b/packages/rstack/src/fmt/lsp/server.ts
@@ -9,7 +9,10 @@ import {
   type InitializeParams,
   type TextEdit,
 } from 'vscode-languageserver/node';
-import { createFmtFileResolver, type FmtFileResolver } from '../fileResolver.ts';
+import {
+  createFmtFileResolver,
+  type FmtFileResolver,
+} from '../fileResolver.ts';
 import { formatFmtSource } from '../format.ts';
 import { createIgnoreMatcher, type IgnorePredicate } from '../ignore.ts';
 import type { ResolvedFmtConfig } from '../types.ts';
@@ -67,7 +70,8 @@ const redirectConsoleToConnection = (connection: Connection): void => {
     connection.console.log(serializeConsoleArguments(args));
   console.trace = (...args: unknown[]): void => {
     const stack = new Error().stack?.replace(/(.+\n){2}/, '') ?? '';
-    const message = args.length === 0 ? 'Trace' : `Trace: ${serializeConsoleArguments(args)}`;
+    const message =
+      args.length === 0 ? 'Trace' : `Trace: ${serializeConsoleArguments(args)}`;
     connection.console.log(`${message}\n${stack}`);
   };
   console.assert = (assertion?: unknown, ...args: unknown[]): void => {
@@ -99,7 +103,9 @@ const redirectConsoleToConnection = (connection: Connection): void => {
 const resolveWorkspaceRoot = (params: InitializeParams): string | undefined => {
   const rootUri = params.workspaceFolders?.[0]?.uri ?? params.rootUri;
 
-  return (rootUri ? toFilePath(rootUri) : undefined) ?? params.rootPath ?? undefined;
+  return (
+    (rootUri ? toFilePath(rootUri) : undefined) ?? params.rootPath ?? undefined
+  );
 };
 
 /** Loads everything a formatting request needs, once per server lifetime. */
@@ -155,7 +161,10 @@ const createDocumentEdits = async (
     return [];
   }
 
-  const edit = formatted === undefined ? undefined : computeMinimalTextEdit(source, formatted);
+  const edit =
+    formatted === undefined
+      ? undefined
+      : computeMinimalTextEdit(source, formatted);
 
   return edit ? [edit] : [];
 };
@@ -198,25 +207,27 @@ const startFmtLsp = (options: RunFmtLspOptions, onExit: () => void): void => {
 
   // TODO: watch the config file and reset the session when it changes.
   const getSession = (): Promise<FmtLspSession> =>
-    (sessionPromise ??= createFmtLspSession({ ...options, root }).catch((error: unknown) => {
-      // Retry on the next request rather than caching the failure forever.
-      sessionPromise = undefined;
-      // A workspace that cannot be set up returns no edits for every document,
-      // which looks like "nothing to format" in editors that hide the server
-      // log, so it is shown to the user instead of only being logged. Repeats
-      // of the same failure stay silent so saving a file cannot spam the editor.
-      const message = `rs fmt cannot format this workspace: ${String(error)}`;
-      if (reportedSessionError !== message) {
-        reportedSessionError = message;
-        // A notification rather than `window.showErrorMessage`, which sends a
-        // request the server would then wait on for a response it does not need.
-        void connection.sendNotification(ShowMessageNotification.type, {
-          type: MessageType.Error,
-          message,
-        });
-      }
-      throw error;
-    }));
+    (sessionPromise ??= createFmtLspSession({ ...options, root }).catch(
+      (error: unknown) => {
+        // Retry on the next request rather than caching the failure forever.
+        sessionPromise = undefined;
+        // A workspace that cannot be set up returns no edits for every document,
+        // which looks like "nothing to format" in editors that hide the server
+        // log, so it is shown to the user instead of only being logged. Repeats
+        // of the same failure stay silent so saving a file cannot spam the editor.
+        const message = `rs fmt cannot format this workspace: ${String(error)}`;
+        if (reportedSessionError !== message) {
+          reportedSessionError = message;
+          // A notification rather than `window.showErrorMessage`, which sends a
+          // request the server would then wait on for a response it does not need.
+          void connection.sendNotification(ShowMessageNotification.type, {
+            type: MessageType.Error,
+            message,
+          });
+        }
+        throw error;
+      },
+    ));
 
   connection.onExit(onExit);
 
@@ -234,26 +245,30 @@ const startFmtLsp = (options: RunFmtLspOptions, onExit: () => void): void => {
     };
   });
 
-  connection.onDocumentFormatting(async ({ textDocument }): Promise<TextEdit[]> => {
-    const filePath = toFilePath(textDocument.uri);
-    if (!filePath) {
-      return [];
-    }
+  connection.onDocumentFormatting(
+    async ({ textDocument }): Promise<TextEdit[]> => {
+      const filePath = toFilePath(textDocument.uri);
+      if (!filePath) {
+        return [];
+      }
 
-    // A formatting failure must never disrupt editing; unsupported, ignored,
-    // and unparsable documents all resolve to "no edits".
-    try {
-      const session = await getSession();
+      // A formatting failure must never disrupt editing; unsupported, ignored,
+      // and unparsable documents all resolve to "no edits".
+      try {
+        const session = await getSession();
 
-      return await createDocumentEdits(
-        () => documents.get(textDocument.uri),
-        (source) => formatDocumentSource(session, filePath, source),
-      );
-    } catch (error) {
-      connection.console.error(`Failed to format "${filePath}": ${String(error)}`);
-      return [];
-    }
-  });
+        return await createDocumentEdits(
+          () => documents.get(textDocument.uri),
+          (source) => formatDocumentSource(session, filePath, source),
+        );
+      } catch (error) {
+        connection.console.error(
+          `Failed to format "${filePath}": ${String(error)}`,
+        );
+        return [];
+      }
+    },
+  );
 
   connection.listen();
 };

--- a/packages/rstack/src/fmt/pathHelpers.ts
+++ b/packages/rstack/src/fmt/pathHelpers.ts
@@ -3,10 +3,14 @@ import path from 'node:path';
 type RelativePathResolver = (filePath: string) => string;
 
 const toPosixPath: (filePath: string) => string =
-  path.sep === '\\' ? (filePath) => filePath.replaceAll('\\', '/') : (filePath) => filePath;
+  path.sep === '\\'
+    ? (filePath) => filePath.replaceAll('\\', '/')
+    : (filePath) => filePath;
 
 const createRelativePathResolver = (rootPath: string): RelativePathResolver => {
-  const rootPrefix = rootPath.endsWith(path.sep) ? rootPath : `${rootPath}${path.sep}`;
+  const rootPrefix = rootPath.endsWith(path.sep)
+    ? rootPath
+    : `${rootPath}${path.sep}`;
 
   return (filePath) =>
     filePath === rootPath
@@ -17,7 +21,8 @@ const createRelativePathResolver = (rootPath: string): RelativePathResolver => {
 };
 
 /** Prettier only inspects a file's shebang when its basename contains no dot. */
-const hasDottedBasename = (filePath: string): boolean => path.basename(filePath).includes('.');
+const hasDottedBasename = (filePath: string): boolean =>
+  path.basename(filePath).includes('.');
 
 export { createRelativePathResolver, hasDottedBasename, toPosixPath };
 export type { RelativePathResolver };

--- a/packages/rstack/src/fmt/plugins.ts
+++ b/packages/rstack/src/fmt/plugins.ts
@@ -1,5 +1,11 @@
 import { readFile, realpath } from 'node:fs/promises';
-import { isAbsolute, join, relative, resolve as resolvePath, sep } from 'node:path';
+import {
+  isAbsolute,
+  join,
+  relative,
+  resolve as resolvePath,
+  sep,
+} from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { moduleResolve } from 'import-meta-resolve';
 import type { Options as PrettierOptions } from 'prettier';
@@ -8,12 +14,16 @@ import type { FmtPluginSpecifier, ResolvedFmtOptions } from './types.ts';
 
 type FmtPlugin = NonNullable<PrettierOptions['plugins']>[number];
 type FmtPluginResolver = (options: ResolvedFmtOptions) => ResolvedFmtOptions;
-type FingerprintResolver = (plugin: FmtPluginSpecifier) => Promise<string | undefined>;
+type FingerprintResolver = (
+  plugin: FmtPluginSpecifier,
+) => Promise<string | undefined>;
 
 const resolveModuleUrl = (specifier: string, parentUrl: URL): string =>
   moduleResolve(specifier, parentUrl).href;
 
-const isFmtPluginSpecifier = (plugin: FmtPlugin): plugin is FmtPluginSpecifier =>
+const isFmtPluginSpecifier = (
+  plugin: FmtPlugin,
+): plugin is FmtPluginSpecifier =>
   typeof plugin === 'string' || plugin instanceof URL;
 
 const getPackageRoot = (entryPath: string): string | undefined => {
@@ -38,7 +48,9 @@ const getPackageRoot = (entryPath: string): string | undefined => {
   return entryPath.slice(0, end);
 };
 
-const fingerprintPlugin = async (pluginUrl: string): Promise<string | undefined> => {
+const fingerprintPlugin = async (
+  pluginUrl: string,
+): Promise<string | undefined> => {
   try {
     const url = new URL(pluginUrl);
     if (url.protocol !== 'file:') {
@@ -53,7 +65,9 @@ const fingerprintPlugin = async (pluginUrl: string): Promise<string | undefined>
       return undefined;
     }
 
-    const pkg: unknown = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
+    const pkg: unknown = JSON.parse(
+      await readFile(join(packageRoot, 'package.json'), 'utf8'),
+    );
     if (
       typeof pkg !== 'object' ||
       pkg === null ||
@@ -142,7 +156,9 @@ const createPluginResolver = (rootPath: string): FmtPluginResolver => {
     }
 
     const resolvedPlugins = plugins.map(resolvePlugin);
-    const resolvedOptions = resolvedPlugins.every((plugin, index) => plugin === plugins[index])
+    const resolvedOptions = resolvedPlugins.every(
+      (plugin, index) => plugin === plugins[index],
+    )
       ? options
       : { ...options, plugins: resolvedPlugins };
     optionsCache.set(options, resolvedOptions);

--- a/packages/rstack/src/fmt/prettierPlugins.ts
+++ b/packages/rstack/src/fmt/prettierPlugins.ts
@@ -24,7 +24,10 @@ const getPrettierPlugins = async (
 ): Promise<PrettierPlugins> => {
   const plugins =
     options.sortPackageJson === true && /(^|[/\\])package\.json$/.test(filePath)
-      ? [...defaultFmtPlugins, (await import('./sortPackageJsonPlugin.ts')).sortPackageJsonPlugin]
+      ? [
+          ...defaultFmtPlugins,
+          (await import('./sortPackageJsonPlugin.ts')).sortPackageJsonPlugin,
+        ]
       : defaultFmtPlugins;
 
   return options.plugins?.length ? [...plugins, ...options.plugins] : plugins;

--- a/packages/rstack/src/fmt/runner.ts
+++ b/packages/rstack/src/fmt/runner.ts
@@ -1,4 +1,8 @@
-import { cacheNamespace, createCacheKeyResolver, createOptionsHasher } from './cacheIdentity.ts';
+import {
+  cacheNamespace,
+  createCacheKeyResolver,
+  createOptionsHasher,
+} from './cacheIdentity.ts';
 import { loadFmtCacheStore } from './cacheStore.ts';
 import type { FmtCacheEntry, FmtCacheStore } from './cacheStore.ts';
 import { hasDottedBasename } from './pathHelpers.ts';
@@ -77,7 +81,10 @@ const loadPluginFingerprints = async (
   );
   const resolveFingerprint = createFingerprintResolver();
   const entries = await Promise.all(
-    Array.from(plugins, async ([key, plugin]) => [key, await resolveFingerprint(plugin)] as const),
+    Array.from(
+      plugins,
+      async ([key, plugin]) => [key, await resolveFingerprint(plugin)] as const,
+    ),
   );
   const fingerprints = new Map<string, string>();
   for (const [key, fingerprint] of entries) {
@@ -89,7 +96,10 @@ const loadPluginFingerprints = async (
 };
 
 /** Resolves the portable cache identity before work is dispatched. */
-const createRunTask = (file: FmtFileRequest, cache?: RunCache): FmtFileRunTask => {
+const createRunTask = (
+  file: FmtFileRequest,
+  cache?: RunCache,
+): FmtFileRunTask => {
   let key: string | undefined;
   let fileCache: FmtFileCache | undefined;
 
@@ -207,7 +217,9 @@ const runWithWorkers = async (
       workerPool.workerCount >= minPriorityWorkers
         ? await runPriorityTasks(tasks, shouldWrite, workerPool.formatFile)
         : await Promise.all(
-            tasks.map((task) => runFmtFile(task, shouldWrite, workerPool.formatFile)),
+            tasks.map((task) =>
+              runFmtFile(task, shouldWrite, workerPool.formatFile),
+            ),
           );
     const processedFiles: FmtFileResult[] = [];
     let processedFileCount = 0;
@@ -277,7 +289,10 @@ const runFmtFiles = async ({
 
   return {
     ...result,
-    exitCode: files.length > 0 && result.processedFileCount === 0 ? 2 : getExitCode(result.files),
+    exitCode:
+      files.length > 0 && result.processedFileCount === 0
+        ? 2
+        : getExitCode(result.files),
   };
 };
 

--- a/packages/rstack/src/fmt/types.ts
+++ b/packages/rstack/src/fmt/types.ts
@@ -1,4 +1,7 @@
-import type { Config as PrettierConfig, Options as PrettierOptions } from 'prettier';
+import type {
+  Config as PrettierConfig,
+  Options as PrettierOptions,
+} from 'prettier';
 import type { FmtCacheEntry } from './cacheStore.ts';
 
 /** Plugin objects cannot cross worker boundaries and are not planned for support. */
@@ -25,7 +28,8 @@ type FmtOverride = Omit<PrettierOverride, 'options'> & {
   options?: FmtOptions;
 };
 
-interface FmtConfig extends Omit<PrettierConfig, 'plugins' | 'overrides'>, FmtBuiltinOptions {
+interface FmtConfig
+  extends Omit<PrettierConfig, 'plugins' | 'overrides'>, FmtBuiltinOptions {
   plugins?: FmtPluginSpecifier[];
   overrides?: FmtOverride[];
   /** Gitignore-compatible patterns relative to the Rstack config root. */

--- a/packages/rstack/src/fmt/worker.ts
+++ b/packages/rstack/src/fmt/worker.ts
@@ -74,7 +74,8 @@ const formatFile = async ({
           cacheEntry: [
             hasDottedBasename(file.path)
               ? ''
-              : (contentHash ?? hashContent(sourceBuffer ?? readFileSync(file.path))),
+              : (contentHash ??
+                hashContent(sourceBuffer ?? readFileSync(file.path))),
             cache.optionsHash,
             'unsupported',
           ],

--- a/packages/rstack/src/fmt/workerPool.ts
+++ b/packages/rstack/src/fmt/workerPool.ts
@@ -22,7 +22,10 @@ interface FmtWorkerPool {
  * scheduling and memory pressure.
  */
 const getWorkerCount = (fileCount: number, maxWorkers?: number): number =>
-  Math.min(fileCount, maxWorkers ?? Math.min(8, Math.max(1, availableParallelism() - 1)));
+  Math.min(
+    fileCount,
+    maxWorkers ?? Math.min(8, Math.max(1, availableParallelism() - 1)),
+  );
 
 const getWorkerUrl = (): URL => {
   // Source tests run after build and exercise the same worker artifact as the CLI.
@@ -33,7 +36,10 @@ const getWorkerUrl = (): URL => {
 };
 
 /** Creates and starts every worker before formatting can begin. */
-const createWorkerPool = async (fileCount: number, maxWorkers?: number): Promise<FmtWorkerPool> => {
+const createWorkerPool = async (
+  fileCount: number,
+  maxWorkers?: number,
+): Promise<FmtWorkerPool> => {
   const workerCount = getWorkerCount(fileCount, maxWorkers);
   const pool = new Tinypool({
     filename: getWorkerUrl().href,

--- a/packages/rstack/src/fmt/yukuPlugin.ts
+++ b/packages/rstack/src/fmt/yukuPlugin.ts
@@ -70,7 +70,8 @@ const locStart = (node: Locatable): number => {
   return firstDecorator ? Math.min(locStart(firstDecorator), start) : start;
 };
 
-const locEndWithFullText = (node: Locatable): number => (node.range?.[1] ?? node.end) as number;
+const locEndWithFullText = (node: Locatable): number =>
+  (node.range?.[1] ?? node.end) as number;
 
 const locEnd = (node: Locatable): number => {
   switch (node.type) {
@@ -89,7 +90,9 @@ const locEnd = (node: Locatable): number => {
       return node.label ? locEnd(node.label) : locStart(node) + 'break'.length;
 
     case 'ContinueStatement':
-      return node.label ? locEnd(node.label) : locStart(node) + 'continue'.length;
+      return node.label
+        ? locEnd(node.label)
+        : locStart(node) + 'continue'.length;
 
     case 'DebuggerStatement':
       return locStart(node) + 'debugger'.length;
@@ -136,10 +139,13 @@ const hasPragmaFrom = (originalText: string, pragmas: Set<string>): boolean => {
   return false;
 };
 
-const hasPragma = (text: string): boolean => hasPragmaFrom(text, FORMAT_PRAGMAS);
-const hasIgnorePragma = (text: string): boolean => hasPragmaFrom(text, FORMAT_IGNORE_PRAGMAS);
+const hasPragma = (text: string): boolean =>
+  hasPragmaFrom(text, FORMAT_PRAGMAS);
+const hasIgnorePragma = (text: string): boolean =>
+  hasPragmaFrom(text, FORMAT_IGNORE_PRAGMAS);
 
-const getVisitorKeys = estreePrinter.getVisitorKeys as ((node: AstNode) => string[]) | undefined;
+const getVisitorKeys = estreePrinter.getVisitorKeys as
+  ((node: AstNode) => string[]) | undefined;
 
 if (!getVisitorKeys) {
   throw new Error('The Prettier ESTree printer does not expose visitor keys.');
@@ -158,7 +164,10 @@ const asAstNode = (value: unknown): AstNode => {
   return value;
 };
 
-const withExtra = (node: AstNode, extra: Record<string, unknown>): Record<string, unknown> => ({
+const withExtra = (
+  node: AstNode,
+  extra: Record<string, unknown>,
+): Record<string, unknown> => ({
   ...(node.extra !== null && typeof node.extra === 'object'
     ? (node.extra as Record<string, unknown>)
     : undefined),
@@ -201,7 +210,10 @@ const mergeNestedJsdocComments = (comments: PrettierComment[]): void => {
   }
 };
 
-const stripComments = (originalText: string, comments: PrettierComment[]): string => {
+const stripComments = (
+  originalText: string,
+  comments: PrettierComment[],
+): string => {
   if (comments.length === 0) {
     return originalText;
   }
@@ -287,7 +299,10 @@ const isUnbalancedLogicalTree = (node: AstNode): boolean => {
     return false;
   }
 
-  return node.right.type === 'LogicalExpression' && node.operator === node.right.operator;
+  return (
+    node.right.type === 'LogicalExpression' &&
+    node.operator === node.right.operator
+  );
 };
 
 const rebalanceLogicalTree = (node: AstNode): AstNode => {
@@ -351,7 +366,9 @@ const postprocess = (
             .filter(isTypeCastComment)
             .map((comment) => locEnd(comment));
 
-          const previousCommentEnd = typeCastCommentEnds.findLast((end) => end <= start);
+          const previousCommentEnd = typeCastCommentEnds.findLast(
+            (end) => end <= start,
+          );
           const shouldKeepParentheses =
             previousCommentEnd !== undefined &&
             text.slice(previousCommentEnd, start).trim().length === 0;
@@ -402,12 +419,17 @@ const postprocess = (
       return undefined;
     },
     onLeave(node) {
-      return isUnbalancedLogicalTree(node) ? rebalanceLogicalTree(node) : undefined;
+      return isUnbalancedLogicalTree(node)
+        ? rebalanceLogicalTree(node)
+        : undefined;
     },
   }) as AstNode;
 };
 
-const indexToPosition = (text: string, index: number): { column: number; line: number } => {
+const indexToPosition = (
+  text: string,
+  index: number,
+): { column: number; line: number } => {
   const lineBreakBefore = index === 0 ? -1 : text.lastIndexOf('\n', index - 1);
   let line = 1;
 
@@ -427,10 +449,13 @@ const createParseError = (error: Diagnostic, text: string): SyntaxError => {
   const start = indexToPosition(text, error.start);
   const end = indexToPosition(text, error.end);
 
-  return Object.assign(new SyntaxError(`${error.message} (${start.line}:${start.column})`), {
-    cause: error,
-    loc: { start, end },
-  });
+  return Object.assign(
+    new SyntaxError(`${error.message} (${start.line}:${start.column})`),
+    {
+      cause: error,
+      loc: { start, end },
+    },
+  );
 };
 
 const parseWithOptions = (text: string, options: ParseOptions): ParseResult => {
@@ -460,7 +485,10 @@ const getSourceType = (filepath: string): SourceType | undefined => {
   return undefined;
 };
 
-const getLanguageCombinations = (text: string, filepath: string): SourceLang[] => {
+const getLanguageCombinations = (
+  text: string,
+  filepath: string,
+): SourceLang[] => {
   const normalizedPath = filepath.toLowerCase();
 
   if (JS_TS_FILE_REGEXP.test(normalizedPath)) {
@@ -493,25 +521,48 @@ const tryCombinations = (combinations: (() => ParseResult)[]): ParseResult => {
   throw new Error('No Yuku parser combinations were provided.');
 };
 
-const parseJavaScript = (text: string, options: ParserOptions<AstNode>): AstNode => {
+const parseJavaScript = (
+  text: string,
+  options: ParserOptions<AstNode>,
+): AstNode => {
   const sourceType = getSourceType(options.filepath);
-  const combinations = (sourceType ? [sourceType] : SOURCE_TYPE_COMBINATIONS).map(
-    (candidate) => () => parseWithOptions(text, { sourceType: candidate, lang: 'jsx' }),
+  const combinations = (
+    sourceType ? [sourceType] : SOURCE_TYPE_COMBINATIONS
+  ).map(
+    (candidate) => () =>
+      parseWithOptions(text, { sourceType: candidate, lang: 'jsx' }),
   );
   const { program, comments } = tryCombinations(combinations);
 
-  return postprocess(program as unknown as AstNode, comments as PrettierComment[], text, 'yuku-js');
+  return postprocess(
+    program as unknown as AstNode,
+    comments as PrettierComment[],
+    text,
+    'yuku-js',
+  );
 };
 
-const parseTypeScript = (text: string, options: ParserOptions<AstNode>): AstNode => {
+const parseTypeScript = (
+  text: string,
+  options: ParserOptions<AstNode>,
+): AstNode => {
   const sourceType = getSourceType(options.filepath);
   const languages = getLanguageCombinations(text, options.filepath);
-  const combinations = (sourceType ? [sourceType] : SOURCE_TYPE_COMBINATIONS).flatMap((candidate) =>
-    languages.map((lang) => () => parseWithOptions(text, { sourceType: candidate, lang })),
+  const combinations = (
+    sourceType ? [sourceType] : SOURCE_TYPE_COMBINATIONS
+  ).flatMap((candidate) =>
+    languages.map(
+      (lang) => () => parseWithOptions(text, { sourceType: candidate, lang }),
+    ),
   );
   const { program, comments } = tryCombinations(combinations);
 
-  return postprocess(program as unknown as AstNode, comments as PrettierComment[], text, 'yuku-ts');
+  return postprocess(
+    program as unknown as AstNode,
+    comments as PrettierComment[],
+    text,
+    'yuku-ts',
+  );
 };
 
 const createParser = (
@@ -530,17 +581,19 @@ const parserNames = new Map([
   ['typescript', 'yuku-ts'],
 ]);
 
-const languages: SupportLanguage[] = estreePlugin.languages.flatMap((language) => {
-  const parsers = [
-    ...new Set(
-      language.parsers
-        .map((parser) => parserNames.get(parser))
-        .filter((parser): parser is string => parser !== undefined),
-    ),
-  ];
+const languages: SupportLanguage[] = estreePlugin.languages.flatMap(
+  (language) => {
+    const parsers = [
+      ...new Set(
+        language.parsers
+          .map((parser) => parserNames.get(parser))
+          .filter((parser): parser is string => parser !== undefined),
+      ),
+    ];
 
-  return parsers.length > 0 ? [{ ...language, parsers }] : [];
-});
+    return parsers.length > 0 ? [{ ...language, parsers }] : [];
+  },
+);
 
 const yukuPlugin: Plugin = {
   languages,

--- a/packages/rstack/src/native/index.ts
+++ b/packages/rstack/src/native/index.ts
@@ -6,5 +6,7 @@ export type NativeBinding = typeof import('../../binding.cjs');
 const require = createRequire(import.meta.url);
 export const loadNativeBinding = (): NativeBinding => {
   const packageJsonPath = require.resolve('rstack/package.json');
-  return require(path.join(path.dirname(packageJsonPath), 'binding.cjs')) as NativeBinding;
+  return require(
+    path.join(path.dirname(packageJsonPath), 'binding.cjs'),
+  ) as NativeBinding;
 };

--- a/packages/rstack/src/projectCache.ts
+++ b/packages/rstack/src/projectCache.ts
@@ -4,13 +4,17 @@ import path from 'node:path';
 const cacheGitignore = '*\n';
 
 type ProjectCacheResult =
-  { status: 'available'; path: string } | { status: 'unavailable'; path: string; error: unknown };
+  | { status: 'available'; path: string }
+  | { status: 'unavailable'; path: string; error: unknown };
 
 /** Returns the disposable cache directory for a resolved Rstack project root. */
-const getProjectCacheDir = (rootPath: string): string => path.join(rootPath, '.rstack', 'cache');
+const getProjectCacheDir = (rootPath: string): string =>
+  path.join(rootPath, '.rstack', 'cache');
 
 /** Creates the project cache directory without making cache failures fatal. */
-const ensureProjectCacheDir = async (rootPath: string): Promise<ProjectCacheResult> => {
+const ensureProjectCacheDir = async (
+  rootPath: string,
+): Promise<ProjectCacheResult> => {
   const cachePath = getProjectCacheDir(rootPath);
   const ignorePath = path.join(cachePath, '.gitignore');
 

--- a/packages/rstack/src/rsbuildConfig.ts
+++ b/packages/rstack/src/rsbuildConfig.ts
@@ -1,4 +1,8 @@
-import type { ConfigParams, RsbuildConfigDefinition, WatchFiles } from '@rsbuild/core';
+import type {
+  ConfigParams,
+  RsbuildConfigDefinition,
+  WatchFiles,
+} from '@rsbuild/core';
 import { loadRstackConfig, type Configs } from './config.ts';
 
 const resolveRsbuildConfig = async (configs: Configs, params: ConfigParams) => {
@@ -31,7 +35,11 @@ const loadRsbuildConfig: RsbuildConfigDefinition = async (params) => {
     dev: {
       ...config.dev,
       watchFiles: [
-        ...(watchFiles ? (Array.isArray(watchFiles) ? watchFiles : [watchFiles]) : []),
+        ...(watchFiles
+          ? Array.isArray(watchFiles)
+            ? watchFiles
+            : [watchFiles]
+          : []),
         watchConfig,
       ],
     },

--- a/packages/rstack/src/rslibConfig.ts
+++ b/packages/rstack/src/rslibConfig.ts
@@ -1,8 +1,15 @@
 import type { WatchFiles } from '@rsbuild/core';
-import type { ConfigParams, RslibConfig, RslibConfigDefinition } from '@rslib/core';
+import type {
+  ConfigParams,
+  RslibConfig,
+  RslibConfigDefinition,
+} from '@rslib/core';
 import { loadRstackConfig, type Configs } from './config.ts';
 
-const resolveRslibConfig = async (configs: Configs, params: ConfigParams): Promise<RslibConfig> => {
+const resolveRslibConfig = async (
+  configs: Configs,
+  params: ConfigParams,
+): Promise<RslibConfig> => {
   const libConfig = configs.lib;
   if (!libConfig) {
     return {};
@@ -32,7 +39,11 @@ const loadRslibConfig = (async (params: ConfigParams) => {
     dev: {
       ...config.dev,
       watchFiles: [
-        ...(watchFiles ? (Array.isArray(watchFiles) ? watchFiles : [watchFiles]) : []),
+        ...(watchFiles
+          ? Array.isArray(watchFiles)
+            ? watchFiles
+            : [watchFiles]
+          : []),
         watchConfig,
       ],
     },

--- a/packages/rstack/src/rspressConfig.ts
+++ b/packages/rstack/src/rspressConfig.ts
@@ -34,7 +34,11 @@ export default async (): Promise<UserConfig> => {
       dev: {
         ...config.builderConfig?.dev,
         watchFiles: [
-          ...(watchFiles ? (Array.isArray(watchFiles) ? watchFiles : [watchFiles]) : []),
+          ...(watchFiles
+            ? Array.isArray(watchFiles)
+              ? watchFiles
+              : [watchFiles]
+            : []),
           watchConfig,
         ],
       },

--- a/packages/rstack/src/rstestConfig.ts
+++ b/packages/rstack/src/rstestConfig.ts
@@ -14,7 +14,8 @@ const resolveAutomaticExtends = async (
       /* rspackChunkName: 'adapterRsbuild' */
       '@rstest/adapter-rsbuild'
     );
-    const config = typeof appConfig === 'function' ? await appConfig(params) : appConfig;
+    const config =
+      typeof appConfig === 'function' ? await appConfig(params) : appConfig;
 
     return withRsbuildConfig({
       config,
@@ -27,7 +28,8 @@ const resolveAutomaticExtends = async (
       /* rspackChunkName: 'adapterRslib' */
       '@rstest/adapter-rslib'
     );
-    const config = typeof libConfig === 'function' ? await libConfig(params) : libConfig;
+    const config =
+      typeof libConfig === 'function' ? await libConfig(params) : libConfig;
 
     return withRslibConfig({
       config,
@@ -51,7 +53,11 @@ const injectExtends = <T extends RstestConfig>(
   };
 };
 
-const extendsConfig = async (configs: Configs, testConfig: RstestConfig, params: ConfigParams) => {
+const extendsConfig = async (
+  configs: Configs,
+  testConfig: RstestConfig,
+  params: ConfigParams,
+) => {
   if ('extends' in testConfig) {
     return testConfig;
   }
@@ -73,7 +79,9 @@ const extendsConfig = async (configs: Configs, testConfig: RstestConfig, params:
   return {
     ...testConfig,
     projects: testConfig.projects.map((project) =>
-      typeof project === 'string' ? project : injectExtends(project, automaticExtends),
+      typeof project === 'string'
+        ? project
+        : injectExtends(project, automaticExtends),
     ),
   };
 };

--- a/packages/rstack/src/setup/hooks.ts
+++ b/packages/rstack/src/setup/hooks.ts
@@ -24,7 +24,10 @@ const quoteShellPath = (value: string): string => {
     process.platform === 'win32'
       ? value
           .replaceAll('\\', '/')
-          .replace(/^([A-Za-z]):\//u, (_, drive: string) => `/${drive.toLowerCase()}/`)
+          .replace(
+            /^([A-Za-z]):\//u,
+            (_, drive: string) => `/${drive.toLowerCase()}/`,
+          )
       : value;
 
   return `'${shellPath.replaceAll("'", `'"'"'`)}'`;
@@ -78,7 +81,8 @@ rs_run "$@"
 export const createHookFiles = (
   nodeExecutable: string = process.execPath,
 ): Record<string, string> => {
-  const messageShim = createShim(`# Keep the message file valid after changing directories.
+  const messageShim =
+    createShim(`# Keep the message file valid after changing directories.
 [ -n "\${1-}" ] || exit 1
 case "$1" in
   /*|[A-Za-z]:/*) ;;
@@ -90,7 +94,8 @@ case "$1" in
 esac
 `);
 
-  const prePushShim = createShim(`# Keep a local remote path valid after changing directories.
+  const prePushShim =
+    createShim(`# Keep a local remote path valid after changing directories.
 rs_remote_name=\${1-}
 rs_remote_location=\${2-}
 [ -n "$rs_remote_name" ] && [ -n "$rs_remote_location" ] || exit 1
@@ -109,7 +114,9 @@ set -- "$rs_remote_name" "$rs_remote_location" "$@"
 `);
 
   const defaultShim = createShim();
-  const files: Record<string, string> = { runner: createRunner(nodeExecutable) };
+  const files: Record<string, string> = {
+    runner: createRunner(nodeExecutable),
+  };
 
   for (const name of hookNames) {
     files[name] = name.endsWith('-msg')

--- a/packages/rstack/src/setup/index.ts
+++ b/packages/rstack/src/setup/index.ts
@@ -16,7 +16,9 @@ export const runSetupCLI = async (args: string[]): Promise<void> => {
 
   const hooksDirs = values.hooksDir;
   if (hooksDirs && hooksDirs.length > 1) {
-    throw new Error('The --hooks-dir option cannot be specified more than once.');
+    throw new Error(
+      'The --hooks-dir option cannot be specified more than once.',
+    );
   }
 
   const hooksDir = hooksDirs?.[0];
@@ -39,7 +41,9 @@ export const runSetupCLI = async (args: string[]): Promise<void> => {
     }
 
     const reason =
-      result.reason === 'disabled' ? 'disabled by RSTACK_HOOKS' : 'not a Git repository';
+      result.reason === 'disabled'
+        ? 'disabled by RSTACK_HOOKS'
+        : 'not a Git repository';
     logger.info(`Git hooks setup skipped: ${color.yellow(reason)}.`);
     return;
   }

--- a/packages/rstack/src/setup/install.ts
+++ b/packages/rstack/src/setup/install.ts
@@ -1,5 +1,12 @@
 import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { createHookFiles, hookNames } from './hooks.ts';
 
@@ -54,7 +61,10 @@ const resolveHooksDir = (hooksDir: string): string | FailedInstallResult => {
   const resolvedDir = hooksDir.replaceAll('\\', '/');
 
   if (resolvedDir.length === 0) {
-    return fail('invalid-hooks-directory', 'Git hooks directory must not be empty.');
+    return fail(
+      'invalid-hooks-directory',
+      'Git hooks directory must not be empty.',
+    );
   }
 
   if (path.isAbsolute(resolvedDir)) {
@@ -65,15 +75,20 @@ const resolveHooksDir = (hooksDir: string): string | FailedInstallResult => {
   }
 
   if (resolvedDir.includes('..')) {
-    return fail('invalid-hooks-directory', 'Git hooks directory must not contain "..".');
+    return fail(
+      'invalid-hooks-directory',
+      'Git hooks directory must not contain "..".',
+    );
   }
 
   return resolvedDir;
 };
 
-const runGit = (cwd: string, args: string[]) => spawnSync('git', args, { cwd, encoding: 'utf8' });
+const runGit = (cwd: string, args: string[]) =>
+  spawnSync('git', args, { cwd, encoding: 'utf8' });
 
-const removeLineEnding = (value: string): string => value.replace(/\r?\n$/u, '');
+const removeLineEnding = (value: string): string =>
+  value.replace(/\r?\n$/u, '');
 
 const gitFailure = (
   error: NodeJS.ErrnoException | undefined,
@@ -83,7 +98,10 @@ const gitFailure = (
     return fail('git-not-found', 'Git command not found.');
   }
 
-  return fail('git-command-failed', `Failed to run Git: ${error?.message || stderr.trim()}`);
+  return fail(
+    'git-command-failed',
+    `Failed to run Git: ${error?.message || stderr.trim()}`,
+  );
 };
 
 const resolveGitContext = (cwd: string): GitContext | InstallResult => {
@@ -123,23 +141,33 @@ const resolveGitContext = (cwd: string): GitContext | InstallResult => {
   }
 
   if (!gitRoot || !gitCommonDirectory || !effectiveHooksDirectory) {
-    return fail('git-command-failed', 'Failed to resolve the Git repository paths.');
+    return fail(
+      'git-command-failed',
+      'Failed to resolve the Git repository paths.',
+    );
   }
 
   return {
     defaultHooksDirectory: path.join(gitCommonDirectory, 'hooks'),
     effectiveHooksDirectory,
     gitRoot,
-    projectPath: repositoryPrefix.replaceAll('\\', '/').replace(/\/$/u, '') || '.',
+    projectPath:
+      repositoryPrefix.replaceAll('\\', '/').replace(/\/$/u, '') || '.',
   };
 };
 
-const isCurrentFile = (filePath: string, content: string, executable = false): boolean => {
+const isCurrentFile = (
+  filePath: string,
+  content: string,
+  executable = false,
+): boolean => {
   try {
     // Windows does not expose POSIX executable bits, but Git for Windows still runs hook shims.
     return (
       readFileSync(filePath, 'utf8') === content &&
-      (!executable || process.platform === 'win32' || (statSync(filePath).mode & 0o777) === 0o755)
+      (!executable ||
+        process.platform === 'win32' ||
+        (statSync(filePath).mode & 0o777) === 0o755)
     );
   } catch {
     return false;
@@ -153,7 +181,9 @@ const readOwner = (directory: string): string | undefined => {
   try {
     const content = readFileSync(path.join(directory, ownerFileName), 'utf8');
     const owner = removeLineEnding(content);
-    return content === `${owner}\n` && owner.length > 0 && !/[\r\n]/u.test(owner)
+    return content === `${owner}\n` &&
+      owner.length > 0 &&
+      !/[\r\n]/u.test(owner)
       ? owner
       : undefined;
   } catch {
@@ -163,13 +193,21 @@ const readOwner = (directory: string): string | undefined => {
 
 const displayPath = (gitRoot: string, filePath: string): string => {
   const relativePath = path.relative(gitRoot, filePath).replaceAll('\\', '/');
-  return relativePath.length > 0 && !relativePath.startsWith('../') ? relativePath : filePath;
+  return relativePath.length > 0 && !relativePath.startsWith('../')
+    ? relativePath
+    : filePath;
 };
 
 const ownerConflict = (project: string): SkippedInstallResult =>
-  skip('owned-by-another-project', `Git hooks are already managed by Rstack project "${project}"`);
+  skip(
+    'owned-by-another-project',
+    `Git hooks are already managed by Rstack project "${project}"`,
+  );
 
-const directoryConflict = (gitRoot: string, directory: string): SkippedInstallResult =>
+const directoryConflict = (
+  gitRoot: string,
+  directory: string,
+): SkippedInstallResult =>
   skip(
     'hooks-directory-conflict',
     `the hooks directory "${displayPath(gitRoot, directory)}" is not managed by Rstack`,
@@ -191,7 +229,8 @@ const claimOwner = (
     // Exclusive creation makes concurrent prepare scripts agree on one owner.
     writeFileSync(ownerPath, `${project}\n`, { flag: 'wx' });
   } catch (error) {
-    const code = error instanceof Error && 'code' in error ? error.code : undefined;
+    const code =
+      error instanceof Error && 'code' in error ? error.code : undefined;
     if (code !== 'EEXIST') {
       throw error;
     }
@@ -200,7 +239,9 @@ const claimOwner = (
     if (!concurrentOwner) {
       return directoryConflict(gitRoot, directory);
     }
-    return concurrentOwner === project ? undefined : ownerConflict(concurrentOwner);
+    return concurrentOwner === project
+      ? undefined
+      : ownerConflict(concurrentOwner);
   }
 
   return undefined;
@@ -228,11 +269,19 @@ export const installHooks = ({
     return context;
   }
 
-  const { defaultHooksDirectory, effectiveHooksDirectory, gitRoot, projectPath } = context;
+  const {
+    defaultHooksDirectory,
+    effectiveHooksDirectory,
+    gitRoot,
+    projectPath,
+  } = context;
   const hooksPath = `${resolvedDir}/${generatedDirectoryName}`;
   const directory = path.join(gitRoot, resolvedDir, generatedDirectoryName);
   const hooksPathMatches = isSamePath(effectiveHooksDirectory, directory);
-  const usesDefaultHooks = isSamePath(effectiveHooksDirectory, defaultHooksDirectory);
+  const usesDefaultHooks = isSamePath(
+    effectiveHooksDirectory,
+    defaultHooksDirectory,
+  );
 
   if (!hooksPathMatches && !usesDefaultHooks) {
     const activeOwner = readOwner(effectiveHooksDirectory);
@@ -269,7 +318,9 @@ export const installHooks = ({
     const unchanged =
       hooksPathMatches &&
       isCurrentFile(path.join(directory, '.gitignore'), gitignore) &&
-      files.every(([name, content]) => isCurrentFile(path.join(directory, name), content, true));
+      files.every(([name, content]) =>
+        isCurrentFile(path.join(directory, name), content, true),
+      );
     if (unchanged) {
       return { status: 'unchanged', hooksPath };
     }
@@ -293,7 +344,12 @@ export const installHooks = ({
   }
 
   // Point Git at the generated directory only after every runtime file is ready.
-  const configured = runGit(cwd, ['config', '--local', 'core.hooksPath', hooksPath]);
+  const configured = runGit(cwd, [
+    'config',
+    '--local',
+    'core.hooksPath',
+    hooksPath,
+  ]);
   if (configured.error || configured.status === null) {
     return gitFailure(configured.error, configured.stderr);
   }

--- a/packages/rstack/src/staged.ts
+++ b/packages/rstack/src/staged.ts
@@ -3,13 +3,16 @@ import { parseArgs } from './cli/args.ts';
 import { printCommandHelp } from './cli/help.ts';
 import { loadRstackConfig } from './config.ts';
 
-export type StagedSyncTaskGenerator = (stagedFileNames: readonly string[]) => string | string[];
+export type StagedSyncTaskGenerator = (
+  stagedFileNames: readonly string[],
+) => string | string[];
 
 export type StagedAsyncTaskGenerator = (
   stagedFileNames: readonly string[],
 ) => Promise<string | string[]>;
 
-export type StagedTaskGenerator = StagedSyncTaskGenerator | StagedAsyncTaskGenerator;
+export type StagedTaskGenerator =
+  StagedSyncTaskGenerator | StagedAsyncTaskGenerator;
 
 export type StagedFunctionTask = {
   title: string;
@@ -17,7 +20,10 @@ export type StagedFunctionTask = {
 };
 
 export type StagedTask =
-  string | StagedFunctionTask | StagedTaskGenerator | (string | StagedTaskGenerator)[];
+  | string
+  | StagedFunctionTask
+  | StagedTaskGenerator
+  | (string | StagedTaskGenerator)[];
 
 export type StagedConfig = Record<string, StagedTask> | StagedTaskGenerator;
 

--- a/packages/rstack/tests/cli/args.test.ts
+++ b/packages/rstack/tests/cli/args.test.ts
@@ -4,17 +4,20 @@ import { parseArgs } from '../../src/cli/args.ts';
 test.each([
   ['--long-option', 'kebab'],
   ['--longOption', 'camel'],
-] as const)('accepts %s and returns only a camel-case value', (option, value) => {
-  const { values } = parseArgs({
-    args: [option, value],
-    options: {
-      'long-option': { type: 'string' },
-    },
-  });
+] as const)(
+  'accepts %s and returns only a camel-case value',
+  (option, value) => {
+    const { values } = parseArgs({
+      args: [option, value],
+      options: {
+        'long-option': { type: 'string' },
+      },
+    });
 
-  expect(values).toEqual({ longOption: value });
-  expect('long-option' in values).toBe(false);
-});
+    expect(values).toEqual({ longOption: value });
+    expect('long-option' in values).toBe(false);
+  },
+);
 
 test('combines repeated kebab-case and camel-case values', () => {
   const { values } = parseArgs({

--- a/packages/rstack/tests/cli/check.test.ts
+++ b/packages/rstack/tests/cli/check.test.ts
@@ -65,7 +65,9 @@ test('enables type checking only with --type-check', () => {
 
   expect(withoutTypeCheck.status).toBe(0);
   expect(withTypeCheck.status).toBe(1);
-  expect(`${withTypeCheck.stdout}\n${withTypeCheck.stderr}`).toContain('TS2322');
+  expect(`${withTypeCheck.stdout}\n${withTypeCheck.stderr}`).toContain(
+    'TS2322',
+  );
 });
 
 test('does not run the formatting check when lint fails', () => {
@@ -75,6 +77,8 @@ test('does not run the formatting check when lint fails', () => {
   const result = runCheck();
 
   expect(result.status).toBe(1);
-  expect(`${result.stdout}\n${result.stderr}`).toContain("Unexpected 'debugger' statement");
+  expect(`${result.stdout}\n${result.stderr}`).toContain(
+    "Unexpected 'debugger' statement",
+  );
   expect(result.stdout).not.toContain('Checking formatting...');
 });

--- a/packages/rstack/tests/cli/fmt/cache.test.ts
+++ b/packages/rstack/tests/cli/fmt/cache.test.ts
@@ -1,8 +1,17 @@
 import { expect, test } from 'rstack/test';
-import { expectWriteSummary, normalizeDuration, setupFmtTest } from './helpers.ts';
+import {
+  expectWriteSummary,
+  normalizeDuration,
+  setupFmtTest,
+} from './helpers.ts';
 
-const { projectFileExists, readProjectFile, resolveProjectPath, runFmt, writeProjectFile } =
-  setupFmtTest();
+const {
+  projectFileExists,
+  readProjectFile,
+  resolveProjectPath,
+  runFmt,
+  writeProjectFile,
+} = setupFmtTest();
 
 interface SerializedFmtCache {
   version: number;
@@ -14,7 +23,10 @@ interface SerializedFmtCache {
 const readFmtCache = (filePath: string): SerializedFmtCache =>
   JSON.parse(readProjectFile(filePath)) as SerializedFmtCache;
 
-const expectSingleCleanEntry = (cache: SerializedFmtCache, filePath: string): void => {
+const expectSingleCleanEntry = (
+  cache: SerializedFmtCache,
+  filePath: string,
+): void => {
   expect(cache.version).toBe(2);
   expect(typeof cache.namespace).toBe('string');
   expect(cache.options).toHaveLength(1);
@@ -37,7 +49,10 @@ test.each([
 
   expect(result.status).toBe(0);
   expect(readProjectFile('.rstack/cache/.gitignore')).toBe('*\n');
-  expectSingleCleanEntry(readFmtCache('.rstack/cache/fmt/cache.json'), 'index.ts');
+  expectSingleCleanEntry(
+    readFmtCache('.rstack/cache/fmt/cache.json'),
+    'index.ts',
+  );
   expect(readProjectFile('.rstack/cache/fmt-v1.json')).toBe('legacy');
 });
 
@@ -67,52 +82,69 @@ test('--no-cache bypasses cache reads and writes', () => {
   expect(projectFileExists('.rstack/cache/.gitignore')).toBe(false);
 });
 
-test.each(['relative', 'absolute'] as const)('uses a %s custom cache location', (kind) => {
-  const cacheLocation = kind === 'relative' ? 'custom-cache' : resolveProjectPath('custom-cache');
-  writeProjectFile('index.ts', 'const value = 1;\n');
+test.each(['relative', 'absolute'] as const)(
+  'uses a %s custom cache location',
+  (kind) => {
+    const cacheLocation =
+      kind === 'relative' ? 'custom-cache' : resolveProjectPath('custom-cache');
+    writeProjectFile('index.ts', 'const value = 1;\n');
 
-  const result = runFmt(['--cache-location', cacheLocation, 'index.ts']);
+    const result = runFmt(['--cache-location', cacheLocation, 'index.ts']);
 
-  expect(result.status).toBe(0);
-  expectSingleCleanEntry(readFmtCache('custom-cache/cache.json'), 'index.ts');
-  expect(projectFileExists('custom-cache/.gitignore')).toBe(false);
-  expect(projectFileExists('.rstack')).toBe(false);
-});
+    expect(result.status).toBe(0);
+    expectSingleCleanEntry(readFmtCache('custom-cache/cache.json'), 'index.ts');
+    expect(projectFileExists('custom-cache/.gitignore')).toBe(false);
+    expect(projectFileExists('.rstack')).toBe(false);
+  },
+);
 
-test.each(['.', '..'])('rejects a custom cache location at %s', (cacheLocation) => {
-  const result = runFmt(['--cache-location', cacheLocation, '.']);
+test.each(['.', '..'])(
+  'rejects a custom cache location at %s',
+  (cacheLocation) => {
+    const result = runFmt(['--cache-location', cacheLocation, '.']);
 
-  expect(result.status).toBe(2);
-  expect(result.stdout).toBe('');
-  expect(result.stderr).toContain(
-    'The --cache-location directory cannot be the current working directory or an ancestor.',
-  );
-});
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain(
+      'The --cache-location directory cannot be the current working directory or an ancestor.',
+    );
+  },
+);
 
 test('excludes the custom cache directory from formatting', () => {
   const cacheLocation = 'custom-cache';
   writeProjectFile('index.ts', 'const value = 1;\n');
   writeProjectFile('custom-cache/nested/ignored.ts', 'const value=2');
-  expect(runFmt(['--cache-location', cacheLocation, 'index.ts']).status).toBe(0);
+  expect(runFmt(['--cache-location', cacheLocation, 'index.ts']).status).toBe(
+    0,
+  );
 
   const result = runFmt(['--cache-location', cacheLocation, '.']);
 
   expect(result.status).toBe(0);
   expectWriteSummary(result.stdout, 2, 0);
-  expect(readProjectFile('custom-cache/nested/ignored.ts')).toBe('const value=2');
+  expect(readProjectFile('custom-cache/nested/ignored.ts')).toBe(
+    'const value=2',
+  );
 });
 
 test('uses an explicit config root cache from a subdirectory', () => {
   const appPath = resolveProjectPath('packages/app');
   writeProjectFile('packages/app/index.ts', 'const value=1');
 
-  const result = runFmt(['index.ts', '--config', '../../rstack.config.ts'], appPath);
+  const result = runFmt(
+    ['index.ts', '--config', '../../rstack.config.ts'],
+    appPath,
+  );
 
   expect(result.status).toBe(0);
   expect(readProjectFile('packages/app/index.ts')).toBe('const value = 1;\n');
   expect(projectFileExists('.rstack/cache/fmt/cache.json')).toBe(true);
   expect(projectFileExists('packages/app/.rstack')).toBe(false);
-  expectSingleCleanEntry(readFmtCache('.rstack/cache/fmt/cache.json'), 'packages/app/index.ts');
+  expectSingleCleanEntry(
+    readFmtCache('.rstack/cache/fmt/cache.json'),
+    'packages/app/index.ts',
+  );
 });
 
 test('recovers from a corrupted cache', () => {
@@ -123,9 +155,13 @@ test('recovers from a corrupted cache', () => {
   const second = runFmt(['--check', 'index.ts']);
 
   expect(second.status).toBe(0);
-  expect(normalizeDuration(second.stdout)).toBe(normalizeDuration(first.stdout));
+  expect(normalizeDuration(second.stdout)).toBe(
+    normalizeDuration(first.stdout),
+  );
   expect(second.stderr).toBe(first.stderr);
-  expect(JSON.parse(readProjectFile('.rstack/cache/fmt/cache.json'))).toMatchObject({ version: 2 });
+  expect(
+    JSON.parse(readProjectFile('.rstack/cache/fmt/cache.json')),
+  ).toMatchObject({ version: 2 });
 });
 
 test('formats without a writable cache directory', () => {

--- a/packages/rstack/tests/cli/fmt/config.test.ts
+++ b/packages/rstack/tests/cli/fmt/config.test.ts
@@ -6,7 +6,8 @@ import {
   sortedPackageJson,
 } from './helpers.ts';
 
-const { readProjectFile, runFmt, writeFixturePlugin, writeProjectFile } = setupFmtTest();
+const { readProjectFile, runFmt, writeFixturePlugin, writeProjectFile } =
+  setupFmtTest();
 
 test('does not sort package.json by default', () => {
   writeProjectFile('package.json', packageJsonSource);
@@ -35,7 +36,9 @@ define.fmt({ sortPackageJson: true });
   expect(result.status).toBe(0);
   expect(result.stderr).toBe('');
   expect(readProjectFile('package.json')).toBe(sortedPackageJson);
-  expect(readProjectFile('packages/example/package.json')).toBe(sortedPackageJson);
+  expect(readProjectFile('packages/example/package.json')).toBe(
+    sortedPackageJson,
+  );
 });
 
 test('supports configuring the worker count', () => {
@@ -52,17 +55,28 @@ test('supports configuring the worker count', () => {
 });
 
 test('does not load Prettier config or ignore files', () => {
-  writeProjectFile('.prettierrc.json', '{ "singleQuote": true, "semi": false }\n');
+  writeProjectFile(
+    '.prettierrc.json',
+    '{ "singleQuote": true, "semi": false }\n',
+  );
   writeProjectFile('.prettierignore', 'index.ts\n');
-  writeProjectFile('.editorconfig', 'root = true\n\n[*]\nindent_style = space\nindent_size = 8\n');
-  writeProjectFile('index.ts', "function getMessage(){\n        return 'hello'\n}");
+  writeProjectFile(
+    '.editorconfig',
+    'root = true\n\n[*]\nindent_style = space\nindent_size = 8\n',
+  );
+  writeProjectFile(
+    'index.ts',
+    "function getMessage(){\n        return 'hello'\n}",
+  );
 
   const result = runFmt(['index.ts']);
 
   expect(result.status).toBe(0);
   expectWriteSummary(result.stdout, 1, 1);
   expect(result.stderr).toBe('');
-  expect(readProjectFile('index.ts')).toBe('function getMessage() {\n  return "hello";\n}\n');
+  expect(readProjectFile('index.ts')).toBe(
+    'function getMessage() {\n  return "hello";\n}\n',
+  );
 });
 
 test('applies repeated ignore paths', () => {
@@ -84,8 +98,12 @@ test('applies repeated ignore paths', () => {
   expect(result.status).toBe(0);
   expectWriteSummary(result.stdout, 1, 1);
   expect(result.stderr).toBe('');
-  expect(readProjectFile('src/ignored-by-root.ts')).toBe('const root="ignored"');
-  expect(readProjectFile('src/ignored-by-extra.ts')).toBe('const extra="ignored"');
+  expect(readProjectFile('src/ignored-by-root.ts')).toBe(
+    'const root="ignored"',
+  );
+  expect(readProjectFile('src/ignored-by-extra.ts')).toBe(
+    'const extra="ignored"',
+  );
   expect(readProjectFile('src/index.ts')).toBe('const index = "formatted";\n');
 });
 
@@ -96,7 +114,9 @@ test('returns exit code 2 for an unreadable ignore path', () => {
 
   expect(result.status).toBe(2);
   expect(result.stdout).toBe('');
-  expect(result.stderr).toContain('Failed to read ignore file "missing.ignore".');
+  expect(result.stderr).toContain(
+    'Failed to read ignore file "missing.ignore".',
+  );
   expect(readProjectFile('index.ts')).toBe('const value=true');
 });
 
@@ -156,7 +176,10 @@ define.fmt({
 });
 
 test('returns exit code 2 for config errors', () => {
-  writeProjectFile('rstack.config.ts', 'throw new Error("invalid fmt config");\n');
+  writeProjectFile(
+    'rstack.config.ts',
+    'throw new Error("invalid fmt config");\n',
+  );
 
   const result = runFmt(['index.ts']);
 

--- a/packages/rstack/tests/cli/fmt/files.test.ts
+++ b/packages/rstack/tests/cli/fmt/files.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from 'rstack/test';
 import { normalizeHelpOutput } from '#test-helpers';
-import { expectWriteSummary, normalizeDuration, setupFmtTest } from './helpers.ts';
+import {
+  expectWriteSummary,
+  normalizeDuration,
+  setupFmtTest,
+} from './helpers.ts';
 
 const { readProjectFile, runCLI, runFmt, writeProjectFile } = setupFmtTest();
 
@@ -77,7 +81,9 @@ test('formats files in node_modules with --with-node-modules', () => {
   expect(result.status).toBe(0);
   expectWriteSummary(result.stdout, 1, 1);
   expect(result.stderr).toBe('');
-  expect(readProjectFile('node_modules/example/index.ts')).toBe('const message = "hello";\n');
+  expect(readProjectFile('node_modules/example/index.ts')).toBe(
+    'const message = "hello";\n',
+  );
 });
 
 test('summarizes write mode when no files change', () => {
@@ -116,18 +122,21 @@ test('checks formatting without writing files', () => {
   expect(formattedResult.stderr).toBe('');
 });
 
-test.each(['-l', '--list-different'])('lists only paths that differ with %s', (option) => {
-  const source = 'const message="hello"';
-  writeProjectFile('src/index.ts', source);
-  writeProjectFile('src/formatted.ts', 'const formatted = true;\n');
+test.each(['-l', '--list-different'])(
+  'lists only paths that differ with %s',
+  (option) => {
+    const source = 'const message="hello"';
+    writeProjectFile('src/index.ts', source);
+    writeProjectFile('src/formatted.ts', 'const formatted = true;\n');
 
-  const result = runFmt([option, 'src/*.ts']);
+    const result = runFmt([option, 'src/*.ts']);
 
-  expect(result.status).toBe(1);
-  expect(result.stdout).toBe('src/index.ts\n');
-  expect(result.stderr).toBe('');
-  expect(readProjectFile('src/index.ts')).toBe(source);
-});
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('src/index.ts\n');
+    expect(result.stderr).toBe('');
+    expect(readProjectFile('src/index.ts')).toBe(source);
+  },
+);
 
 test('returns exit code 2 for formatting errors', () => {
   writeProjectFile('index.ts', 'const value = ;');

--- a/packages/rstack/tests/cli/fmt/helpers.ts
+++ b/packages/rstack/tests/cli/fmt/helpers.ts
@@ -1,5 +1,12 @@
 import { type SpawnSyncReturns, spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { afterEach, beforeEach, expect } from 'rstack/test';
 import { RSTACK_BIN_PATH } from '#test-helpers';
@@ -9,7 +16,11 @@ export const packageJsonSource =
 export const sortedPackageJson =
   '{\n  "name": "fixture",\n  "version": "1.0.0",\n  "type": "module",\n  "dependencies": {\n    "a": "1.0.0",\n    "z": "1.0.0"\n  }\n}\n';
 
-type RunCLI = (args: string[], input?: string, cwd?: string) => SpawnSyncReturns<string>;
+type RunCLI = (
+  args: string[],
+  input?: string,
+  cwd?: string,
+) => SpawnSyncReturns<string>;
 
 type FmtTestHarness = {
   projectFileExists: (filePath: string) => boolean;
@@ -42,15 +53,19 @@ export const expectWriteSummary = (
   const message = writtenCount
     ? `Formatted ${writtenCount} of ${matchedFileCount} ${files} in <duration>.`
     : `Checked ${matchedFileCount} ${files} in <duration>. No changes needed.`;
-  expect(normalizeDuration(output)).toBe(`start   Formatting...\nsuccess ${message}\n`);
+  expect(normalizeDuration(output)).toBe(
+    `start   Formatting...\nsuccess ${message}\n`,
+  );
 };
 
 export const setupFmtTest = (): FmtTestHarness => {
   let projectPath: string;
 
-  const resolveProjectPath = (filePath: string): string => path.join(projectPath, filePath);
+  const resolveProjectPath = (filePath: string): string =>
+    path.join(projectPath, filePath);
 
-  const projectFileExists = (filePath: string): boolean => existsSync(resolveProjectPath(filePath));
+  const projectFileExists = (filePath: string): boolean =>
+    existsSync(resolveProjectPath(filePath));
 
   const writeProjectFile = (filePath: string, content: string): void => {
     const absolutePath = resolveProjectPath(filePath);
@@ -64,7 +79,10 @@ export const setupFmtTest = (): FmtTestHarness => {
   const writeFixturePlugin = (): void => {
     writeProjectFile(
       'node_modules/prettier-plugin-fixture/package.json',
-      JSON.stringify({ name: 'prettier-plugin-fixture', exports: './index.mjs' }),
+      JSON.stringify({
+        name: 'prettier-plugin-fixture',
+        exports: './index.mjs',
+      }),
     );
     writeProjectFile(
       'node_modules/prettier-plugin-fixture/index.mjs',
@@ -86,7 +104,8 @@ export const setupFmtTest = (): FmtTestHarness => {
   const runFmt = (args: string[] = [], cwd = projectPath) =>
     runCLI(['fmt', ...args], undefined, cwd);
 
-  const runFmtStdin = (args: string[], input: string) => runCLI(['fmt', ...args], input);
+  const runFmtStdin = (args: string[], input: string) =>
+    runCLI(['fmt', ...args], input);
 
   beforeEach(() => {
     projectPath = mkdtempSync(path.join(import.meta.dirname, 'test-temp-fmt-'));

--- a/packages/rstack/tests/cli/fmt/lsp.test.ts
+++ b/packages/rstack/tests/cli/fmt/lsp.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from 'rstack/test';
 import { setupFmtTest } from './helpers.ts';
-import { applyTextEdits, type LspClient, startLspServer, toFileUri } from './lspClient.ts';
+import {
+  applyTextEdits,
+  type LspClient,
+  startLspServer,
+  toFileUri,
+} from './lspClient.ts';
 
 const { resolveProjectPath, runFmt, writeProjectFile } = setupFmtTest();
 
@@ -27,7 +32,11 @@ const withLspServer = async (
   }
 };
 
-const openDocument = (client: LspClient, filePath: string, text: string): string => {
+const openDocument = (
+  client: LspClient,
+  filePath: string,
+  text: string,
+): string => {
   const uri = toFileUri(resolveProjectPath(filePath));
   client.openDocument(uri, 'typescript', text);
 
@@ -87,7 +96,9 @@ test(
 
       const edits = await client.formatDocument(uri);
 
-      expect(applyTextEdits(source, edits)).toBe('const inBuffer = "buffer";\n');
+      expect(applyTextEdits(source, edits)).toBe(
+        'const inBuffer = "buffer";\n',
+      );
     });
   },
   TEST_TIMEOUT,
@@ -252,8 +263,16 @@ test(
     await withLspServer(
       async (client) => {
         await client.initialize(resolveProjectPath('.'));
-        const ignoredUri = openDocument(client, 'src/ignored.ts', 'const ignored="ignored"\n');
-        const formattedUri = openDocument(client, 'src/index.ts', 'const x=1\n');
+        const ignoredUri = openDocument(
+          client,
+          'src/ignored.ts',
+          'const ignored="ignored"\n',
+        );
+        const formattedUri = openDocument(
+          client,
+          'src/index.ts',
+          'const x=1\n',
+        );
 
         expect(await client.formatDocument(ignoredUri)).toEqual([]);
         // The ignore file was read rather than reported as missing.
@@ -330,7 +349,11 @@ define.fmt({ ignorePatterns: ['src/ignored.ts'] });
 
     await withLspServer(async (client) => {
       await client.initialize();
-      const uri = openDocument(client, 'src/ignored.ts', 'const ignored="ignored"\n');
+      const uri = openDocument(
+        client,
+        'src/ignored.ts',
+        'const ignored="ignored"\n',
+      );
 
       expect(await client.formatDocument(uri)).toEqual([]);
     });
@@ -379,12 +402,16 @@ test('returns exit code 2 for file arguments with --lsp', () => {
   const result = runFmt(['--lsp', 'src/index.ts']);
 
   expect(result.status).toBe(2);
-  expect(result.stderr).toContain('The --lsp option cannot be used with file arguments.');
+  expect(result.stderr).toContain(
+    'The --lsp option cannot be used with file arguments.',
+  );
 });
 
 test('returns exit code 2 for --stdin-filepath with --lsp', () => {
   const result = runFmt(['--lsp', '--stdin-filepath', 'src/index.ts']);
 
   expect(result.status).toBe(2);
-  expect(result.stderr).toContain('The --lsp option cannot be used with --stdin-filepath.');
+  expect(result.stderr).toContain(
+    'The --lsp option cannot be used with --stdin-filepath.',
+  );
 });

--- a/packages/rstack/tests/cli/fmt/lspClient.ts
+++ b/packages/rstack/tests/cli/fmt/lspClient.ts
@@ -13,14 +13,19 @@ type JsonRpcMessage = {
 };
 
 export type Position = { line: number; character: number };
-export type TextEdit = { range: { start: Position; end: Position }; newText: string };
+export type TextEdit = {
+  range: { start: Position; end: Position };
+  newText: string;
+};
 
 export type ShownMessage = { type: number; message: string };
 
 export type LspClient = {
   notify: (method: string, params: unknown) => void;
   /** Initializes the server with `root` as the workspace root; defaults to the spawn cwd. */
-  initialize: (root?: string) => Promise<{ capabilities: Record<string, unknown> }>;
+  initialize: (
+    root?: string,
+  ) => Promise<{ capabilities: Record<string, unknown> }>;
   openDocument: (uri: string, languageId: string, text: string) => void;
   formatDocument: (uri: string) => Promise<TextEdit[]>;
   /** `window/showMessage` notifications received so far, in order. */
@@ -34,13 +39,19 @@ const CONTENT_LENGTH_REGEXP = /content-length:\s*(\d+)/i;
 /** A header block is `key: value` lines separated by `\r\n` and nothing else. */
 const HEADER_BLOCK_REGEXP = /^[^\r\n:]+:[^\r\n]*(?:\r\n[^\r\n:]+:[^\r\n]*)*$/;
 
-export const toFileUri = (filePath: string): string => pathToFileURL(filePath).href;
+export const toFileUri = (filePath: string): string =>
+  pathToFileURL(filePath).href;
 
 /** Applies LSP text edits to a document, mirroring an editor. */
 export const applyTextEdits = (text: string, edits: TextEdit[]): string =>
-  TextDocument.applyEdits(TextDocument.create('file:///document', 'plaintext', 1, text), edits);
+  TextDocument.applyEdits(
+    TextDocument.create('file:///document', 'plaintext', 1, text),
+    edits,
+  );
 
-const readMessage = (buffer: Buffer): { message: JsonRpcMessage; rest: Buffer } | undefined => {
+const readMessage = (
+  buffer: Buffer,
+): { message: JsonRpcMessage; rest: Buffer } | undefined => {
   const headerEnd = buffer.indexOf('\r\n\r\n');
   if (headerEnd === -1) {
     return undefined;
@@ -50,7 +61,9 @@ const readMessage = (buffer: Buffer): { message: JsonRpcMessage; rest: Buffer } 
   // Real clients fall out of sync here, so anything that is not a header is a
   // failure rather than something to skip over.
   if (!HEADER_BLOCK_REGEXP.test(headers)) {
-    throw new Error(`Unexpected bytes on stdout before a message: ${JSON.stringify(headers)}.`);
+    throw new Error(
+      `Unexpected bytes on stdout before a message: ${JSON.stringify(headers)}.`,
+    );
   }
 
   const contentLength = CONTENT_LENGTH_REGEXP.exec(headers);
@@ -65,7 +78,9 @@ const readMessage = (buffer: Buffer): { message: JsonRpcMessage; rest: Buffer } 
   }
 
   return {
-    message: JSON.parse(buffer.subarray(bodyStart, bodyEnd).toString('utf8')) as JsonRpcMessage,
+    message: JSON.parse(
+      buffer.subarray(bodyStart, bodyEnd).toString('utf8'),
+    ) as JsonRpcMessage,
     rest: buffer.subarray(bodyEnd),
   };
 };
@@ -128,18 +143,26 @@ export const startLspServer = (cwd: string, args: string[] = []): LspClient => {
   const closed = new Promise<number | null>((resolve) => {
     childProcess.once('close', (code) => {
       exitCode = code;
-      fail(new Error(`The language server exited with code ${code}.\n${stderr}`));
+      fail(
+        new Error(`The language server exited with code ${code}.\n${stderr}`),
+      );
       resolve(code);
     });
   });
 
   const send = (message: Record<string, unknown>): void => {
-    const body = Buffer.from(JSON.stringify({ jsonrpc: '2.0', ...message }), 'utf8');
+    const body = Buffer.from(
+      JSON.stringify({ jsonrpc: '2.0', ...message }),
+      'utf8',
+    );
     childProcess.stdin.write(`Content-Length: ${body.byteLength}\r\n\r\n`);
     childProcess.stdin.write(body);
   };
 
-  const request = <Result>(method: string, params: unknown): Promise<Result> => {
+  const request = <Result>(
+    method: string,
+    params: unknown,
+  ): Promise<Result> => {
     if (failure) {
       return Promise.reject(failure);
     }
@@ -147,7 +170,10 @@ export const startLspServer = (cwd: string, args: string[] = []): LspClient => {
     const id = nextId++;
 
     return new Promise<Result>((resolve, reject) => {
-      pending.set(id, { resolve: resolve as (result: unknown) => void, reject });
+      pending.set(id, {
+        resolve: resolve as (result: unknown) => void,
+        reject,
+      });
       send({ id, method, params });
     });
   };

--- a/packages/rstack/tests/cli/fmt/patterns.test.ts
+++ b/packages/rstack/tests/cli/fmt/patterns.test.ts
@@ -19,7 +19,11 @@ test('returns exit code 2 when no files match', () => {
 
 test('allows no files to match with --no-error-on-unmatched-pattern', () => {
   for (const modeArgs of [[], ['--check'], ['--list-different']]) {
-    const result = runFmt([...modeArgs, '--no-error-on-unmatched-pattern', 'missing/**/*.ts']);
+    const result = runFmt([
+      ...modeArgs,
+      '--no-error-on-unmatched-pattern',
+      'missing/**/*.ts',
+    ]);
 
     expect(result.status).toBe(0);
     expect(result.stdout).toBe('');
@@ -78,7 +82,9 @@ test('supports -u as an alias for --ignore-unknown', () => {
   const result = runFmt(['-u', 'notes.unknown']);
 
   expect(result.status).toBe(0);
-  expect(result.stdout).toBe('start   Formatting...\nsuccess No supported files to format.\n');
+  expect(result.stdout).toBe(
+    'start   Formatting...\nsuccess No supported files to format.\n',
+  );
   expect(result.stderr).toBe('');
 });
 
@@ -87,7 +93,9 @@ test('does not treat unmatched patterns as unknown files', () => {
 
   expect(result.status).toBe(2);
   expect(result.stdout).toBe('');
-  expect(result.stderr).toContain('No supported files matched "missing/**/*.unknown"');
+  expect(result.stderr).toContain(
+    'No supported files matched "missing/**/*.unknown"',
+  );
 });
 
 test('does not treat unsupported files as unmatched patterns', () => {

--- a/packages/rstack/tests/cli/fmt/stdin.test.ts
+++ b/packages/rstack/tests/cli/fmt/stdin.test.ts
@@ -1,10 +1,17 @@
 import { expect, test } from 'rstack/test';
-import { packageJsonSource, setupFmtTest, sortedPackageJson } from './helpers.ts';
+import {
+  packageJsonSource,
+  setupFmtTest,
+  sortedPackageJson,
+} from './helpers.ts';
 
 const { projectFileExists, runFmtStdin, writeProjectFile } = setupFmtTest();
 
 test('formats stdin for the given filepath', () => {
-  const result = runFmtStdin(['--stdin-filepath', 'src/index.ts'], 'const message="hello"');
+  const result = runFmtStdin(
+    ['--stdin-filepath', 'src/index.ts'],
+    'const message="hello"',
+  );
 
   expect(result.status).toBe(0);
   expect(result.stdout).toBe('const message = "hello";\n');
@@ -31,7 +38,10 @@ define.fmt({
 `,
   );
 
-  const result = runFmtStdin(['--stdin-filepath', 'src/index.test.ts'], 'const test="test"');
+  const result = runFmtStdin(
+    ['--stdin-filepath', 'src/index.test.ts'],
+    'const test="test"',
+  );
 
   expect(result.status).toBe(0);
   expect(result.stdout).toBe("const test = 'test'\n");
@@ -47,7 +57,10 @@ define.fmt({ sortPackageJson: true });
 `,
   );
 
-  const result = runFmtStdin(['--stdin-filepath', 'package.json'], packageJsonSource);
+  const result = runFmtStdin(
+    ['--stdin-filepath', 'package.json'],
+    packageJsonSource,
+  );
 
   expect(result.status).toBe(0);
   expect(result.stdout).toBe(sortedPackageJson);
@@ -99,11 +112,16 @@ test('returns exit code 2 when no parser can be inferred for stdin', () => {
 
   expect(result.status).toBe(2);
   expect(result.stdout).toBe('');
-  expect(result.stderr).toContain('No parser could be inferred for "data.unknown".');
+  expect(result.stderr).toContain(
+    'No parser could be inferred for "data.unknown".',
+  );
 });
 
 test('ignores stdin when no parser can be inferred with --ignore-unknown', () => {
-  const result = runFmtStdin(['--stdin-filepath', 'data.unknown', '--ignore-unknown'], 'value');
+  const result = runFmtStdin(
+    ['--stdin-filepath', 'data.unknown', '--ignore-unknown'],
+    'value',
+  );
 
   expect(result.status).toBe(0);
   expect(result.stdout).toBe('');
@@ -111,7 +129,10 @@ test('ignores stdin when no parser can be inferred with --ignore-unknown', () =>
 });
 
 test('returns exit code 2 for stdin parse errors', () => {
-  const result = runFmtStdin(['--stdin-filepath', 'index.ts'], 'const value = ;');
+  const result = runFmtStdin(
+    ['--stdin-filepath', 'index.ts'],
+    'const value = ;',
+  );
 
   expect(result.status).toBe(2);
   expect(result.stdout).toBe('');
@@ -121,7 +142,10 @@ test('returns exit code 2 for stdin parse errors', () => {
 test.each(['--write', '--check', '--list-different'])(
   'returns exit code 2 for %s with --stdin-filepath',
   (option) => {
-    const result = runFmtStdin(['--stdin-filepath', 'index.ts', option], 'const value=1');
+    const result = runFmtStdin(
+      ['--stdin-filepath', 'index.ts', option],
+      'const value=1',
+    );
 
     expect(result.status).toBe(2);
     expect(result.stdout).toBe('');
@@ -132,7 +156,10 @@ test.each(['--write', '--check', '--list-different'])(
 );
 
 test('returns exit code 2 for file arguments with --stdin-filepath', () => {
-  const result = runFmtStdin(['--stdin-filepath', 'index.ts', 'src/other.ts'], 'const value=1');
+  const result = runFmtStdin(
+    ['--stdin-filepath', 'index.ts', 'src/other.ts'],
+    'const value=1',
+  );
 
   expect(result.status).toBe(2);
   expect(result.stdout).toBe('');

--- a/packages/rstack/tests/cli/fmt/vue.test.ts
+++ b/packages/rstack/tests/cli/fmt/vue.test.ts
@@ -6,13 +6,17 @@ const { readProjectFile, runFmt, writeProjectFile } = setupFmtTest();
 test.each([
   {
     name: 'TypeScript',
-    source: '<script setup lang="ts">\nconst title=ref<string>("Rstack + Vue")\n</script>\n',
-    expected: '<script setup lang="ts">\nconst title = ref<string>("Rstack + Vue");\n</script>\n',
+    source:
+      '<script setup lang="ts">\nconst title=ref<string>("Rstack + Vue")\n</script>\n',
+    expected:
+      '<script setup lang="ts">\nconst title = ref<string>("Rstack + Vue");\n</script>\n',
   },
   {
     name: 'TSX',
-    source: '<script setup lang="tsx">\nconst view=<Component value={1}/>\n</script>\n',
-    expected: '<script setup lang="tsx">\nconst view = <Component value={1} />;\n</script>\n',
+    source:
+      '<script setup lang="tsx">\nconst view=<Component value={1}/>\n</script>\n',
+    expected:
+      '<script setup lang="tsx">\nconst view = <Component value={1} />;\n</script>\n',
   },
 ])('formats $name embedded in Vue files', ({ source, expected }) => {
   writeProjectFile('App.vue', source);

--- a/packages/rstack/tests/cli/setup/index.test.ts
+++ b/packages/rstack/tests/cli/setup/index.test.ts
@@ -1,5 +1,11 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { afterEach, beforeEach } from 'rstack/test';
 import { normalizeHelpOutput, RSTACK_BIN_PATH, test } from '#test-helpers';
@@ -61,7 +67,9 @@ test('reports missing and repeated hooks directory options', ({ expect }) => {
 
   const repeated = runSetup(['--hooks-dir', 'first', '--hooks-dir', 'second']);
   expect(repeated.status).toBe(1);
-  expect(repeated.stderr).toContain('The --hooks-dir option cannot be specified more than once.');
+  expect(repeated.stderr).toContain(
+    'The --hooks-dir option cannot be specified more than once.',
+  );
 });
 
 test('rejects invalid hooks directory options', ({ expect }) => {
@@ -80,27 +88,42 @@ test('rejects invalid hooks directory options', ({ expect }) => {
   expect(parent.stderr).toContain('Git hooks directory must not contain "..".');
 });
 
-test('installs hooks silently without loading Rstack config', ({ execCli, expect }) => {
+test('installs hooks silently without loading Rstack config', ({
+  execCli,
+  expect,
+}) => {
   initRepository();
-  writeFileSync(path.join(cwd, 'rstack.config.ts'), 'throw new Error("must not load");\n');
+  writeFileSync(
+    path.join(cwd, 'rstack.config.ts'),
+    'throw new Error("must not load");\n',
+  );
 
   expect(execCli('setup', { cwd, env })).toBe('');
   expect(git(['config', '--local', '--get', 'core.hooksPath'])).toBe(hooksPath);
   expect(existsSync(path.join(cwd, hooksPath, 'runner'))).toBe(true);
-  expect(existsSync(path.join(cwd, '.rstack', 'hooks', 'pre-commit'))).toBe(false);
+  expect(existsSync(path.join(cwd, '.rstack', 'hooks', 'pre-commit'))).toBe(
+    false,
+  );
 
   expect(execCli('setup', { cwd, env })).toBe('');
 });
 
-test('installs root-relative hooks and reports owner conflicts', ({ execCli, expect }) => {
+test('installs root-relative hooks and reports owner conflicts', ({
+  execCli,
+  expect,
+}) => {
   initRepository();
   const frontend = path.join(cwd, 'frontend');
   const docs = path.join(cwd, 'docs');
   mkdirSync(frontend);
   mkdirSync(docs);
 
-  expect(execCli('setup --hooks-dir "custom hooks"', { cwd: frontend, env })).toBe('');
-  expect(git(['config', '--local', '--get', 'core.hooksPath'])).toBe('custom hooks/_');
+  expect(
+    execCli('setup --hooks-dir "custom hooks"', { cwd: frontend, env }),
+  ).toBe('');
+  expect(git(['config', '--local', '--get', 'core.hooksPath'])).toBe(
+    'custom hooks/_',
+  );
   expect(existsSync(path.join(cwd, 'custom hooks', '_', 'runner'))).toBe(true);
 
   const conflict = runSetup(['--hooks-dir', 'custom hooks'], docs);
@@ -110,7 +133,10 @@ test('installs root-relative hooks and reports owner conflicts', ({ execCli, exp
   );
 });
 
-test('skips non-Git directories without creating files', ({ execCli, expect }) => {
+test('skips non-Git directories without creating files', ({
+  execCli,
+  expect,
+}) => {
   expect(execCli('setup', { cwd, env })).toContain(
     'info    Git hooks setup skipped: not a Git repository.',
   );
@@ -120,7 +146,9 @@ test('skips non-Git directories without creating files', ({ execCli, expect }) =
 test('skips setup when hooks are disabled', ({ execCli, expect }) => {
   const output = execCli('setup', { cwd, env: { ...env, RSTACK_HOOKS: '0' } });
 
-  expect(output).toContain('info    Git hooks setup skipped: disabled by RSTACK_HOOKS.');
+  expect(output).toContain(
+    'info    Git hooks setup skipped: disabled by RSTACK_HOOKS.',
+  );
   expect(existsSync(path.join(cwd, '.rstack'))).toBe(false);
 });
 

--- a/packages/rstack/tests/cli/specify-config/index.test.ts
+++ b/packages/rstack/tests/cli/specify-config/index.test.ts
@@ -1,7 +1,11 @@
 import { getDistFiles, getFileContent } from '@rstackjs/test-utils';
 import { test } from '#test-helpers';
 
-test('should build with rstack --config', async ({ prepareDist, execCli, expect }) => {
+test('should build with rstack --config', async ({
+  prepareDist,
+  execCli,
+  expect,
+}) => {
   const distPath = await prepareDist();
 
   execCli('build --config ./custom.config.ts');

--- a/packages/rstack/tests/cli/staged/fmt.test.ts
+++ b/packages/rstack/tests/cli/staged/fmt.test.ts
@@ -21,7 +21,9 @@ const git = (args: string[]): string => {
   });
 
   if (result.status !== 0) {
-    throw new Error(result.stderr || `Git exited with status ${result.status}.`);
+    throw new Error(
+      result.stderr || `Git exited with status ${result.status}.`,
+    );
   }
 
   return result.stdout;
@@ -35,7 +37,9 @@ const runStaged = () =>
   });
 
 beforeEach(() => {
-  projectPath = mkdtempSync(path.join(import.meta.dirname, 'test-temp-staged-fmt-'));
+  projectPath = mkdtempSync(
+    path.join(import.meta.dirname, 'test-temp-staged-fmt-'),
+  );
   env = {
     ...process.env,
     GIT_CONFIG_GLOBAL: path.join(projectPath, 'global.gitconfig'),
@@ -74,11 +78,21 @@ test('formats staged files with rs fmt and applies ignore rules', () => {
   const result = runStaged();
 
   expect(result.status).toBe(0);
-  expect(readProjectFile('file with spaces.ts')).toBe('const spaced = "spaced";\n');
-  expect(readProjectFile('ignored-by-git.ts')).toBe('const gitIgnored = "git ignored";\n');
-  expect(readProjectFile('ignored-by-fmt.ts')).toBe('const fmtIgnored="fmt ignored"');
-  expect(git(['show', ':file with spaces.ts'])).toBe('const spaced = "spaced";\n');
-  expect(git(['show', ':ignored-by-git.ts'])).toBe('const gitIgnored = "git ignored";\n');
+  expect(readProjectFile('file with spaces.ts')).toBe(
+    'const spaced = "spaced";\n',
+  );
+  expect(readProjectFile('ignored-by-git.ts')).toBe(
+    'const gitIgnored = "git ignored";\n',
+  );
+  expect(readProjectFile('ignored-by-fmt.ts')).toBe(
+    'const fmtIgnored="fmt ignored"',
+  );
+  expect(git(['show', ':file with spaces.ts'])).toBe(
+    'const spaced = "spaced";\n',
+  );
+  expect(git(['show', ':ignored-by-git.ts'])).toBe(
+    'const gitIgnored = "git ignored";\n',
+  );
 });
 
 test('allows rs fmt when all staged files are ignored', () => {
@@ -91,7 +105,9 @@ test('allows rs fmt when all staged files are ignored', () => {
   expect(result.status).toBe(0);
   expect(readProjectFile('ignored-by-fmt.ts')).toBe(source);
   expect(git(['show', ':ignored-by-fmt.ts'])).toBe(source);
-  expect(`${result.stdout}\n${result.stderr}`).not.toContain('No supported files matched');
+  expect(`${result.stdout}\n${result.stderr}`).not.toContain(
+    'No supported files matched',
+  );
 });
 
 test('still rejects staged files unsupported by rs fmt', () => {
@@ -101,7 +117,9 @@ test('still rejects staged files unsupported by rs fmt', () => {
   const result = runStaged();
 
   expect(result.status).toBe(1);
-  expect(`${result.stdout}\n${result.stderr}`).toContain('No supported files matched');
+  expect(`${result.stdout}\n${result.stderr}`).toContain(
+    'No supported files matched',
+  );
 });
 
 test('allows staged files unsupported by rs fmt with --ignore-unknown', () => {
@@ -120,7 +138,9 @@ define.staged({
   const result = runStaged();
 
   expect(result.status).toBe(0);
-  expect(`${result.stdout}\n${result.stderr}`).not.toContain('No supported files matched');
+  expect(`${result.stdout}\n${result.stderr}`).not.toContain(
+    'No supported files matched',
+  );
 });
 
 test('propagates rs fmt failures', () => {

--- a/packages/rstack/tests/config/define-app-lib/index.test.ts
+++ b/packages/rstack/tests/config/define-app-lib/index.test.ts
@@ -1,5 +1,7 @@
 import { test } from '#test-helpers';
 
-test('should prefer define.app when app and lib are both defined', ({ execCli }) => {
+test('should prefer define.app when app and lib are both defined', ({
+  execCli,
+}) => {
   execCli('test');
 });

--- a/packages/rstack/tests/config/define-app/index.test.ts
+++ b/packages/rstack/tests/config/define-app/index.test.ts
@@ -4,7 +4,11 @@ import { test } from '#test-helpers';
 
 const expectedText = 'define.app works';
 
-test('should build app with define.app config', async ({ prepareDist, execCli, expect }) => {
+test('should build app with define.app config', async ({
+  prepareDist,
+  execCli,
+  expect,
+}) => {
   const distPath = await prepareDist();
 
   try {

--- a/packages/rstack/tests/config/define-doc/index.test.ts
+++ b/packages/rstack/tests/config/define-doc/index.test.ts
@@ -3,7 +3,11 @@ import { test } from '#test-helpers';
 
 const expectedText = 'define.doc works';
 
-test('should build docs with define.doc config', async ({ prepareDist, execCli, expect }) => {
+test('should build docs with define.doc config', async ({
+  prepareDist,
+  execCli,
+  expect,
+}) => {
   const distPath = await prepareDist('doc_build');
 
   execCli('doc build');

--- a/packages/rstack/tests/config/define-lib/index.test.ts
+++ b/packages/rstack/tests/config/define-lib/index.test.ts
@@ -3,7 +3,11 @@ import { test } from '#test-helpers';
 
 const expectedText = 'define.lib works';
 
-test('should build lib with define.lib config', async ({ prepareDist, execCli, expect }) => {
+test('should build lib with define.lib config', async ({
+  prepareDist,
+  execCli,
+  expect,
+}) => {
   const distPath = await prepareDist();
 
   execCli('lib');

--- a/packages/rstack/tests/config/define-lint/index.test.ts
+++ b/packages/rstack/tests/config/define-lint/index.test.ts
@@ -7,7 +7,11 @@ test('should run lint with define.lint config', ({ execCli }) => {
   execCli('lint src/index.js');
 });
 
-test('should fail when lint reports errors', async ({ cwd, execCli, logHelper }) => {
+test('should fail when lint reports errors', async ({
+  cwd,
+  execCli,
+  logHelper,
+}) => {
   const filePath = path.join(cwd, 'src/test-temp-error.js');
   await writeFile(filePath, 'debugger;');
   expect(() => execCli('lint src/test-temp-error.js')).toThrow();

--- a/packages/rstack/tests/config/define-test-projects-app/index.test.ts
+++ b/packages/rstack/tests/config/define-test-projects-app/index.test.ts
@@ -1,5 +1,7 @@
 import { test } from '#test-helpers';
 
-test('should apply define.app config to every inline test project', ({ execCli }) => {
+test('should apply define.app config to every inline test project', ({
+  execCli,
+}) => {
   execCli('test');
 });

--- a/packages/rstack/tests/config/define-test-projects-lib/index.test.ts
+++ b/packages/rstack/tests/config/define-test-projects-lib/index.test.ts
@@ -1,5 +1,7 @@
 import { test } from '#test-helpers';
 
-test('should apply define.lib config to every inline test project', ({ execCli }) => {
+test('should apply define.lib config to every inline test project', ({
+  execCli,
+}) => {
   execCli('test');
 });

--- a/packages/rstack/tests/config/load-config/index.test.ts
+++ b/packages/rstack/tests/config/load-config/index.test.ts
@@ -15,7 +15,8 @@ declare global {
 }
 
 const state = getConfigState();
-const configPath = (fileName: string): string => path.join(import.meta.dirname, fileName);
+const configPath = (fileName: string): string =>
+  path.join(import.meta.dirname, fileName);
 const loadConfigFile = (fileName: string) =>
   loadRstackConfig({ configFilePath: configPath(fileName) });
 
@@ -62,7 +63,9 @@ test('should resolve a relative explicit config path from cwd', async () => {
 });
 
 test('should search for the config file in cwd', async () => {
-  await expect(loadRstackConfig({ cwd: import.meta.dirname })).rejects.toThrow('test config error');
+  await expect(loadRstackConfig({ cwd: import.meta.dirname })).rejects.toThrow(
+    'test config error',
+  );
 });
 
 test('should isolate parallel config sessions across top-level await', async () => {

--- a/packages/rstack/tests/config/reload-app-config/index.test.ts
+++ b/packages/rstack/tests/config/reload-app-config/index.test.ts
@@ -9,7 +9,10 @@ test('should restart dev server and reload config when Rstack config changes', a
 }) => {
   const dist1 = await prepareDist();
   const dist2 = await prepareDist('dist-2');
-  const configFile = path.join(import.meta.dirname, 'test-temp-rstack.config.ts');
+  const configFile = path.join(
+    import.meta.dirname,
+    'test-temp-rstack.config.ts',
+  );
 
   await writeFile(
     configFile,
@@ -47,8 +50,14 @@ define.app({
   await waitForFile(dist2);
 });
 
-test('should reload config when an imported file changes', async ({ execCliAsync, logHelper }) => {
-  const configFile = path.join(import.meta.dirname, 'test-temp-import.config.ts');
+test('should reload config when an imported file changes', async ({
+  execCliAsync,
+  logHelper,
+}) => {
+  const configFile = path.join(
+    import.meta.dirname,
+    'test-temp-import.config.ts',
+  );
   const importedFile = path.join(import.meta.dirname, 'test-temp-imported.ts');
 
   await writeFile(importedFile, '');
@@ -69,5 +78,7 @@ define.app({
 
   await writeFile(importedFile, '// changed\n');
 
-  await logHelper.expectLog('restarting server as test-temp-imported.ts changed');
+  await logHelper.expectLog(
+    'restarting server as test-temp-imported.ts changed',
+  );
 });

--- a/packages/rstack/tests/config/reload-doc-config/index.test.ts
+++ b/packages/rstack/tests/config/reload-doc-config/index.test.ts
@@ -7,8 +7,14 @@ test('should restart doc dev server when Rstack config changes', async ({
   execCliAsync,
   logHelper,
 }) => {
-  const configFile = path.join(import.meta.dirname, 'test-temp-rstack.config.ts');
-  const userWatchFile = path.join(import.meta.dirname, 'test-temp-user-watch.txt');
+  const configFile = path.join(
+    import.meta.dirname,
+    'test-temp-rstack.config.ts',
+  );
+  const userWatchFile = path.join(
+    import.meta.dirname,
+    'test-temp-user-watch.txt',
+  );
 
   const writeConfig = (title: string) =>
     writeFile(
@@ -33,19 +39,25 @@ define.doc({
   await writeFile(userWatchFile, 'initial\n');
   await writeConfig('before config change');
 
-  execCliAsync(`doc --config test-temp-rstack.config.ts --port ${await getRandomPort()}`);
+  execCliAsync(
+    `doc --config test-temp-rstack.config.ts --port ${await getRandomPort()}`,
+  );
   await logHelper.expectBuildEnd();
   logHelper.clearLogs();
 
   await writeConfig('after config change');
 
-  await logHelper.expectLog('restarting server as test-temp-rstack.config.ts changed');
+  await logHelper.expectLog(
+    'restarting server as test-temp-rstack.config.ts changed',
+  );
   await logHelper.expectBuildEnd();
   logHelper.clearLogs();
 
   await writeFile(userWatchFile, 'changed\n');
 
-  await logHelper.expectLog('restarting server as test-temp-user-watch.txt changed');
+  await logHelper.expectLog(
+    'restarting server as test-temp-user-watch.txt changed',
+  );
   await logHelper.expectBuildEnd();
 });
 
@@ -53,10 +65,16 @@ test('should restart doc dev server when an imported config file changes', async
   execCliAsync,
   logHelper,
 }) => {
-  const configFile = path.join(import.meta.dirname, 'test-temp-import.config.ts');
+  const configFile = path.join(
+    import.meta.dirname,
+    'test-temp-import.config.ts',
+  );
   const importedFile = path.join(import.meta.dirname, 'test-temp-imported.ts');
 
-  await writeFile(importedFile, "export const title = 'before import change';\n");
+  await writeFile(
+    importedFile,
+    "export const title = 'before import change';\n",
+  );
   await writeFile(
     configFile,
     `import { define } from 'rstack';
@@ -69,12 +87,19 @@ define.doc({
 `,
   );
 
-  execCliAsync(`doc --config test-temp-import.config.ts --port ${await getRandomPort()}`);
+  execCliAsync(
+    `doc --config test-temp-import.config.ts --port ${await getRandomPort()}`,
+  );
   await logHelper.expectBuildEnd();
   logHelper.clearLogs();
 
-  await writeFile(importedFile, "export const title = 'after import change';\n");
+  await writeFile(
+    importedFile,
+    "export const title = 'after import change';\n",
+  );
 
-  await logHelper.expectLog('restarting server as test-temp-imported.ts changed');
+  await logHelper.expectLog(
+    'restarting server as test-temp-imported.ts changed',
+  );
   await logHelper.expectBuildEnd();
 });

--- a/packages/rstack/tests/config/reload-lib-config/index.test.ts
+++ b/packages/rstack/tests/config/reload-lib-config/index.test.ts
@@ -10,8 +10,14 @@ test('should restart lib watch build when Rstack config changes', async ({
 }) => {
   const dist1 = await prepareDist();
   const dist2 = await prepareDist('dist-2');
-  const configFile = path.join(import.meta.dirname, 'test-temp-rstack.config.ts');
-  const userWatchFile = path.join(import.meta.dirname, 'test-temp-user-watch.txt');
+  const configFile = path.join(
+    import.meta.dirname,
+    'test-temp-rstack.config.ts',
+  );
+  const userWatchFile = path.join(
+    import.meta.dirname,
+    'test-temp-user-watch.txt',
+  );
 
   const writeConfig = (distPath: string) =>
     writeFile(
@@ -42,14 +48,18 @@ define.lib({
 
   await writeConfig('dist-2');
 
-  await logHelper.expectLog('restarting build as test-temp-rstack.config.ts changed');
+  await logHelper.expectLog(
+    'restarting build as test-temp-rstack.config.ts changed',
+  );
   await logHelper.expectLog('build completed, watching for changes...');
   await waitForFile(path.join(dist2, 'index.js'));
   logHelper.clearLogs();
 
   await writeFile(userWatchFile, 'changed\n');
 
-  await logHelper.expectLog('restarting build as test-temp-user-watch.txt changed');
+  await logHelper.expectLog(
+    'restarting build as test-temp-user-watch.txt changed',
+  );
   await logHelper.expectLog('build completed, watching for changes...');
 });
 
@@ -60,7 +70,10 @@ test('should restart lib watch build when an imported config file changes', asyn
 }) => {
   const dist1 = await prepareDist('dist-import-1');
   const dist2 = await prepareDist('dist-import-2');
-  const configFile = path.join(import.meta.dirname, 'test-temp-import.config.ts');
+  const configFile = path.join(
+    import.meta.dirname,
+    'test-temp-import.config.ts',
+  );
   const importedFile = path.join(import.meta.dirname, 'test-temp-imported.ts');
 
   await writeFile(importedFile, "export const distPath = 'dist-import-1';\n");
@@ -84,7 +97,9 @@ define.lib({
 
   await writeFile(importedFile, "export const distPath = 'dist-import-2';\n");
 
-  await logHelper.expectLog('restarting build as test-temp-imported.ts changed');
+  await logHelper.expectLog(
+    'restarting build as test-temp-imported.ts changed',
+  );
   await logHelper.expectLog('build completed, watching for changes...');
   await waitForFile(path.join(dist2, 'index.js'));
 });

--- a/packages/rstack/tests/exports/test-subpath/index.test.ts
+++ b/packages/rstack/tests/exports/test-subpath/index.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from 'rstack/test';
 
-const commonTestMethods = ['test', 'it', 'describe', 'expect', 'beforeAll', 'afterAll'] as const;
+const commonTestMethods = [
+  'test',
+  'it',
+  'describe',
+  'expect',
+  'beforeAll',
+  'afterAll',
+] as const;
 
 test('should expose test APIs from `rstack/test`', async () => {
   const test = await import('rstack/test');

--- a/packages/rstack/tests/fmt/cacheIdentity.test.ts
+++ b/packages/rstack/tests/fmt/cacheIdentity.test.ts
@@ -54,7 +54,9 @@ test('includes plugin fingerprints in option hashes', () => {
   const second = createOptionsHasher(new Map([[plugin, 'plugin@2']]));
 
   expect(first({ plugins: [plugin] })).toHaveLength(cacheHashLength);
-  expect(first({ plugins: [new URL(plugin)] })).toBe(first({ plugins: [plugin] }));
+  expect(first({ plugins: [new URL(plugin)] })).toBe(
+    first({ plugins: [plugin] }),
+  );
   expect(first({ plugins: [plugin] })).not.toBe(second({ plugins: [plugin] }));
 });
 
@@ -71,8 +73,12 @@ test('bypasses user plugins and unserializable options', () => {
   );
   cyclic.self = cyclic;
 
-  expect(hashOptions({ plugins: [path.resolve('plugin.mjs')] })).toBeUndefined();
-  expect(hashOptions({ plugins: [pathToFileURL(path.resolve('plugin.mjs'))] })).toBeUndefined();
+  expect(
+    hashOptions({ plugins: [path.resolve('plugin.mjs')] }),
+  ).toBeUndefined();
+  expect(
+    hashOptions({ plugins: [pathToFileURL(path.resolve('plugin.mjs'))] }),
+  ).toBeUndefined();
 
   expect(hashOptions(asOptions({ custom: cyclic }))).toBeUndefined();
   expect(hashOptions(asOptions(unreadable))).toBeUndefined();
@@ -94,5 +100,7 @@ test('creates config-root-relative POSIX cache keys', () => {
   expect(resolveKey(firstPath)).toBe('src/nested/index.ts');
   expect(resolveKey(secondPath)).toBe('src/other.ts');
   expect(resolveKey(firstPath)).not.toBe(resolveKey(secondPath));
-  expect(resolveKey(path.join(rootPath, '../shared/index.ts'))).toBe('../shared/index.ts');
+  expect(resolveKey(path.join(rootPath, '../shared/index.ts'))).toBe(
+    '../shared/index.ts',
+  );
 });

--- a/packages/rstack/tests/fmt/cacheStore.test.ts
+++ b/packages/rstack/tests/fmt/cacheStore.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { expect, test } from 'rstack/test';
 import {
@@ -144,6 +150,8 @@ test('does not throw or leave temporary files when persistence fails', async () 
     store.set('src/a.ts', firstEntry);
 
     await expect(store.save()).resolves.toBe(false);
-    expect(readdirSync(rootPath).filter((name) => name.endsWith('.tmp'))).toEqual([]);
+    expect(
+      readdirSync(rootPath).filter((name) => name.endsWith('.tmp')),
+    ).toEqual([]);
   });
 });

--- a/packages/rstack/tests/fmt/config.test.ts
+++ b/packages/rstack/tests/fmt/config.test.ts
@@ -1,6 +1,9 @@
 import path from 'node:path';
 import { expect, test } from 'rstack/test';
-import { createOptionsResolver, normalizeFmtConfig } from '../../src/fmt/config.ts';
+import {
+  createOptionsResolver,
+  normalizeFmtConfig,
+} from '../../src/fmt/config.ts';
 
 const rootPath = path.join(import.meta.dirname, 'project');
 
@@ -14,7 +17,9 @@ test('reuses base options when no override matches', () => {
   );
   const resolveOptions = createOptionsResolver(config);
 
-  expect(resolveOptions(path.join(rootPath, 'index.js'))).toBe(config.baseOptions);
+  expect(resolveOptions(path.join(rootPath, 'index.js'))).toBe(
+    config.baseOptions,
+  );
 });
 
 test('applies basename and path overrides in declaration order', () => {
@@ -82,5 +87,7 @@ test('applies overrides outside the config root', () => {
   );
   const resolveOptions = createOptionsResolver(config);
 
-  expect(resolveOptions(path.join(rootPath, '../shared/index.ts'))).toEqual({ semi: false });
+  expect(resolveOptions(path.join(rootPath, '../shared/index.ts'))).toEqual({
+    semi: false,
+  });
 });

--- a/packages/rstack/tests/fmt/discoverPaths.test.ts
+++ b/packages/rstack/tests/fmt/discoverPaths.test.ts
@@ -20,7 +20,10 @@ test('discovers non-binary files in stable order and skips hard-ignored paths', 
     writeProjectFile(rootPath, '.jj/internal.js');
 
     const files = await discoverFmtPaths({ cwd: rootPath });
-    const filesWithNodeModules = await discoverFmtPaths({ cwd: rootPath, withNodeModules: true });
+    const filesWithNodeModules = await discoverFmtPaths({
+      cwd: rootPath,
+      withNodeModules: true,
+    });
 
     expect(relativePaths(rootPath, files)).toEqual([
       'a.js',
@@ -36,7 +39,10 @@ test('discovers non-binary files in stable order and skips hard-ignored paths', 
       'unknown.extension',
     ]);
     await expect(
-      discoverFmtPaths({ cwd: rootPath, patterns: ['node_modules/package/index.js'] }),
+      discoverFmtPaths({
+        cwd: rootPath,
+        patterns: ['node_modules/package/index.js'],
+      }),
     ).resolves.toEqual([]);
     await expect(
       discoverFmtPaths({
@@ -54,7 +60,10 @@ test('keeps node_modules excluded by gitignore when built-in exclusion is disabl
     writeProjectFile(rootPath, 'node_modules/package/index.js');
     writeProjectFile(rootPath, 'index.js');
 
-    const files = await discoverFmtPaths({ cwd: rootPath, withNodeModules: true });
+    const files = await discoverFmtPaths({
+      cwd: rootPath,
+      withNodeModules: true,
+    });
 
     expect(relativePaths(rootPath, files)).toEqual(['.gitignore', 'index.js']);
   });
@@ -93,7 +102,9 @@ test('combines files, directories, and globs without duplicates', async () => {
       path.join('src', 'a.ts'),
       path.join('test', 'c.ts'),
     ]);
-    expect(relativePaths(rootPath, dotFiles)).toEqual([path.join('dot', '.hidden.ts')]);
+    expect(relativePaths(rootPath, dotFiles)).toEqual([
+      path.join('dot', '.hidden.ts'),
+    ]);
     await expect(
       discoverFmtPaths({ cwd: rootPath, patterns: ['missing/**/*.ts'] }),
     ).resolves.toEqual([]);
@@ -112,13 +123,19 @@ test('applies nested gitignore rules with child negation', async () => {
     writeProjectFile(rootPath, 'dist/nested/keep.js');
     writeProjectFile(rootPath, 'visible.ts');
 
-    const files = await discoverFmtPaths({ cwd: rootPath, patterns: ['**/*.{js,ts}'] });
+    const files = await discoverFmtPaths({
+      cwd: rootPath,
+      patterns: ['**/*.{js,ts}'],
+    });
     const ignoredNestedDirectory = await discoverFmtPaths({
       cwd: rootPath,
       patterns: ['dist/nested'],
     });
 
-    expect(relativePaths(rootPath, files)).toEqual([path.join('src', 'keep.js'), 'visible.ts']);
+    expect(relativePaths(rootPath, files)).toEqual([
+      path.join('src', 'keep.js'),
+      'visible.ts',
+    ]);
     expect(ignoredNestedDirectory).toEqual([]);
   });
 });
@@ -129,7 +146,10 @@ test('does not extend a nested directory negation to its files', async () => {
     writeProjectFile(rootPath, 'scripts/.gitignore', '!debug\n');
     writeProjectFile(rootPath, 'scripts/debug/launch.mjs');
 
-    const files = await discoverFmtPaths({ cwd: rootPath, patterns: ['**/*.mjs'] });
+    const files = await discoverFmtPaths({
+      cwd: rootPath,
+      patterns: ['**/*.mjs'],
+    });
 
     expect(files).toEqual([]);
   });
@@ -195,9 +215,15 @@ test('keeps valid nested gitignore rules around normalized and malformed lines',
     writeProjectFile(rootPath, 'src/drop.js');
     writeProjectFile(rootPath, 'visible.ts');
 
-    const files = await discoverFmtPaths({ cwd: rootPath, patterns: ['**/*.{js,ts}'] });
+    const files = await discoverFmtPaths({
+      cwd: rootPath,
+      patterns: ['**/*.{js,ts}'],
+    });
 
-    expect(relativePaths(rootPath, files)).toEqual([path.join('src', 'keep.js'), 'visible.ts']);
+    expect(relativePaths(rootPath, files)).toEqual([
+      path.join('src', 'keep.js'),
+      'visible.ts',
+    ]);
   });
 });
 
@@ -213,7 +239,9 @@ test('propagates native binding errors while loading a nested gitignore', async 
       });
 
     try {
-      await expect(discoverFmtPaths({ cwd: rootPath })).rejects.toBe(nativeError);
+      await expect(discoverFmtPaths({ cwd: rootPath })).rejects.toBe(
+        nativeError,
+      );
     } finally {
       loadNativeBinding.mockRestore();
     }
@@ -230,10 +258,17 @@ test('lets explicit files bypass gitignore', async () => {
       cwd: rootPath,
       patterns: ['**/*.ts'],
     });
-    const explicitFiles = await discoverFmtPaths({ cwd: rootPath, patterns: [keepPath] });
+    const explicitFiles = await discoverFmtPaths({
+      cwd: rootPath,
+      patterns: [keepPath],
+    });
 
-    expect(relativePaths(rootPath, discoveredFiles)).toEqual([path.join('src', 'index.ts')]);
-    expect(relativePaths(rootPath, explicitFiles)).toEqual([path.join('generated', 'keep.ts')]);
+    expect(relativePaths(rootPath, discoveredFiles)).toEqual([
+      path.join('src', 'index.ts'),
+    ]);
+    expect(relativePaths(rootPath, explicitFiles)).toEqual([
+      path.join('generated', 'keep.ts'),
+    ]);
   });
 });
 
@@ -249,7 +284,9 @@ test('applies an external ignore matcher to traversed and explicit paths', async
         path: path.relative(rootPath, filePath),
         isDirectory,
       });
-      return isDirectory ? filePath === generatedPath : filePath === ignoredFilePath;
+      return isDirectory
+        ? filePath === generatedPath
+        : filePath === ignoredFilePath;
     };
 
     const files = await discoverFmtPaths({ cwd: rootPath, isIgnored });
@@ -264,10 +301,15 @@ test('applies an external ignore matcher to traversed and explicit paths', async
       isIgnored,
     });
 
-    expect(relativePaths(rootPath, files)).toEqual([path.join('src', 'index.ts')]);
+    expect(relativePaths(rootPath, files)).toEqual([
+      path.join('src', 'index.ts'),
+    ]);
     expect(ignoredRoot).toEqual([]);
     expect(explicitIgnoredFile).toEqual([]);
-    expect(checkedPaths).toContainEqual({ path: 'generated', isDirectory: true });
+    expect(checkedPaths).toContainEqual({
+      path: 'generated',
+      isDirectory: true,
+    });
     expect(checkedPaths).toContainEqual({
       path: path.join('src', 'ignored.ts'),
       isDirectory: false,
@@ -279,19 +321,27 @@ test('applies an external ignore matcher to traversed and explicit paths', async
   });
 });
 
-test.runIf(process.platform !== 'win32')('does not follow file or directory symlinks', async () => {
-  await withTempProject(async (rootPath) => {
-    const targetPath = writeProjectFile(rootPath, 'target/index.ts');
-    symlinkSync(path.join(rootPath, 'target'), path.join(rootPath, 'linked-directory'));
-    symlinkSync(targetPath, path.join(rootPath, 'linked-file.ts'));
+test.runIf(process.platform !== 'win32')(
+  'does not follow file or directory symlinks',
+  async () => {
+    await withTempProject(async (rootPath) => {
+      const targetPath = writeProjectFile(rootPath, 'target/index.ts');
+      symlinkSync(
+        path.join(rootPath, 'target'),
+        path.join(rootPath, 'linked-directory'),
+      );
+      symlinkSync(targetPath, path.join(rootPath, 'linked-file.ts'));
 
-    const discoveredFiles = await discoverFmtPaths({ cwd: rootPath });
-    const explicitFiles = await discoverFmtPaths({
-      cwd: rootPath,
-      patterns: ['linked-directory', 'linked-file.ts'],
+      const discoveredFiles = await discoverFmtPaths({ cwd: rootPath });
+      const explicitFiles = await discoverFmtPaths({
+        cwd: rootPath,
+        patterns: ['linked-directory', 'linked-file.ts'],
+      });
+
+      expect(relativePaths(rootPath, discoveredFiles)).toEqual([
+        path.join('target', 'index.ts'),
+      ]);
+      expect(explicitFiles).toEqual([]);
     });
-
-    expect(relativePaths(rootPath, discoveredFiles)).toEqual([path.join('target', 'index.ts')]);
-    expect(explicitFiles).toEqual([]);
-  });
-});
+  },
+);

--- a/packages/rstack/tests/fmt/discovery.test.ts
+++ b/packages/rstack/tests/fmt/discovery.test.ts
@@ -6,15 +6,22 @@ import { discoverFmtFiles } from '../../src/fmt/discovery.ts';
 import type { FmtConfig } from '../../src/fmt/types.ts';
 import { withTempProject, writeProjectFile } from './helpers.ts';
 
-const discover = async (cwd: string, patterns?: string[], config?: FmtConfig, configRoot = cwd) =>
+const discover = async (
+  cwd: string,
+  patterns?: string[],
+  config?: FmtConfig,
+  configRoot = cwd,
+) =>
   discoverFmtFiles({
     cwd,
     patterns,
     config: normalizeFmtConfig(config, configRoot),
   });
 
-const relativePaths = (rootPath: string, files: Awaited<ReturnType<typeof discover>>): string[] =>
-  files.map((file) => path.relative(rootPath, file.path));
+const relativePaths = (
+  rootPath: string,
+  files: Awaited<ReturnType<typeof discover>>,
+): string[] => files.map((file) => path.relative(rootPath, file.path));
 
 test('applies config ignore patterns to discovered and explicit files', async () => {
   await withTempProject(async (rootPath) => {
@@ -24,13 +31,19 @@ test('applies config ignore patterns to discovered and explicit files', async ()
     const config = { ignorePatterns: ['generated/blocked.ts'] };
 
     const discoveredFiles = await discover(rootPath, undefined, config);
-    const explicitFiles = await discover(rootPath, [keepPath, blockedPath], config);
+    const explicitFiles = await discover(
+      rootPath,
+      [keepPath, blockedPath],
+      config,
+    );
 
     expect(relativePaths(rootPath, discoveredFiles)).toEqual([
       path.join('generated', 'keep.ts'),
       path.join('src', 'index.ts'),
     ]);
-    expect(relativePaths(rootPath, explicitFiles)).toEqual([path.join('generated', 'keep.ts')]);
+    expect(relativePaths(rootPath, explicitFiles)).toEqual([
+      path.join('generated', 'keep.ts'),
+    ]);
   });
 });
 
@@ -41,14 +54,23 @@ test('applies config ignore patterns outside the config root', async () => {
     mkdirSync(configRoot);
 
     await expect(
-      discover(configRoot, [filePath], { ignorePatterns: ['../shared/*.ts'] }, configRoot),
+      discover(
+        configRoot,
+        [filePath],
+        { ignorePatterns: ['../shared/*.ts'] },
+        configRoot,
+      ),
     ).resolves.toEqual([]);
   });
 });
 
 test('excludes .rstack from discovery', async () => {
   await withTempProject(async (rootPath) => {
-    const cacheFile = writeProjectFile(rootPath, '.rstack/cache/fmt-v1.json', '{}');
+    const cacheFile = writeProjectFile(
+      rootPath,
+      '.rstack/cache/fmt-v1.json',
+      '{}',
+    );
     writeProjectFile(rootPath, 'index.ts');
 
     const discoveredFiles = await discover(rootPath);
@@ -85,7 +107,11 @@ test('excludes a custom cache directory', async () => {
 
 test('keeps files re-included by a CLI ignore file during directory traversal', async () => {
   await withTempProject(async (rootPath) => {
-    writeProjectFile(rootPath, '.prettierignore', 'generated/*\n!generated/keep.ts\n');
+    writeProjectFile(
+      rootPath,
+      '.prettierignore',
+      'generated/*\n!generated/keep.ts\n',
+    );
     writeProjectFile(rootPath, 'generated/drop.ts');
     writeProjectFile(rootPath, 'generated/keep.ts');
     writeProjectFile(rootPath, 'src/index.ts');
@@ -112,7 +138,9 @@ test('defers parser inference to workers and preserves an explicit parser', asyn
     writeProjectFile(rootPath, 'unknown.extension');
 
     const inferredFiles = await discover(rootPath);
-    const configuredFiles = await discover(rootPath, ['source.custom'], { parser: 'babel' });
+    const configuredFiles = await discover(rootPath, ['source.custom'], {
+      parser: 'babel',
+    });
 
     expect(relativePaths(rootPath, inferredFiles)).toEqual([
       'index.js',
@@ -120,7 +148,9 @@ test('defers parser inference to workers and preserves an explicit parser', asyn
       'source.custom',
       'unknown.extension',
     ]);
-    expect(inferredFiles.every((file) => file.options.parser === undefined)).toBe(true);
+    expect(
+      inferredFiles.every((file) => file.options.parser === undefined),
+    ).toBe(true);
     expect(configuredFiles[0]).toEqual({
       path: path.join(rootPath, 'source.custom'),
       options: { parser: 'babel' },

--- a/packages/rstack/tests/fmt/fileResolver.test.ts
+++ b/packages/rstack/tests/fmt/fileResolver.test.ts
@@ -21,7 +21,10 @@ test('applies matching overrides before resolving plugins', async () => {
     writeProjectFile(
       rootPath,
       'node_modules/prettier-plugin-fixture/package.json',
-      JSON.stringify({ name: 'prettier-plugin-fixture', exports: './index.mjs' }),
+      JSON.stringify({
+        name: 'prettier-plugin-fixture',
+        exports: './index.mjs',
+      }),
     );
     const config = normalizeFmtConfig(
       {

--- a/packages/rstack/tests/fmt/helpers.ts
+++ b/packages/rstack/tests/fmt/helpers.ts
@@ -1,7 +1,11 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fmtCacheFileName } from '../../src/fmt/cacheStore.ts';
-import type { FmtCacheContext, FmtFileRequest, ResolvedFmtOptions } from '../../src/fmt/types.ts';
+import type {
+  FmtCacheContext,
+  FmtFileRequest,
+  ResolvedFmtOptions,
+} from '../../src/fmt/types.ts';
 
 export const createFmtRequest = (
   filePath: string,
@@ -19,7 +23,9 @@ export const createFmtCacheContext = (rootPath: string): FmtCacheContext => ({
 export const withTempProject = async (
   callback: (rootPath: string) => void | Promise<void>,
 ): Promise<void> => {
-  const rootPath = mkdtempSync(path.join(import.meta.dirname, 'test-temp-fmt-'));
+  const rootPath = mkdtempSync(
+    path.join(import.meta.dirname, 'test-temp-fmt-'),
+  );
   // Prevent repository-level ignore rules from affecting the fixture.
   mkdirSync(path.join(rootPath, '.git'));
 
@@ -30,7 +36,11 @@ export const withTempProject = async (
   }
 };
 
-export const writeProjectFile = (rootPath: string, filePath: string, content = ''): string => {
+export const writeProjectFile = (
+  rootPath: string,
+  filePath: string,
+  content = '',
+): string => {
   const absolutePath = path.join(rootPath, filePath);
   mkdirSync(path.dirname(absolutePath), { recursive: true });
   writeFileSync(absolutePath, content);

--- a/packages/rstack/tests/fmt/ignore.test.ts
+++ b/packages/rstack/tests/fmt/ignore.test.ts
@@ -55,7 +55,11 @@ test('does not apply negated directory patterns to files', async () => {
 
 test('applies negated patterns in declaration order', async () => {
   const isIgnored = await createMatcher(['*.js', '!src/keep.js']);
-  const isIgnoredAgain = await createMatcher(['*.js', '!src/keep.js', 'src/keep.js']);
+  const isIgnoredAgain = await createMatcher([
+    '*.js',
+    '!src/keep.js',
+    'src/keep.js',
+  ]);
   const isIgnoredAfterReinclude = await createMatcher(['dist', '!dist']);
   const filePath = path.join(rootPath, 'src/keep.js');
 
@@ -70,11 +74,17 @@ test('ignores common lock files by default and allows explicit negation', async 
   const isIgnoredAfterReinclude = await createMatcher(['!pnpm-lock.yaml']);
 
   expect(isIgnored(path.join(rootPath, 'package-lock.json'))).toBe(true);
-  expect(isIgnored(path.join(rootPath, 'packages/app/pnpm-lock.yaml'))).toBe(true);
-  expect(isIgnored(path.join(rootPath, 'packages/app/PNPM-LOCK.YAML'))).toBe(false);
+  expect(isIgnored(path.join(rootPath, 'packages/app/pnpm-lock.yaml'))).toBe(
+    true,
+  );
+  expect(isIgnored(path.join(rootPath, 'packages/app/PNPM-LOCK.YAML'))).toBe(
+    false,
+  );
   expect(isIgnored(path.join(rootPath, '../shared/pnpm-lock.yaml'))).toBe(true);
   expect(isIgnored(path.join(rootPath, 'pnpm-lock.yaml.backup'))).toBe(false);
-  expect(isIgnoredAfterReinclude(path.join(rootPath, 'pnpm-lock.yaml'))).toBe(false);
+  expect(isIgnoredAfterReinclude(path.join(rootPath, 'pnpm-lock.yaml'))).toBe(
+    false,
+  );
 });
 
 test('does not let explicit files bypass ignore patterns', async () => {
@@ -99,11 +109,18 @@ test('does not ignore other files when no patterns are configured', async () => 
 
 test('loads repeated ignore paths relative to cwd and each ignore file', async () => {
   await withTempProject(async (projectPath) => {
-    writeProjectFile(projectPath, '.prettierignore', 'src/*.js\n!src/keep.js\n');
+    writeProjectFile(
+      projectPath,
+      '.prettierignore',
+      'src/*.js\n!src/keep.js\n',
+    );
     writeProjectFile(projectPath, 'config/extra.ignore', '../generated/*.js\n');
 
     const isIgnored = await createIgnoreMatcher({
-      config: normalizeFmtConfig({ ignorePatterns: ['configured.js'] }, projectPath),
+      config: normalizeFmtConfig(
+        { ignorePatterns: ['configured.js'] },
+        projectPath,
+      ),
       cwd: projectPath,
       ignorePaths: ['.prettierignore', 'config/extra.ignore'],
     });

--- a/packages/rstack/tests/fmt/lsp/minimalEdit.test.ts
+++ b/packages/rstack/tests/fmt/lsp/minimalEdit.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'rstack/test';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { computeMinimalEdit, computeMinimalTextEdit } from '../../../src/fmt/lsp/minimalEdit.ts';
+import {
+  computeMinimalEdit,
+  computeMinimalTextEdit,
+} from '../../../src/fmt/lsp/minimalEdit.ts';
 
 /** Applies an edit the way an editor does, to prove it rewrites the document. */
 const applyMinimalEdit = (source: string, formatted: string): string => {
@@ -17,7 +20,10 @@ const applyMinimalEdit = (source: string, formatted: string): string => {
  * does: offsets become positions on the server and positions become offsets
  * again on the client, which moves any offset that lands inside a `\r\n`.
  */
-const applyMinimalEditThroughPositions = (source: string, formatted: string): string => {
+const applyMinimalEditThroughPositions = (
+  source: string,
+  formatted: string,
+): string => {
   const edit = computeMinimalEdit(source, formatted);
   if (!edit) {
     return source;
@@ -35,7 +41,9 @@ const applyMinimalEditThroughPositions = (source: string, formatted: string): st
 
 test('returns no edit for identical sources', () => {
   expect(computeMinimalEdit('', '')).toBeUndefined();
-  expect(computeMinimalEdit('const x = 1;\n', 'const x = 1;\n')).toBeUndefined();
+  expect(
+    computeMinimalEdit('const x = 1;\n', 'const x = 1;\n'),
+  ).toBeUndefined();
 });
 
 test('replaces the whole document when nothing is shared', () => {
@@ -44,7 +52,11 @@ test('replaces the whole document when nothing is shared', () => {
     end: 0,
     newText: 'const x = 1;\n',
   });
-  expect(computeMinimalEdit('a\n', '')).toEqual({ start: 0, end: 2, newText: '' });
+  expect(computeMinimalEdit('a\n', '')).toEqual({
+    start: 0,
+    end: 2,
+    newText: '',
+  });
 });
 
 test('trims a shared prefix', () => {
@@ -134,8 +146,12 @@ test('survives a round trip through a real text document', () => {
   const formatted = 'const a = 1;\r\nconst b = 2;\r\n';
 
   expect(applyMinimalEditThroughPositions(source, formatted)).toBe(formatted);
-  expect(applyMinimalEditThroughPositions('a\nb\n', 'a\r\nb\r\n')).toBe('a\r\nb\r\n');
-  expect(applyMinimalEditThroughPositions('a\r\nb\r\n', 'a\nb\n')).toBe('a\nb\n');
+  expect(applyMinimalEditThroughPositions('a\nb\n', 'a\r\nb\r\n')).toBe(
+    'a\r\nb\r\n',
+  );
+  expect(applyMinimalEditThroughPositions('a\r\nb\r\n', 'a\nb\n')).toBe(
+    'a\nb\n',
+  );
 });
 
 // Line terminators are where offsets stop being interchangeable with positions,
@@ -146,13 +162,20 @@ test('addresses every combination of line terminators', () => {
   const texts: string[] = [''];
   let current = [''];
   for (let length = 0; length < 5; length++) {
-    current = current.flatMap((text) => alphabet.map((character) => text + character));
+    current = current.flatMap((text) =>
+      alphabet.map((character) => text + character),
+    );
     texts.push(...current);
   }
 
   const failures: string[] = [];
   for (const source of texts) {
-    const document = TextDocument.create('file:///a.ts', 'typescript', 1, source);
+    const document = TextDocument.create(
+      'file:///a.ts',
+      'typescript',
+      1,
+      source,
+    );
     for (const formatted of texts) {
       const edit = computeMinimalEdit(source, formatted);
       if (!edit) {
@@ -163,7 +186,9 @@ test('addresses every combination of line terminators', () => {
       const end = document.offsetAt(document.positionAt(edit.end));
       const applied = source.slice(0, start) + edit.newText + source.slice(end);
       if (applied !== formatted) {
-        failures.push(`${JSON.stringify(source)} -> ${JSON.stringify(formatted)}`);
+        failures.push(
+          `${JSON.stringify(source)} -> ${JSON.stringify(formatted)}`,
+        );
       }
 
       // The hand-rolled position mapping must agree with the reference
@@ -174,7 +199,9 @@ test('addresses every combination of line terminators', () => {
         end: document.positionAt(edit.end),
       };
       if (JSON.stringify(range) !== JSON.stringify(expected)) {
-        failures.push(`positions ${JSON.stringify(source)} -> ${JSON.stringify(formatted)}`);
+        failures.push(
+          `positions ${JSON.stringify(source)} -> ${JSON.stringify(formatted)}`,
+        );
       }
     }
   }

--- a/packages/rstack/tests/fmt/lsp/server.test.ts
+++ b/packages/rstack/tests/fmt/lsp/server.test.ts
@@ -9,7 +9,10 @@ test('maps the edit onto the formatted document', async () => {
 
   expect(edits).toEqual([
     {
-      range: { start: { line: 1, character: 7 }, end: { line: 1, character: 8 } },
+      range: {
+        start: { line: 1, character: 7 },
+        end: { line: 1, character: 8 },
+      },
       newText: ' = ',
     },
   ]);
@@ -18,8 +21,12 @@ test('maps the edit onto the formatted document', async () => {
 test('returns no edits for an already formatted document', async () => {
   const getText = () => 'const a = 1;\n';
 
-  expect(await createDocumentEdits(getText, () => Promise.resolve('const a = 1;\n'))).toEqual([]);
-  expect(await createDocumentEdits(getText, () => Promise.resolve(undefined))).toEqual([]);
+  expect(
+    await createDocumentEdits(getText, () => Promise.resolve('const a = 1;\n')),
+  ).toEqual([]);
+  expect(
+    await createDocumentEdits(getText, () => Promise.resolve(undefined)),
+  ).toEqual([]);
 });
 
 test('returns no edits for a document that is not open', async () => {

--- a/packages/rstack/tests/fmt/plugins.test.ts
+++ b/packages/rstack/tests/fmt/plugins.test.ts
@@ -1,6 +1,9 @@
 import { pathToFileURL } from 'node:url';
 import { expect, test } from 'rstack/test';
-import { createFingerprintResolver, createPluginResolver } from '../../src/fmt/plugins.ts';
+import {
+  createFingerprintResolver,
+  createPluginResolver,
+} from '../../src/fmt/plugins.ts';
 import { withTempProject, writeProjectFile } from './helpers.ts';
 
 test('resolves plugin specifiers from the config root', async () => {
@@ -65,7 +68,10 @@ test('rejects imported plugin objects', () => {
 
 test('fingerprints installed package plugins once', async () => {
   await withTempProject(async (rootPath) => {
-    const entry = writeProjectFile(rootPath, 'node_modules/prettier-plugin-fixture/dist/index.mjs');
+    const entry = writeProjectFile(
+      rootPath,
+      'node_modules/prettier-plugin-fixture/dist/index.mjs',
+    );
     const packageJsonPath = 'node_modules/prettier-plugin-fixture/package.json';
     writeProjectFile(
       rootPath,

--- a/packages/rstack/tests/fmt/runner.test.ts
+++ b/packages/rstack/tests/fmt/runner.test.ts
@@ -1,4 +1,10 @@
-import { chmodSync, readFileSync, statSync, utimesSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  readFileSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { expect, test } from 'rstack/test';
 import { runFmtFiles } from '../../src/fmt/runner.ts';
@@ -46,17 +52,20 @@ test('writes changed files', async () => {
   });
 });
 
-test.runIf(process.platform !== 'win32')('preserves file mode when writing', async () => {
-  await withTempProject(async (rootPath) => {
-    const filePath = path.join(rootPath, 'executable.ts');
-    writeFileSync(filePath, 'const value=1');
-    chmodSync(filePath, 0o744);
+test.runIf(process.platform !== 'win32')(
+  'preserves file mode when writing',
+  async () => {
+    await withTempProject(async (rootPath) => {
+      const filePath = path.join(rootPath, 'executable.ts');
+      writeFileSync(filePath, 'const value=1');
+      chmodSync(filePath, 0o744);
 
-    await run([createFmtRequest(filePath)]);
+      await run([createFmtRequest(filePath)]);
 
-    expect(statSync(filePath).mode & 0o777).toBe(0o744);
-  });
-});
+      expect(statSync(filePath).mode & 0o777).toBe(0o744);
+    });
+  },
+);
 
 for (const mode of ['check', 'list-different'] as const) {
   test(`${mode} reports differences without writing`, async () => {
@@ -84,7 +93,10 @@ test('continues after a file fails and gives errors exit-code precedence', async
     writeFileSync(invalidPath, 'const value = ;');
     writeFileSync(validPath, 'const value=1');
 
-    const result = await run([createFmtRequest(invalidPath), createFmtRequest(validPath)], 'check');
+    const result = await run(
+      [createFmtRequest(invalidPath), createFmtRequest(validPath)],
+      'check',
+    );
 
     expect(result).toMatchObject({
       exitCode: 2,
@@ -110,7 +122,11 @@ test('omits unsupported files from the result', async () => {
       },
     ]);
 
-    expect(result).toMatchObject({ exitCode: 2, files: [], processedFileCount: 0 });
+    expect(result).toMatchObject({
+      exitCode: 2,
+      files: [],
+      processedFileCount: 0,
+    });
     expect(readFileSync(filePath, 'utf8')).toBe('plain text');
   });
 });

--- a/packages/rstack/tests/fmt/runnerCache.test.ts
+++ b/packages/rstack/tests/fmt/runnerCache.test.ts
@@ -10,7 +10,11 @@ import {
 } from '../../src/fmt/cacheIdentity.ts';
 import { loadFmtCacheStore } from '../../src/fmt/cacheStore.ts';
 import { runFmtFiles } from '../../src/fmt/runner.ts';
-import type { FmtCacheContext, FmtFileRequest, FmtMode } from '../../src/fmt/types.ts';
+import type {
+  FmtCacheContext,
+  FmtFileRequest,
+  FmtMode,
+} from '../../src/fmt/types.ts';
 import {
   createFmtCacheContext,
   createFmtRequest,
@@ -77,7 +81,9 @@ test('uses content hashes instead of file metadata', async () => {
       size: Buffer.byteLength(clean),
     });
 
-    await expect(run([createFmtRequest(filePath)], 'check', cache)).resolves.toMatchObject({
+    await expect(
+      run([createFmtRequest(filePath)], 'check', cache),
+    ).resolves.toMatchObject({
       exitCode: 1,
       files: [{ path: filePath, status: 'different' }],
     });
@@ -99,10 +105,16 @@ test('invalidates entries when final options change', async () => {
     const cache = createFmtCacheContext(rootPath);
     writeFileSync(filePath, 'const value = "text";\n');
 
-    const initial = createFmtRequest(filePath, { parser: 'typescript', singleQuote: false });
+    const initial = createFmtRequest(filePath, {
+      parser: 'typescript',
+      singleQuote: false,
+    });
     await run([initial], 'check', cache);
 
-    const changed = createFmtRequest(filePath, { parser: 'typescript', singleQuote: true });
+    const changed = createFmtRequest(filePath, {
+      parser: 'typescript',
+      singleQuote: true,
+    });
     await expect(run([changed], 'check', cache)).resolves.toMatchObject({
       exitCode: 1,
       files: [{ path: filePath, status: 'different' }],
@@ -119,7 +131,11 @@ test('invalidates entries when final options change', async () => {
 
 test('caches unsupported parser results until final options change', async () => {
   await withTempProject(async (rootPath) => {
-    const filePath = writeProjectFile(rootPath, 'data.unknown', '{"value":true}');
+    const filePath = writeProjectFile(
+      rootPath,
+      'data.unknown',
+      '{"value":true}',
+    );
     const cache = createFmtCacheContext(rootPath);
     const unsupported = createFmtRequest(filePath, {});
 
@@ -129,11 +145,11 @@ test('caches unsupported parser results until final options change', async () =>
       files: [],
       processedFileCount: 0,
     });
-    expect((await loadFmtCacheStore(cache.filePath, cacheNamespace)).get('data.unknown')).toEqual([
-      '',
-      createOptionsHasher()(unsupported.options),
-      'unsupported',
-    ]);
+    expect(
+      (await loadFmtCacheStore(cache.filePath, cacheNamespace)).get(
+        'data.unknown',
+      ),
+    ).toEqual(['', createOptionsHasher()(unsupported.options), 'unsupported']);
 
     await expect(run([unsupported], 'check', cache)).resolves.toEqual(first);
 
@@ -143,7 +159,11 @@ test('caches unsupported parser results until final options change', async () =>
       files: [{ path: filePath, status: 'different' }],
       processedFileCount: 1,
     });
-    expect((await loadFmtCacheStore(cache.filePath, cacheNamespace)).get('data.unknown')).toEqual([
+    expect(
+      (await loadFmtCacheStore(cache.filePath, cacheNamespace)).get(
+        'data.unknown',
+      ),
+    ).toEqual([
       createCacheHash(readFileSync(filePath)),
       createOptionsHasher()(supported.options),
       'dirty',
@@ -163,7 +183,9 @@ test('invalidates cached unsupported parser results when content changes without
       files: [],
       processedFileCount: 0,
     });
-    expect((await loadFmtCacheStore(cache.filePath, cacheNamespace)).get('script')).toEqual([
+    expect(
+      (await loadFmtCacheStore(cache.filePath, cacheNamespace)).get('script'),
+    ).toEqual([
       createCacheHash(readFileSync(filePath)),
       createOptionsHasher()(file.options),
       'unsupported',
@@ -177,7 +199,9 @@ test('invalidates cached unsupported parser results when content changes without
       files: [{ path: filePath, status: 'different' }],
       processedFileCount: 1,
     });
-    expect((await loadFmtCacheStore(cache.filePath, cacheNamespace)).get('script')).toEqual([
+    expect(
+      (await loadFmtCacheStore(cache.filePath, cacheNamespace)).get('script'),
+    ).toEqual([
       createCacheHash(readFileSync(filePath)),
       createOptionsHasher()(file.options),
       'dirty',
@@ -187,7 +211,11 @@ test('invalidates cached unsupported parser results when content changes without
 
 test('caches only plugins with stable fingerprints', async () => {
   await withTempProject(async (rootPath) => {
-    const filePath = writeProjectFile(rootPath, 'data.fixture', '{"value":true}');
+    const filePath = writeProjectFile(
+      rootPath,
+      'data.fixture',
+      '{"value":true}',
+    );
     const pluginEntry = writeProjectFile(
       rootPath,
       'node_modules/prettier-plugin-fixture/index.mjs',
@@ -208,26 +236,30 @@ test('caches only plugins with stable fingerprints', async () => {
         }),
       );
     const cache = createFmtCacheContext(rootPath);
-    const file = createFmtRequest(filePath, { plugins: [pathToFileURL(pluginEntry).href] });
+    const file = createFmtRequest(filePath, {
+      plugins: [pathToFileURL(pluginEntry).href],
+    });
 
     writePackageJson();
     await run([file], 'check', cache);
-    expect((await loadFmtCacheStore(cache.filePath, cacheNamespace)).get('data.fixture')).toBe(
-      undefined,
-    );
+    expect(
+      (await loadFmtCacheStore(cache.filePath, cacheNamespace)).get(
+        'data.fixture',
+      ),
+    ).toBe(undefined);
 
     writePackageJson('1.0.0');
     await run([file], 'check', cache);
-    const firstHash = (await loadFmtCacheStore(cache.filePath, cacheNamespace)).get(
-      'data.fixture',
-    )?.[1];
+    const firstHash = (
+      await loadFmtCacheStore(cache.filePath, cacheNamespace)
+    ).get('data.fixture')?.[1];
     expect(firstHash).toHaveLength(cacheHashLength);
 
     writePackageJson('2.0.0');
     await run([file], 'check', cache);
-    const secondHash = (await loadFmtCacheStore(cache.filePath, cacheNamespace)).get(
-      'data.fixture',
-    )?.[1];
+    const secondHash = (
+      await loadFmtCacheStore(cache.filePath, cacheNamespace)
+    ).get('data.fixture')?.[1];
     expect(secondHash).toHaveLength(cacheHashLength);
     expect(secondHash).not.toBe(firstHash);
   });
@@ -241,7 +273,11 @@ test('preserves entries outside the formatted subset', async () => {
     writeFileSync(firstPath, 'const first = 1;\n');
     writeFileSync(secondPath, 'const second = 2;\n');
 
-    await run([createFmtRequest(firstPath), createFmtRequest(secondPath)], 'check', cache);
+    await run(
+      [createFmtRequest(firstPath), createFmtRequest(secondPath)],
+      'check',
+      cache,
+    );
     const firstStore = await loadFmtCacheStore(cache.filePath, cacheNamespace);
     const secondEntry = firstStore.get('second.ts');
 
@@ -262,7 +298,9 @@ test('does not cache formatting errors', async () => {
     writeFileSync(invalidPath, 'const invalid = ;');
 
     await run([createFmtRequest(validPath)], 'check', cache);
-    await expect(run([createFmtRequest(invalidPath)], 'check', cache)).resolves.toMatchObject({
+    await expect(
+      run([createFmtRequest(invalidPath)], 'check', cache),
+    ).resolves.toMatchObject({
       exitCode: 2,
       files: [{ path: invalidPath, status: 'error' }],
     });
@@ -306,7 +344,9 @@ test('write persists clean results for misses and hits', async () => {
       files: [],
       processedFileCount: 2,
     });
-    expect(files.map((file) => statSync(file.path).mtimeMs)).toEqual(timestamps);
+    expect(files.map((file) => statSync(file.path).mtimeMs)).toEqual(
+      timestamps,
+    );
   });
 });
 

--- a/packages/rstack/tests/fmt/runnerWorkerPreflight.test.ts
+++ b/packages/rstack/tests/fmt/runnerWorkerPreflight.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, expect, rs, test } from 'rstack/test';
-import { cacheNamespace, createOptionsHasher } from '../../src/fmt/cacheIdentity.ts';
+import {
+  cacheNamespace,
+  createOptionsHasher,
+} from '../../src/fmt/cacheIdentity.ts';
 import { loadFmtCacheStore } from '../../src/fmt/cacheStore.ts';
 import { runFmtFiles } from '../../src/fmt/runner.ts';
 import {
@@ -24,7 +27,10 @@ beforeEach(() => {
   mocks.workerPoolCalls.length = 0;
 });
 
-const createCachedUnsupportedFile = async (rootPath: string, fileName: string) => {
+const createCachedUnsupportedFile = async (
+  rootPath: string,
+  fileName: string,
+) => {
   const filePath = writeProjectFile(rootPath, fileName, 'plain text');
   const cache = createFmtCacheContext(rootPath);
   const file = createFmtRequest(filePath, {});
@@ -42,7 +48,10 @@ const createCachedUnsupportedFile = async (rootPath: string, fileName: string) =
 
 test('does not start the worker pool when every parser result is cached as unsupported', async () => {
   await withTempProject(async (rootPath) => {
-    const { cache, file } = await createCachedUnsupportedFile(rootPath, 'example.unknown');
+    const { cache, file } = await createCachedUnsupportedFile(
+      rootPath,
+      'example.unknown',
+    );
 
     await expect(
       runFmtFiles({
@@ -61,7 +70,10 @@ test('does not start the worker pool when every parser result is cached as unsup
 
 test('starts the worker pool for a path-only unsupported entry without an extension', async () => {
   await withTempProject(async (rootPath) => {
-    const { cache, file } = await createCachedUnsupportedFile(rootPath, 'script');
+    const { cache, file } = await createCachedUnsupportedFile(
+      rootPath,
+      'script',
+    );
 
     await expect(
       runFmtFiles({

--- a/packages/rstack/tests/fmt/worker.test.ts
+++ b/packages/rstack/tests/fmt/worker.test.ts
@@ -18,8 +18,18 @@ test('returns cached states before resolving the parser', async () => {
       [[contentHash, optionsHash, 'clean'], filePath, false, 'unchanged'],
       [[contentHash, optionsHash, 'dirty'], filePath, false, 'changed'],
       [[contentHash, optionsHash, 'clean'], filePath, true, 'unchanged'],
-      [[contentHash, optionsHash, 'unsupported'], noExtensionPath, false, 'unsupported'],
-      [[contentHash, optionsHash, 'unsupported'], noExtensionPath, true, 'unsupported'],
+      [
+        [contentHash, optionsHash, 'unsupported'],
+        noExtensionPath,
+        false,
+        'unsupported',
+      ],
+      [
+        [contentHash, optionsHash, 'unsupported'],
+        noExtensionPath,
+        true,
+        'unsupported',
+      ],
       [['', optionsHash, 'unsupported'], missingPath, false, 'unsupported'],
       [['', optionsHash, 'unsupported'], missingPath, true, 'unsupported'],
     ] as const) {
@@ -44,7 +54,11 @@ test('returns cached states before resolving the parser', async () => {
 
 test('does not trust path-only unsupported entries for files without extensions', async () => {
   await withTempProject(async (rootPath) => {
-    const filePath = writeProjectFile(rootPath, 'script', '#!/usr/bin/env node\nconst value=1');
+    const filePath = writeProjectFile(
+      rootPath,
+      'script',
+      '#!/usr/bin/env node\nconst value=1',
+    );
 
     await expect(
       formatFile({

--- a/packages/rstack/tests/fmt/yukuPlugin.test.ts
+++ b/packages/rstack/tests/fmt/yukuPlugin.test.ts
@@ -1,4 +1,9 @@
-import { format, getFileInfo, type Options, type ParserOptions } from 'prettier';
+import {
+  format,
+  getFileInfo,
+  type Options,
+  type ParserOptions,
+} from 'prettier';
 import { expect, test } from 'rstack/test';
 import { yukuPlugin } from '../../src/fmt/yukuPlugin.ts';
 
@@ -9,11 +14,14 @@ const formatWithYuku = (
   format(source, {
     plugins: [yukuPlugin],
     ...options,
-    filepath: options.filepath ?? `example.${options.parser === 'yuku' ? 'js' : 'ts'}`,
+    filepath:
+      options.filepath ?? `example.${options.parser === 'yuku' ? 'js' : 'ts'}`,
   });
 
 test('exposes the same JavaScript and TypeScript language mappings as the official plugin', async () => {
-  expect(yukuPlugin.languages?.map(({ name, parsers }) => ({ name, parsers }))).toEqual([
+  expect(
+    yukuPlugin.languages?.map(({ name, parsers }) => ({ name, parsers })),
+  ).toEqual([
     { name: 'JavaScript', parsers: ['yuku', 'yuku-ts'] },
     { name: 'JSX', parsers: ['yuku', 'yuku-ts'] },
     { name: 'TypeScript', parsers: ['yuku-ts'] },
@@ -63,7 +71,9 @@ test.each(['example.d.ts', 'example.d.mts', 'example.d.cts'])(
         filepath,
         parser: 'yuku-ts',
       }),
-    ).rejects.toThrow('An implementation cannot be declared in ambient contexts');
+    ).rejects.toThrow(
+      'An implementation cannot be declared in ambient contexts',
+    );
   },
 );
 
@@ -115,7 +125,8 @@ test.each([
     parser: 'yuku-ts' as const,
     filepath: 'example.tsx',
     source: 'const view=(<Component value={{foo:1}}>{(item)}</Component>)',
-    expected: 'const view = <Component value={{ foo: 1 }}>{item}</Component>;\n',
+    expected:
+      'const view = <Component value={{ foo: 1 }}>{item}</Component>;\n',
   },
 ])('normalizes $name for the ESTree printer', async (fixture) => {
   await expect(
@@ -179,15 +190,18 @@ test.each([
     hasPragma: false,
     hasIgnorePragma: false,
   },
-])('matches Prettier pragma detection for $source', ({ source, hasPragma, hasIgnorePragma }) => {
-  const parser = yukuPlugin.parsers?.yuku;
-  if (!parser?.hasPragma || !parser.hasIgnorePragma) {
-    throw new Error('The Yuku parser does not expose pragma handlers.');
-  }
+])(
+  'matches Prettier pragma detection for $source',
+  ({ source, hasPragma, hasIgnorePragma }) => {
+    const parser = yukuPlugin.parsers?.yuku;
+    if (!parser?.hasPragma || !parser.hasIgnorePragma) {
+      throw new Error('The Yuku parser does not expose pragma handlers.');
+    }
 
-  expect(parser.hasPragma(source)).toBe(hasPragma);
-  expect(parser.hasIgnorePragma(source)).toBe(hasIgnorePragma);
-});
+    expect(parser.hasPragma(source)).toBe(hasPragma);
+    expect(parser.hasIgnorePragma(source)).toBe(hasIgnorePragma);
+  },
+);
 
 test('matches Prettier JavaScript location overrides', () => {
   const parser = yukuPlugin.parsers?.yuku;
@@ -278,10 +292,10 @@ test('matches the official hashbang AST shape', async () => {
   }
 
   const options = { filepath: 'example.js' } as ParserOptions;
-  const astWithoutHashbang = (await parser.parse('const value = 1', options)) as Record<
-    string,
-    unknown
-  >;
+  const astWithoutHashbang = (await parser.parse(
+    'const value = 1',
+    options,
+  )) as Record<string, unknown>;
   const astWithHashbang = (await parser.parse(
     '#!/usr/bin/env node\nconst value = 1',
     options,

--- a/packages/rstack/tests/helpers/cli.ts
+++ b/packages/rstack/tests/helpers/cli.ts
@@ -2,7 +2,10 @@ import { type ExecSyncOptions, execSync } from 'node:child_process';
 import path from 'node:path';
 import type { LogHelper } from '@rstackjs/test-utils';
 
-export const RSTACK_BIN_PATH: string = path.join(import.meta.dirname, '../../bin/rs.js');
+export const RSTACK_BIN_PATH: string = path.join(
+  import.meta.dirname,
+  '../../bin/rs.js',
+);
 
 export type ExecCliOptions = ExecSyncOptions & {
   logHelper?: LogHelper;
@@ -18,7 +21,10 @@ type ExecCliError = Error & {
   stderr?: Buffer | string;
 };
 
-const addLog = (logHelper: LogHelper | undefined, output: Buffer | string | undefined) => {
+const addLog = (
+  logHelper: LogHelper | undefined,
+  output: Buffer | string | undefined,
+) => {
   if (output) {
     logHelper?.addLog(output.toString());
   }
@@ -28,14 +34,17 @@ export const execCli: ExecCli = (command, options = {}) => {
   const { logHelper, ...execOptions } = options;
 
   try {
-    const output = execSync(`"${process.execPath}" "${RSTACK_BIN_PATH}" ${command}`, {
-      stdio: 'pipe',
-      ...execOptions,
-      env: {
-        ...process.env,
-        ...execOptions.env,
+    const output = execSync(
+      `"${process.execPath}" "${RSTACK_BIN_PATH}" ${command}`,
+      {
+        stdio: 'pipe',
+        ...execOptions,
+        env: {
+          ...process.env,
+          ...execOptions.env,
+        },
       },
-    });
+    );
 
     addLog(logHelper, output);
     return output.toString();

--- a/packages/rstack/tests/helpers/cliTest.ts
+++ b/packages/rstack/tests/helpers/cliTest.ts
@@ -1,8 +1,16 @@
-import { type ChildProcess, type SpawnOptions, spawn as nodeSpawn } from 'node:child_process';
+import {
+  type ChildProcess,
+  type SpawnOptions,
+  spawn as nodeSpawn,
+} from 'node:child_process';
 import path from 'node:path';
 import { prepareDist as basePrepareDist } from '@rstackjs/test-utils';
 import { test as baseTest } from 'rstack/test';
-import { execCli as baseExecCli, type ExecCli, RSTACK_BIN_PATH } from './cli.ts';
+import {
+  execCli as baseExecCli,
+  type ExecCli,
+  RSTACK_BIN_PATH,
+} from './cli.ts';
 import { type ExtendedLogHelper, proxyConsole } from './logs.ts';
 
 type Exec = (
@@ -33,7 +41,10 @@ function makeBox(title: string) {
   };
 }
 
-const setupExecOptions = <T extends SpawnOptions>(options: T, cwd: string): T => {
+const setupExecOptions = <T extends SpawnOptions>(
+  options: T,
+  cwd: string,
+): T => {
   // inherit process.env from current process
   const { NODE_ENV: _, ...restEnv } = process.env;
   options.env ||= {};
@@ -47,7 +58,9 @@ export const test: CliTest = baseTest.extend<CliTestFixtures>({
     const { testPath } = expect.getState();
 
     if (!testPath) {
-      throw new Error('Unable to resolve current test file path from expect state.');
+      throw new Error(
+        'Unable to resolve current test file path from expect state.',
+      );
     }
 
     await use(path.dirname(testPath));
@@ -86,7 +99,10 @@ export const test: CliTest = baseTest.extend<CliTestFixtures>({
     const closes: Array<() => void> = [];
 
     const exec: Exec = (command, options = {}) => {
-      const childProcess = nodeSpawn(command, setupExecOptions({ shell: true, ...options }, cwd));
+      const childProcess = nodeSpawn(
+        command,
+        setupExecOptions({ shell: true, ...options }, cwd),
+      );
 
       const onData = (data: Buffer) => {
         logHelper.addLog(data.toString());

--- a/packages/rstack/tests/helpers/logs.ts
+++ b/packages/rstack/tests/helpers/logs.ts
@@ -14,7 +14,9 @@ export type LogHelper = BaseLogHelper & ExpectBuildEnd;
 
 export type ExtendedLogHelper = BaseExtendedLogHelper & ExpectBuildEnd;
 
-export const proxyConsole = (options?: ProxyConsoleOptions): ExtendedLogHelper => {
+export const proxyConsole = (
+  options?: ProxyConsoleOptions,
+): ExtendedLogHelper => {
   const logHelper = baseProxyConsole(options);
 
   return {

--- a/packages/rstack/tests/setup/directories.test.ts
+++ b/packages/rstack/tests/setup/directories.test.ts
@@ -2,7 +2,13 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { expect, test } from 'rstack/test';
 import { installHooks } from '../../src/setup/install.ts';
-import { hooksPath, runGit, runHook, withRepository, writeHook } from './helpers.ts';
+import {
+  hooksPath,
+  runGit,
+  runHook,
+  withRepository,
+  writeHook,
+} from './helpers.ts';
 
 test('installs a custom hooks directory from the Git root and runs its hook', () => {
   withRepository((cwd) => {
@@ -14,11 +20,15 @@ test('installs a custom hooks directory from the Git root and runs its hook', ()
       status: 'installed',
       hooksPath: customHooksPath,
     });
-    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(customHooksPath);
+    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(
+      customHooksPath,
+    );
     expect(existsSync(path.join(cwd, customHooksPath, 'runner'))).toBe(true);
 
     expect(runHook(cwd).status).toBe(0);
-    expect(readFileSync(path.join(cwd, 'custom-hook-ran'), 'utf8')).toBe('ran\n');
+    expect(readFileSync(path.join(cwd, 'custom-hook-ran'), 'utf8')).toBe(
+      'ran\n',
+    );
   });
 });
 
@@ -36,12 +46,18 @@ test('installs repository-level hooks from a nested project', () => {
       status: 'unchanged',
       hooksPath,
     });
-    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(hooksPath);
+    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(
+      hooksPath,
+    );
     expect(existsSync(path.join(cwd, hooksPath, 'runner'))).toBe(true);
-    expect(readFileSync(path.join(cwd, hooksPath, '.owner'), 'utf8')).toBe('frontend\n');
+    expect(readFileSync(path.join(cwd, hooksPath, '.owner'), 'utf8')).toBe(
+      'frontend\n',
+    );
 
     expect(runHook(cwd).status).toBe(0);
-    expect(readFileSync(path.join(projectDirectory, 'nested-hook-ran'), 'utf8')).toBe('ran\n');
+    expect(
+      readFileSync(path.join(projectDirectory, 'nested-hook-ran'), 'utf8'),
+    ).toBe('ran\n');
   });
 });
 
@@ -50,15 +66,23 @@ test('installs a root-relative custom hooks directory from a nested project', ()
     const projectDirectory = path.join(cwd, 'frontend app');
     mkdirSync(projectDirectory);
 
-    expect(installHooks({ cwd: projectDirectory, hooksDir: 'config\\hooks' })).toEqual({
+    expect(
+      installHooks({ cwd: projectDirectory, hooksDir: 'config\\hooks' }),
+    ).toEqual({
       status: 'installed',
       hooksPath: 'config/hooks/_',
     });
-    expect(installHooks({ cwd: projectDirectory, hooksDir: 'config\\hooks' })).toEqual({
+    expect(
+      installHooks({ cwd: projectDirectory, hooksDir: 'config\\hooks' }),
+    ).toEqual({
       status: 'unchanged',
       hooksPath: 'config/hooks/_',
     });
-    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe('config/hooks/_');
-    expect(existsSync(path.join(cwd, 'config', 'hooks', '_', 'runner'))).toBe(true);
+    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(
+      'config/hooks/_',
+    );
+    expect(existsSync(path.join(cwd, 'config', 'hooks', '_', 'runner'))).toBe(
+      true,
+    );
   });
 });

--- a/packages/rstack/tests/setup/helpers.ts
+++ b/packages/rstack/tests/setup/helpers.ts
@@ -10,7 +10,8 @@ export const git = (
   cwd: string,
   args: string[],
   env: NodeJS.ProcessEnv = process.env,
-): SpawnSyncReturns<string> => spawnSync('git', args, { cwd, encoding: 'utf8', env });
+): SpawnSyncReturns<string> =>
+  spawnSync('git', args, { cwd, encoding: 'utf8', env });
 
 export const runGit = (cwd: string, args: string[]): string => {
   const result = git(cwd, args);
@@ -21,7 +22,9 @@ export const runGit = (cwd: string, args: string[]): string => {
 };
 
 export const withDirectory = (callback: (cwd: string) => void): void => {
-  const cwd = mkdtempSync(path.join(import.meta.dirname, 'test-temp-rstack hooks '));
+  const cwd = mkdtempSync(
+    path.join(import.meta.dirname, 'test-temp-rstack hooks '),
+  );
   const gitCeilingDirectories = process.env.GIT_CEILING_DIRECTORIES;
   // Keep Git from treating the temporary directory as part of this repository.
   process.env.GIT_CEILING_DIRECTORIES = import.meta.dirname;
@@ -55,7 +58,11 @@ const hookEnv = (cwd: string, value?: string): NodeJS.ProcessEnv => {
   return env;
 };
 
-export const writeHook = (cwd: string, content: string, directory: string = hooksDir): void => {
+export const writeHook = (
+  cwd: string,
+  content: string,
+  directory: string = hooksDir,
+): void => {
   const filePath = path.join(cwd, directory, 'pre-commit');
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, content);
@@ -67,10 +74,17 @@ export const writeInit = (cwd: string, content: string): void => {
   writeFileSync(filePath, content);
 };
 
-export const runHook = (cwd: string, value?: string): SpawnSyncReturns<string> =>
+export const runHook = (
+  cwd: string,
+  value?: string,
+): SpawnSyncReturns<string> =>
   git(cwd, ['hook', 'run', 'pre-commit'], hookEnv(cwd, value));
 
-export const runGitHook = (cwd: string, name: string, args: string[]): SpawnSyncReturns<string> =>
+export const runGitHook = (
+  cwd: string,
+  name: string,
+  args: string[],
+): SpawnSyncReturns<string> =>
   git(cwd, ['hook', 'run', name, '--', ...args], hookEnv(cwd));
 
 export const withRepository = (callback: (cwd: string) => void): void =>

--- a/packages/rstack/tests/setup/hooks.test.ts
+++ b/packages/rstack/tests/setup/hooks.test.ts
@@ -6,7 +6,9 @@ import { createHookFiles } from '../../src/setup/hooks.ts';
 import { withDirectory } from './helpers.ts';
 
 test('generates the runner and all client-side Git hook shims', () => {
-  expect(Object.keys(createHookFiles()).filter((name) => name !== 'runner')).toEqual([
+  expect(
+    Object.keys(createHookFiles()).filter((name) => name !== 'runner'),
+  ).toEqual([
     'pre-commit',
     'pre-merge-commit',
     'prepare-commit-msg',
@@ -25,17 +27,24 @@ test('generates the runner and all client-side Git hook shims', () => {
 });
 
 test.runIf(process.platform === 'win32')('converts Windows Node paths', () => {
-  const { runner } = createHookFiles(String.raw`C:\Program Files\nodejs\node.exe`);
+  const { runner } = createHookFiles(
+    String.raw`C:\Program Files\nodejs\node.exe`,
+  );
 
-  expect(runner).toContain("rs_node_fallback='/c/Program Files/nodejs/node.exe'");
+  expect(runner).toContain(
+    "rs_node_fallback='/c/Program Files/nodejs/node.exe'",
+  );
 });
 
-test.runIf(process.platform !== 'win32')('preserves backslashes in POSIX Node paths', () => {
-  const nodeExecutable = String.raw`/opt/node\24/bin/node`;
-  const { runner } = createHookFiles(nodeExecutable);
+test.runIf(process.platform !== 'win32')(
+  'preserves backslashes in POSIX Node paths',
+  () => {
+    const nodeExecutable = String.raw`/opt/node\24/bin/node`;
+    const { runner } = createHookFiles(nodeExecutable);
 
-  expect(runner).toContain(`rs_node_fallback='${nodeExecutable}'`);
-});
+    expect(runner).toContain(`rs_node_fallback='${nodeExecutable}'`);
+  },
+);
 
 test.runIf(process.platform !== 'win32')('runs generated hooks', () => {
   withDirectory((directory) => {
@@ -58,7 +67,9 @@ test.runIf(process.platform !== 'win32')('runs generated hooks', () => {
     writeFileSync(path.join(generatedDirectory, 'runner'), files.runner);
     writeFileSync(generatedHook, files['pre-commit']);
 
-    expect(spawnSync('sh', [generatedHook], { cwd: directory, env }).status).toBe(0);
+    expect(
+      spawnSync('sh', [generatedHook], { cwd: directory, env }).status,
+    ).toBe(0);
 
     writeFileSync(
       userHook,
@@ -89,7 +100,9 @@ printf 'unreachable\\n'
     });
 
     expect(errexitResult.status).toBe(1);
-    expect(errexitResult.stdout).toBe('Rstack - pre-commit hook failed (code 1)\n');
+    expect(errexitResult.stdout).toBe(
+      'Rstack - pre-commit hook failed (code 1)\n',
+    );
 
     mkdirSync(runtimeDirectory, { recursive: true });
     writeFileSync(init, `export PATH="${runtimeDirectory}"\n`);

--- a/packages/rstack/tests/setup/install.test.ts
+++ b/packages/rstack/tests/setup/install.test.ts
@@ -1,19 +1,38 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { expect, test } from 'rstack/test';
 import { createHookFiles } from '../../src/setup/hooks.ts';
 import { installHooks } from '../../src/setup/install.ts';
-import { git, hooksPath, restoreEnv, runGit, withRepository } from './helpers.ts';
+import {
+  git,
+  hooksPath,
+  restoreEnv,
+  runGit,
+  withRepository,
+} from './helpers.ts';
 
 test('installs generated hooks and configures the repository', () => {
   withRepository((cwd) => {
     expect(installHooks({ cwd })).toEqual({ status: 'installed', hooksPath });
-    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(hooksPath);
+    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(
+      hooksPath,
+    );
 
     const directory = path.join(cwd, hooksPath);
-    expect(readFileSync(path.join(directory, '.gitignore'), 'utf8')).toBe('*\n');
+    expect(readFileSync(path.join(directory, '.gitignore'), 'utf8')).toBe(
+      '*\n',
+    );
     expect(readFileSync(path.join(directory, '.owner'), 'utf8')).toBe('.\n');
-    expect(runGit(cwd, ['status', '--short', '--untracked-files=all'])).toBe('');
+    expect(runGit(cwd, ['status', '--short', '--untracked-files=all'])).toBe(
+      '',
+    );
 
     for (const [name, content] of Object.entries(createHookFiles())) {
       const filePath = path.join(directory, name);
@@ -40,16 +59,19 @@ test('is idempotent and preserves user hooks', () => {
   });
 });
 
-test.runIf(process.platform !== 'win32')('restores executable mode on existing shims', () => {
-  withRepository((cwd) => {
-    expect(installHooks({ cwd }).status).toBe('installed');
-    const shim = path.join(cwd, hooksPath, 'pre-commit');
-    chmodSync(shim, 0o644);
+test.runIf(process.platform !== 'win32')(
+  'restores executable mode on existing shims',
+  () => {
+    withRepository((cwd) => {
+      expect(installHooks({ cwd }).status).toBe('installed');
+      const shim = path.join(cwd, hooksPath, 'pre-commit');
+      chmodSync(shim, 0o644);
 
-    expect(installHooks({ cwd }).status).toBe('installed');
-    expect(statSync(shim).mode & 0o777).toBe(0o755);
-  });
-});
+      expect(installHooks({ cwd }).status).toBe('installed');
+      expect(statSync(shim).mode & 0o777).toBe(0o755);
+    });
+  },
+);
 
 test('repairs generated files without rewriting an unchanged hooksPath', () => {
   withRepository((cwd) => {
@@ -94,7 +116,9 @@ test('does not configure Git when writing generated files fails', () => {
       status: 'failed',
       reason: 'write-failed',
     });
-    expect(git(cwd, ['config', '--local', '--get', 'core.hooksPath']).status).toBe(1);
+    expect(
+      git(cwd, ['config', '--local', '--get', 'core.hooksPath']).status,
+    ).toBe(1);
   });
 });
 
@@ -106,7 +130,9 @@ test('reports Git configuration failures without changing hooksPath', () => {
       status: 'failed',
       reason: 'git-config-failed',
     });
-    expect(git(cwd, ['config', '--local', '--get', 'core.hooksPath']).status).toBe(1);
+    expect(
+      git(cwd, ['config', '--local', '--get', 'core.hooksPath']).status,
+    ).toBe(1);
     expect(existsSync(path.join(cwd, hooksPath, 'runner'))).toBe(true);
   });
 });
@@ -119,7 +145,9 @@ test('does not replace another Git hooks path', () => {
       status: 'skipped',
       reason: 'hooks-path-conflict',
     });
-    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe('.husky/_');
+    expect(runGit(cwd, ['config', '--local', '--get', 'core.hooksPath'])).toBe(
+      '.husky/_',
+    );
     expect(existsSync(path.join(cwd, hooksPath))).toBe(false);
   });
 });
@@ -134,7 +162,9 @@ test('does not bypass existing Git hooks', () => {
       reason: 'existing-git-hooks',
       message: 'existing Git hooks were found: pre-commit',
     });
-    expect(git(cwd, ['config', '--local', '--get', 'core.hooksPath']).status).toBe(1);
+    expect(
+      git(cwd, ['config', '--local', '--get', 'core.hooksPath']).status,
+    ).toBe(1);
     expect(readFileSync(existingHook, 'utf8')).toBe('#!/usr/bin/env sh\n');
   });
 });

--- a/packages/rstack/tests/setup/runtime-errors.test.ts
+++ b/packages/rstack/tests/setup/runtime-errors.test.ts
@@ -28,6 +28,8 @@ missing-command
 
     expect(missing.status).toBe(127);
     expect(output).toContain('Rstack - pre-commit hook failed (code 127)');
-    expect(output).toContain(`Rstack - command not found in PATH=${actualPath}`);
+    expect(output).toContain(
+      `Rstack - command not found in PATH=${actualPath}`,
+    );
   });
 });

--- a/packages/rstack/tests/setup/runtime.test.ts
+++ b/packages/rstack/tests/setup/runtime.test.ts
@@ -1,8 +1,20 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { expect, test } from 'rstack/test';
 import { installHooks } from '../../src/setup/install.ts';
-import { runGitHook, runHook, withRepository, writeHook, writeInit } from './helpers.ts';
+import {
+  runGitHook,
+  runHook,
+  withRepository,
+  writeHook,
+  writeInit,
+} from './helpers.ts';
 
 test('loads user init and project binaries', () => {
   withRepository((cwd) => {
@@ -30,8 +42,12 @@ rstack-hook-command
     expect(installHooks({ cwd: projectDirectory }).status).toBe('installed');
 
     expect(runHook(cwd).status).toBe(0);
-    expect(readFileSync(path.join(projectDirectory, 'init-ran'), 'utf8')).toBe('loaded\n');
-    expect(readFileSync(path.join(projectDirectory, 'project-bin-ran'), 'utf8')).toBe('ran\n');
+    expect(readFileSync(path.join(projectDirectory, 'init-ran'), 'utf8')).toBe(
+      'loaded\n',
+    );
+    expect(
+      readFileSync(path.join(projectDirectory, 'project-bin-ran'), 'utf8'),
+    ).toBe('ran\n');
   });
 });
 

--- a/packages/rstack/tests/types/resolution-bundler/index.ts
+++ b/packages/rstack/tests/types/resolution-bundler/index.ts
@@ -17,7 +17,9 @@ import { expect as importedExpect, test as importedTest } from 'rstack/test';
 const appConfig = defineAppConfig({});
 const libConfig = defineLibConfig({});
 const lintConfig = defineLintConfig([]);
-const loadOptions: LoadRstackConfigOptions = { configFilePath: 'rstack.config.ts' };
+const loadOptions: LoadRstackConfigOptions = {
+  configFilePath: 'rstack.config.ts',
+};
 const loadedConfig: Promise<LoadedRstackConfig> = loadRstackConfig(loadOptions);
 const configs: Configs = {};
 
@@ -28,7 +30,10 @@ void createRsbuild({ config: appConfig });
 define.app(appConfig);
 define.lib(libConfig);
 define.lint(lintConfig);
-define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 define.doc({});
 define.test({});
 define.staged({});

--- a/packages/rstack/tests/types/resolution-nodenext/index.ts
+++ b/packages/rstack/tests/types/resolution-nodenext/index.ts
@@ -17,7 +17,9 @@ import { expect as importedExpect, test as importedTest } from 'rstack/test';
 const appConfig = defineAppConfig({});
 const libConfig = defineLibConfig({});
 const lintConfig = defineLintConfig([]);
-const loadOptions: LoadRstackConfigOptions = { configFilePath: 'rstack.config.ts' };
+const loadOptions: LoadRstackConfigOptions = {
+  configFilePath: 'rstack.config.ts',
+};
 const loadedConfig: Promise<LoadedRstackConfig> = loadRstackConfig(loadOptions);
 const configs: Configs = {};
 
@@ -28,7 +30,10 @@ void createRsbuild({ config: appConfig });
 define.app(appConfig);
 define.lib(libConfig);
 define.lint(lintConfig);
-define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 define.doc({});
 define.test({});
 define.staged({});

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -52,16 +52,10 @@ define.lint(async ({ js, ts }) => {
 });
 
 define.fmt({
-  ignorePatterns: ['packages/rstack/binding.cjs', 'packages/rstack/binding.d.cts'],
-  overrides: [
-    {
-      files: 'packages/create-rstack/template-*/**/*',
-      options: {
-        printWidth: 80,
-      },
-    },
+  ignorePatterns: [
+    'packages/rstack/binding.cjs',
+    'packages/rstack/binding.d.cts',
   ],
-  printWidth: 100,
   singleQuote: true,
   sortPackageJson: true,
 });

--- a/scripts/benchmark-fmt-discovery.js
+++ b/scripts/benchmark-fmt-discovery.js
@@ -30,7 +30,9 @@ const readValue = (args, index, flag) => {
 const parseInteger = (value, flag, minimum) => {
   const result = Number(value);
   if (!Number.isSafeInteger(result) || result < minimum) {
-    throw new Error(`${flag} must be an integer greater than or equal to ${minimum}.`);
+    throw new Error(
+      `${flag} must be an integer greater than or equal to ${minimum}.`,
+    );
   }
   return result;
 };
@@ -58,7 +60,11 @@ const parseArgs = (args) => {
         index++;
         break;
       case '--explicit-count':
-        options.explicitCount = parseInteger(readValue(args, index, arg), arg, 1);
+        options.explicitCount = parseInteger(
+          readValue(args, index, arg),
+          arg,
+          1,
+        );
         index++;
         break;
       case '--runs':

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
-import { copyFile, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import {
+  copyFile,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import path from 'node:path';
 
 const rootDir = path.resolve(import.meta.dirname, '..');

--- a/website/docs/en/guide/ai.mdx
+++ b/website/docs/en/guide/ai.mdx
@@ -50,7 +50,10 @@ The [migrate-to-rstack-cli](https://github.com/rstackjs/rstack-cli/tree/main/.ag
 
 To migrate an existing project, install the Skill:
 
-<PackageManagerTabs command="skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli" dlx />
+<PackageManagerTabs
+  command="skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli"
+  dlx
+/>
 
 For supported tools and migration instructions, see [Migrate to Rstack CLI](./migration).
 

--- a/website/docs/en/guide/cli/_meta.json
+++ b/website/docs/en/guide/cli/_meta.json
@@ -1,1 +1,13 @@
-["dev", "build", "preview", "lib", "doc", "test", "check", "lint", "fmt", "setup", "staged"]
+[
+  "dev",
+  "build",
+  "preview",
+  "lib",
+  "doc",
+  "test",
+  "check",
+  "lint",
+  "fmt",
+  "setup",
+  "staged"
+]

--- a/website/docs/en/guide/cli/lint.mdx
+++ b/website/docs/en/guide/cli/lint.mdx
@@ -34,5 +34,8 @@ Configure linting through [`define.lint()`](../configuration#define-lint) in the
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 ```

--- a/website/docs/en/guide/configuration.mdx
+++ b/website/docs/en/guide/configuration.mdx
@@ -154,7 +154,10 @@ Defines the [Rslint configuration](https://rslint.rs/config/). Pass the configur
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 ```
 
 ### `define.fmt()` \{#define-fmt}

--- a/website/docs/en/guide/monorepo.mdx
+++ b/website/docs/en/guide/monorepo.mdx
@@ -46,7 +46,10 @@ Use [`define.lint()`](./configuration#define-lint), [`define.fmt()`](./configura
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/website/docs/zh/guide/ai.mdx
+++ b/website/docs/zh/guide/ai.mdx
@@ -50,7 +50,10 @@ Rstack CLI 提供面向特定领域的 Agent Skills，帮助 Coding Agent 更准
 
 迁移现有项目时，安装该 Skill：
 
-<PackageManagerTabs command="skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli" dlx />
+<PackageManagerTabs
+  command="skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli"
+  dlx
+/>
 
 支持的工具和迁移说明请参阅[迁移到 Rstack CLI](./migration)。
 

--- a/website/docs/zh/guide/cli/_meta.json
+++ b/website/docs/zh/guide/cli/_meta.json
@@ -1,1 +1,13 @@
-["dev", "build", "preview", "lib", "doc", "test", "check", "lint", "fmt", "setup", "staged"]
+[
+  "dev",
+  "build",
+  "preview",
+  "lib",
+  "doc",
+  "test",
+  "check",
+  "lint",
+  "fmt",
+  "setup",
+  "staged"
+]

--- a/website/docs/zh/guide/cli/lint.mdx
+++ b/website/docs/zh/guide/cli/lint.mdx
@@ -34,5 +34,8 @@ rs lint --type-check
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 ```

--- a/website/docs/zh/guide/configuration.mdx
+++ b/website/docs/zh/guide/configuration.mdx
@@ -154,7 +154,10 @@ define.test({
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 ```
 
 ### `define.fmt()` \{#define-fmt}

--- a/website/docs/zh/guide/monorepo.mdx
+++ b/website/docs/zh/guide/monorepo.mdx
@@ -46,7 +46,10 @@ Rsbuild 插件、测试库等项目专属依赖，建议定义在实际使用它
 ```ts title="rstack.config.ts"
 import { define } from 'rstack';
 
-define.lint(({ js, ts }) => [js.configs.recommended, ts.configs.recommendedTypeChecked]);
+define.lint(({ js, ts }) => [
+  js.configs.recommended,
+  ts.configs.recommendedTypeChecked,
+]);
 
 define.fmt({
   singleQuote: true,

--- a/website/rstack.config.ts
+++ b/website/rstack.config.ts
@@ -5,14 +5,19 @@ import { define } from 'rstack';
 const title = 'Rstack CLI';
 const description =
   'Rstack CLI brings the Rstack toolchain together with one CLI, one configuration, and one consistent workflow.';
-const descriptionZh = 'Rstack CLI 通过统一的命令行、配置和工作流整合 Rstack 工具链。';
+const descriptionZh =
+  'Rstack CLI 通过统一的命令行、配置和工作流整合 Rstack 工具链。';
 const injectLlmsHint = process.env.RSPRESS_INJECT_LLMS_HINT !== 'false';
 
 define.doc(async () => {
   const { pluginSass } = await import('@rsbuild/plugin-sass');
-  const { transformerNotationDiff, transformerNotationFocus, transformerNotationHighlight } =
-    await import('@shikijs/transformers');
-  const { pluginClientRedirects } = await import('@rspress/plugin-client-redirects');
+  const {
+    transformerNotationDiff,
+    transformerNotationFocus,
+    transformerNotationHighlight,
+  } = await import('@shikijs/transformers');
+  const { pluginClientRedirects } =
+    await import('@rspress/plugin-client-redirects');
   const { pluginSitemap } = await import('@rspress/plugin-sitemap');
   const { pluginOpenGraph } = await import('rsbuild-plugin-open-graph');
   const { pluginFontOpenSans } = await import('rspress-plugin-font-open-sans');
@@ -88,7 +93,8 @@ define.doc(async () => {
         },
       ],
       editLink: {
-        docRepoBaseUrl: 'https://github.com/rstackjs/rstack-cli/tree/main/website/docs',
+        docRepoBaseUrl:
+          'https://github.com/rstackjs/rstack-cli/tree/main/website/docs',
       },
     },
     builderConfig: {

--- a/website/theme/components/Copyright.tsx
+++ b/website/theme/components/Copyright.tsx
@@ -5,7 +5,10 @@ export const CopyRight = () => {
     <footer className={styles.copyRight}>
       <div className={styles.copyRightInner}>
         <div className={styles.copyRightText}>
-          <p>Rstack CLI is free and open source software released under the MIT license.</p>
+          <p>
+            Rstack CLI is free and open source software released under the MIT
+            license.
+          </p>
           <p>© 2026 Rstack contributors.</p>
         </div>
       </div>

--- a/website/theme/components/Features.tsx
+++ b/website/theme/components/Features.tsx
@@ -1,7 +1,13 @@
 import { useI18n } from '@rspress/core/runtime';
 import { Link } from '@rspress/core/theme-original';
-import { containerStyle, innerContainerStyle } from '@rstack-dev/doc-ui/section-style';
-import { type Feature, WhyRspack as BaseFeatures } from '@rstack-dev/doc-ui/why-rspack';
+import {
+  containerStyle,
+  innerContainerStyle,
+} from '@rstack-dev/doc-ui/section-style';
+import {
+  type Feature,
+  WhyRspack as BaseFeatures,
+} from '@rstack-dev/doc-ui/why-rspack';
 import { memo, useMemo } from 'react';
 import CompatibleJson from './Features/assets/Compatible.json';
 import Compatible from './Features/assets/Compatible.svg';

--- a/website/theme/components/Hero.module.scss
+++ b/website/theme/components/Hero.module.scss
@@ -85,7 +85,8 @@
   code,
   .prompt {
     font-family:
-      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+      monospace;
     font-size: clamp(0.8125rem, 1vw, 0.9375rem);
     line-height: 1.4;
   }

--- a/website/theme/components/Hero.tsx
+++ b/website/theme/components/Hero.tsx
@@ -65,7 +65,12 @@ export function Hero() {
             <span>{t('quickStart')}</span>
             <SvgWrapper icon={IconArrowRight} />
           </Link>
-          <a className={styles.link} href={githubUrl} target="_blank" rel="noopener noreferrer">
+          <a
+            className={styles.link}
+            href={githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <span>{t('viewSource')}</span>
             <SvgWrapper icon={IconArrowRight} />
           </a>


### PR DESCRIPTION
This PR aligns the repository with the formatter's default 80-column print width so code remains easier to review in split views. It removes the explicit 100-column setting and the now-redundant template override, then reformats the affected files.