### PR TITLE
chore(ci): publish package previews

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,31 @@
+name: Publish Package Previews
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.19.0
+          package-manager-cache: false
+
+      - name: Install Pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          run_install: true
+
+      - name: Build Packages
+        run: node --run build
+
+      - name: Publish Package Previews
+        run: pnpm exec pkg-pr-new publish --pnpm --previewVersion --no-template './packages/rstack' './packages/create-rstack'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cspell-ban-words": "catalog:",
     "globals": "catalog:",
     "heading-case": "catalog:",
+    "pkg-pr-new": "catalog:",
     "prettier": "catalog:",
     "rstack": "workspace:*",
     "typescript": "catalog:"

--- a/packages/rstack/tests/pkgPrNew.test.ts
+++ b/packages/rstack/tests/pkgPrNew.test.ts
@@ -1,0 +1,20 @@
+import { readFile } from 'node:fs/promises';
+import { expect, test } from 'rstack/test';
+
+test('publishes pull request previews for public packages', async () => {
+  const [workflow, packageJson, workspace] = await Promise.all([
+    readFile(
+      new URL('../../../.github/workflows/pkg-pr-new.yml', import.meta.url),
+      'utf8',
+    ),
+    readFile(new URL('../../../package.json', import.meta.url), 'utf8'),
+    readFile(new URL('../../../pnpm-workspace.yaml', import.meta.url), 'utf8'),
+  ]);
+
+  expect(workflow).toContain('pkg-pr-new publish --pnpm --previewVersion');
+  expect(workflow).toContain("'./packages/rstack'");
+  expect(workflow).toContain("'./packages/create-rstack'");
+  expect(workflow).not.toContain('head.repo.full_name == github.repository');
+  expect(packageJson).toContain('"pkg-pr-new": "catalog:"');
+  expect(workspace).toContain('pkg-pr-new: 0.0.87');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ catalogs:
     micromatch:
       specifier: 4.0.8
       version: 4.0.8
+    pkg-pr-new:
+      specifier: 0.0.87
+      version: 0.0.87
     prettier:
       specifier: 3.9.6
       version: 3.9.6
@@ -168,6 +171,9 @@ importers:
       heading-case:
         specifier: 'catalog:'
         version: 1.1.5
+      pkg-pr-new:
+        specifier: 'catalog:'
+        version: 0.0.87
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -2675,6 +2681,9 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pkg-pr-new@0.0.87:
+    resolution: {integrity: sha512-nm+30Py1csXWfyMH1ueQyTR11IZGHS5oW8Qok/MxMwjPx9g1jX3wMRrJf8TgEvNo0a0M4i14T0zQsEPWdZfAhg==}
+    hasBin: true
   postcss@8.5.19:
     resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5471,6 +5480,7 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  pkg-pr-new@0.0.87: {}
   postcss@8.5.19:
     dependencies:
       nanoid: 3.3.16

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ catalog:
   is-binary-path: 3.0.0
   'lint-staged': '^17.3.0'
   'micromatch': '4.0.8'
+  pkg-pr-new: 0.0.87
   prettier: '3.9.6'
   'prettier-plugin-svelte': '^4.1.1'
   'react': '^19.2.8'


### PR DESCRIPTION
This PR enables pkg.pr.new previews for `rstack` and `create-rstack` so pull requests can be tested through installable package URLs before release.

It installs the publisher from the workspace lockfile, builds both packages, and publishes them in one pnpm-aware workflow invocation. The workflow is ready while the pkg.pr.new GitHub App access request is awaiting approval.