### PR TITLE
feat(create-rstack): enable Rstest lint rules

### DIFF
--- a/packages/create-rstack/template-app-lit-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-lit-ts/rstack.config.ts
@@ -12,9 +12,13 @@ define.app({
   },
 });
 
-define.lint(({ js, ts }) => [
+define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-app-lit-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-lit-ts/rstack.config.ts
@@ -16,7 +16,7 @@ define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
   {
-    files: ['**/*.test.{ts,tsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-lit/rstack.config.js
+++ b/packages/create-rstack/template-app-lit/rstack.config.js
@@ -16,7 +16,7 @@ define.app({
 define.lint(({ js, rstestPlugin }) => [
   js.configs.recommended,
   {
-    files: ['**/*.test.{js,jsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-lit/rstack.config.js
+++ b/packages/create-rstack/template-app-lit/rstack.config.js
@@ -13,7 +13,13 @@ define.app({
   },
 });
 
-define.lint(({ js }) => [js.configs.recommended]);
+define.lint(({ js, rstestPlugin }) => [
+  js.configs.recommended,
+  {
+    files: ['**/*.test.{js,jsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-preact-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-preact-ts/rstack.config.ts
@@ -18,7 +18,7 @@ define.lint(({ js, ts, reactHooksPlugin, reactPlugin, rstestPlugin }) => [
   reactPlugin.configs.recommended,
   reactHooksPlugin.configs.recommended,
   {
-    files: ['**/*.test.{ts,tsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-preact-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-preact-ts/rstack.config.ts
@@ -12,11 +12,15 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(({ js, ts, reactHooksPlugin, reactPlugin }) => [
+define.lint(({ js, ts, reactHooksPlugin, reactPlugin, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
   reactPlugin.configs.recommended,
   reactHooksPlugin.configs.recommended,
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-app-preact/rstack.config.js
+++ b/packages/create-rstack/template-app-preact/rstack.config.js
@@ -18,7 +18,7 @@ define.lint(({ js, reactHooksPlugin, reactPlugin, rstestPlugin }) => [
   reactPlugin.configs.recommended,
   reactHooksPlugin.configs.recommended,
   {
-    files: ['**/*.test.{js,jsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-preact/rstack.config.js
+++ b/packages/create-rstack/template-app-preact/rstack.config.js
@@ -13,10 +13,14 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(({ js, reactHooksPlugin, reactPlugin }) => [
+define.lint(({ js, reactHooksPlugin, reactPlugin, rstestPlugin }) => [
   js.configs.recommended,
   reactPlugin.configs.recommended,
   reactHooksPlugin.configs.recommended,
+  {
+    files: ['**/*.test.{js,jsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-app-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-react-ts/rstack.config.ts
@@ -12,11 +12,15 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(({ js, ts, reactPlugin, reactHooksPlugin }) => [
+define.lint(({ js, ts, reactPlugin, reactHooksPlugin, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
   reactPlugin.configs.recommended,
   reactHooksPlugin.configs.recommended,
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-app-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-react-ts/rstack.config.ts
@@ -18,7 +18,7 @@ define.lint(({ js, ts, reactPlugin, reactHooksPlugin, rstestPlugin }) => [
   reactPlugin.configs.recommended,
   reactHooksPlugin.configs.recommended,
   {
-    files: ['**/*.test.{ts,tsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-react/rstack.config.js
+++ b/packages/create-rstack/template-app-react/rstack.config.js
@@ -18,7 +18,7 @@ define.lint(({ js, reactHooksPlugin, reactPlugin, rstestPlugin }) => [
   reactPlugin.configs.recommended,
   reactHooksPlugin.configs.recommended,
   {
-    files: ['**/*.test.{js,jsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-react/rstack.config.js
+++ b/packages/create-rstack/template-app-react/rstack.config.js
@@ -13,10 +13,14 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(({ js, reactHooksPlugin, reactPlugin }) => [
+define.lint(({ js, reactHooksPlugin, reactPlugin, rstestPlugin }) => [
   js.configs.recommended,
   reactPlugin.configs.recommended,
   reactHooksPlugin.configs.recommended,
+  {
+    files: ['**/*.test.{js,jsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-app-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-solid-ts/rstack.config.ts
@@ -22,7 +22,7 @@ define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
   {
-    files: ['**/*.test.{ts,tsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-solid-ts/rstack.config.ts
@@ -18,9 +18,13 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(({ js, ts }) => [
+define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-app-solid/rstack.config.js
+++ b/packages/create-rstack/template-app-solid/rstack.config.js
@@ -19,7 +19,13 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(({ js }) => [js.configs.recommended]);
+define.lint(({ js, rstestPlugin }) => [
+  js.configs.recommended,
+  {
+    files: ['**/*.test.{js,jsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-solid/rstack.config.js
+++ b/packages/create-rstack/template-app-solid/rstack.config.js
@@ -22,7 +22,7 @@ define.test({
 define.lint(({ js, rstestPlugin }) => [
   js.configs.recommended,
   {
-    files: ['**/*.test.{js,jsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
@@ -16,7 +16,7 @@ define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
   {
-    files: ['**/*.test.{ts,tsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-svelte-ts/rstack.config.ts
@@ -12,9 +12,13 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(({ js, ts }) => [
+define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-app-svelte/rstack.config.js
+++ b/packages/create-rstack/template-app-svelte/rstack.config.js
@@ -16,7 +16,7 @@ define.test({
 define.lint(({ js, rstestPlugin }) => [
   js.configs.recommended,
   {
-    files: ['**/*.test.{js,jsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-svelte/rstack.config.js
+++ b/packages/create-rstack/template-app-svelte/rstack.config.js
@@ -13,7 +13,13 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(({ js }) => [js.configs.recommended]);
+define.lint(({ js, rstestPlugin }) => [
+  js.configs.recommended,
+  {
+    files: ['**/*.test.{js,jsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
+]);
 
 define.fmt({
   plugins: ['prettier-plugin-svelte'],

--- a/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
@@ -13,7 +13,7 @@ define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
   {
-    files: ['**/*.test.{ts,tsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vanilla-ts/rstack.config.ts
@@ -9,9 +9,13 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(({ js, ts }) => [
+define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-app-vanilla/rstack.config.js
+++ b/packages/create-rstack/template-app-vanilla/rstack.config.js
@@ -13,7 +13,7 @@ define.test({
 define.lint(({ js, rstestPlugin }) => [
   js.configs.recommended,
   {
-    files: ['**/*.test.{js,jsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-vanilla/rstack.config.js
+++ b/packages/create-rstack/template-app-vanilla/rstack.config.js
@@ -10,7 +10,13 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(({ js }) => [js.configs.recommended]);
+define.lint(({ js, rstestPlugin }) => [
+  js.configs.recommended,
+  {
+    files: ['**/*.test.{js,jsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-app-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vue-ts/rstack.config.ts
@@ -16,7 +16,7 @@ define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
   {
-    files: ['**/*.test.{ts,tsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-app-vue-ts/rstack.config.ts
@@ -12,9 +12,13 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(({ js, ts }) => [
+define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-app-vue/rstack.config.js
+++ b/packages/create-rstack/template-app-vue/rstack.config.js
@@ -16,7 +16,7 @@ define.test({
 define.lint(({ js, rstestPlugin }) => [
   js.configs.recommended,
   {
-    files: ['**/*.test.{js,jsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-app-vue/rstack.config.js
+++ b/packages/create-rstack/template-app-vue/rstack.config.js
@@ -13,7 +13,13 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(({ js }) => [js.configs.recommended]);
+define.lint(({ js, rstestPlugin }) => [
+  js.configs.recommended,
+  {
+    files: ['**/*.test.{js,jsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-lib-node-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-node-ts/rstack.config.ts
@@ -6,9 +6,13 @@ define.lib({
   dts: true,
 });
 
-define.lint(({ js, ts }) => [
+define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-lib-node-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-node-ts/rstack.config.ts
@@ -10,7 +10,7 @@ define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
   {
-    files: ['**/*.test.{ts,tsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-lib-node/rstack.config.js
+++ b/packages/create-rstack/template-lib-node/rstack.config.js
@@ -9,7 +9,7 @@ define.lib({
 define.lint(({ js, rstestPlugin }) => [
   js.configs.recommended,
   {
-    files: ['**/*.test.{js,jsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-lib-node/rstack.config.js
+++ b/packages/create-rstack/template-lib-node/rstack.config.js
@@ -6,7 +6,13 @@ define.lib({
   syntax: ['node 22'],
 });
 
-define.lint(({ js }) => [js.configs.recommended]);
+define.lint(({ js, rstestPlugin }) => [
+  js.configs.recommended,
+  {
+    files: ['**/*.test.{js,jsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-lib-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-react-ts/rstack.config.ts
@@ -22,11 +22,15 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(({ js, ts, reactPlugin, reactHooksPlugin }) => [
+define.lint(({ js, ts, reactPlugin, reactHooksPlugin, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
   reactPlugin.configs.recommended,
   reactHooksPlugin.configs.recommended,
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-lib-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-react-ts/rstack.config.ts
@@ -28,7 +28,7 @@ define.lint(({ js, ts, reactPlugin, reactHooksPlugin, rstestPlugin }) => [
   reactPlugin.configs.recommended,
   reactHooksPlugin.configs.recommended,
   {
-    files: ['**/*.test.{ts,tsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-lib-react/rstack.config.js
+++ b/packages/create-rstack/template-lib-react/rstack.config.js
@@ -22,10 +22,14 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(({ js, reactHooksPlugin, reactPlugin }) => [
+define.lint(({ js, reactHooksPlugin, reactPlugin, rstestPlugin }) => [
   js.configs.recommended,
   reactPlugin.configs.recommended,
   reactHooksPlugin.configs.recommended,
+  {
+    files: ['**/*.test.{js,jsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-lib-react/rstack.config.js
+++ b/packages/create-rstack/template-lib-react/rstack.config.js
@@ -27,7 +27,7 @@ define.lint(({ js, reactHooksPlugin, reactPlugin, rstestPlugin }) => [
   reactPlugin.configs.recommended,
   reactHooksPlugin.configs.recommended,
   {
-    files: ['**/*.test.{js,jsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
@@ -77,7 +77,7 @@ define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
   {
-    files: ['**/*.test.{ts,tsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
@@ -73,9 +73,13 @@ define.test(async () => {
   };
 });
 
-define.lint(({ js, ts }) => [
+define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-lib-solid/rstack.config.js
+++ b/packages/create-rstack/template-lib-solid/rstack.config.js
@@ -73,7 +73,13 @@ define.test(async () => {
   };
 });
 
-define.lint(({ js }) => [js.configs.recommended]);
+define.lint(({ js, rstestPlugin }) => [
+  js.configs.recommended,
+  {
+    files: ['**/*.test.{js,jsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
+]);
 
 define.fmt({
   singleQuote: true,

--- a/packages/create-rstack/template-lib-solid/rstack.config.js
+++ b/packages/create-rstack/template-lib-solid/rstack.config.js
@@ -76,7 +76,7 @@ define.test(async () => {
 define.lint(({ js, rstestPlugin }) => [
   js.configs.recommended,
   {
-    files: ['**/*.test.{js,jsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
@@ -22,7 +22,7 @@ define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
   {
-    files: ['**/*.test.{ts,tsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
@@ -18,9 +18,13 @@ define.lib(async () => {
   };
 });
 
-define.lint(({ js, ts }) => [
+define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-lib-svelte/rstack.config.js
+++ b/packages/create-rstack/template-lib-svelte/rstack.config.js
@@ -18,7 +18,13 @@ define.lib(async () => {
   };
 });
 
-define.lint(({ js }) => [js.configs.recommended]);
+define.lint(({ js, rstestPlugin }) => [
+  js.configs.recommended,
+  {
+    files: ['**/*.test.{js,jsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
+]);
 
 define.fmt({
   plugins: ['prettier-plugin-svelte'],

--- a/packages/create-rstack/template-lib-svelte/rstack.config.js
+++ b/packages/create-rstack/template-lib-svelte/rstack.config.js
@@ -21,7 +21,7 @@ define.lib(async () => {
 define.lint(({ js, rstestPlugin }) => [
   js.configs.recommended,
   {
-    files: ['**/*.test.{js,jsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
@@ -21,9 +21,13 @@ define.test({
   setupFiles: ['./tests/rstest.setup.ts'],
 });
 
-define.lint(({ js, ts }) => [
+define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
 ]);
 
 define.fmt({

--- a/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
@@ -25,7 +25,7 @@ define.lint(({ js, ts, rstestPlugin }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
   {
-    files: ['**/*.test.{ts,tsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-lib-vue/rstack.config.js
+++ b/packages/create-rstack/template-lib-vue/rstack.config.js
@@ -25,7 +25,7 @@ define.test({
 define.lint(({ js, rstestPlugin }) => [
   js.configs.recommended,
   {
-    files: ['**/*.test.{js,jsx}'],
+    files: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     ...rstestPlugin.configs.recommended,
   },
 ]);

--- a/packages/create-rstack/template-lib-vue/rstack.config.js
+++ b/packages/create-rstack/template-lib-vue/rstack.config.js
@@ -22,7 +22,13 @@ define.test({
   setupFiles: ['./tests/rstest.setup.js'],
 });
 
-define.lint(({ js }) => [js.configs.recommended]);
+define.lint(({ js, rstestPlugin }) => [
+  js.configs.recommended,
+  {
+    files: ['**/*.test.{js,jsx}'],
+    ...rstestPlugin.configs.recommended,
+  },
+]);
 
 define.fmt({
   singleQuote: true,


### PR DESCRIPTION
This PR enables Rstest's recommended lint rules in all create-rstack application and library templates so generated projects catch invalid test patterns by default. The rules are scoped to JavaScript/JSX or TypeScript/TSX test files, keeping them out of regular source files.