### PR TITLE
chore(deps): disable Rust toolchain updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,11 @@
   "extends": ["github>rstackjs/renovate"],
   "packageRules": [
     {
+      "description": "Disable Rust toolchain updates",
+      "matchManagers": ["rust-toolchain"],
+      "enabled": false
+    },
+    {
       "description": "Disable TypeScript updates in Svelte and Vue templates until svelte-check, svelte2tsx, and vue-tsc support TypeScript 7",
       "matchManagers": ["npm"],
       "matchPackageNames": ["typescript"],


### PR DESCRIPTION
Renovate currently advances the pinned Rust toolchain automatically, which can introduce unplanned compiler changes.

This PR disables updates from the `rust-toolchain` manager while leaving Cargo dependency updates enabled.