### PR TITLE
chore(lint): enable Rstest rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,6 @@
   "mdx.validate.validateFileLinks": "ignore",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   // Temporary workaround until we switch to the Rstack VS Code extension.
-  "prettier.printWidth": 100,
   "prettier.singleQuote": true,
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[typescript]": {

--- a/examples/app-vanilla/tests/dom.test.ts
+++ b/examples/app-vanilla/tests/dom.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'rstack/test';
 import { screen } from '@testing-library/dom';
 
-test('test dom', () => {
+test('renders content', () => {
   document.body.innerHTML = `
     <span data-testid="not-empty"><span data-testid="empty"></span></span>
     <div data-testid="visible">Visible Example</div>

--- a/packages/create-rstack/template-app-vanilla-ts/tests/dom.test.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/tests/dom.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'rstack/test';
 import { screen } from '@testing-library/dom';
 
-test('test dom', () => {
+test('renders content', () => {
   document.body.innerHTML = `
     <span data-testid="not-empty"><span data-testid="empty"></span></span>
     <div data-testid="visible">Visible Example</div>

--- a/packages/create-rstack/template-app-vanilla/tests/dom.test.js
+++ b/packages/create-rstack/template-app-vanilla/tests/dom.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'rstack/test';
 import { screen } from '@testing-library/dom';
 
-test('test dom', () => {
+test('renders content', () => {
   document.body.innerHTML = `
     <span data-testid="not-empty"><span data-testid="empty"></span></span>
     <div data-testid="visible">Visible Example</div>

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -1,7 +1,7 @@
 // Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
-define.lint(async ({ js, ts }) => {
+define.lint(async ({ js, ts, rstestPlugin }) => {
   const { default: globals } = await import('globals');
   return [
     js.configs.recommended,
@@ -17,6 +17,10 @@ define.lint(async ({ js, ts }) => {
           DEFINE_VALUE: 'readonly',
         },
       },
+    },
+    {
+      files: ['**/*.test.ts'],
+      ...rstestPlugin.configs.recommended,
     },
     // Source imports use .ts for Node.js native TypeScript execution; builds rewrite them to .js.
     {

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -19,7 +19,7 @@ define.lint(async ({ js, ts, rstestPlugin }) => {
       },
     },
     {
-      files: ['**/*.test.ts'],
+      files: ['**/*.test.{ts,tsx}'],
       ...rstestPlugin.configs.recommended,
     },
     // Source imports use .ts for Node.js native TypeScript execution; builds rewrite them to .js.


### PR DESCRIPTION
This PR enables Rstest's recommended lint rules for TypeScript test files so invalid test patterns are caught by repository checks. It updates the vanilla example and templates with a valid minimal test title, and removes the obsolete VS Code print-width override now that the repository uses Prettier's default.