### PR TITLE
refactor(create-rstack): unify lib template tsconfig

### DIFF
--- a/packages/create-rstack/template-app-lit-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-app-lit-ts/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["rstack/types", "node"]
+  },
+  "include": ["./"]
+}

--- a/packages/create-rstack/template-app-svelte-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-app-svelte-ts/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["rstack/types", "node", "@testing-library/jest-dom"]
+    "types": ["rstack/types", "node", "svelte", "@testing-library/jest-dom"]
   },
   "include": ["./"]
 }

--- a/packages/create-rstack/template-lib-node-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-lib-node-ts/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "types": ["rstack/types", "node"]
+  },
+  "include": ["./"]
+}

--- a/packages/create-rstack/template-lib-react-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-lib-react-ts/tests/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "types": ["@testing-library/jest-dom"]
+    "types": ["rstack/types", "node", "@testing-library/jest-dom"]
   },
   "include": ["./"]
 }

--- a/packages/create-rstack/template-lib-solid-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-lib-solid-ts/tests/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "types": ["@testing-library/jest-dom"]
+    "types": ["rstack/types", "node", "@testing-library/jest-dom"]
   },
   "include": ["./"]
 }

--- a/packages/create-rstack/template-lib-svelte-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-lib-svelte-ts/tests/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".."
+    "noEmit": true,
+    "rootDir": "..",
+    "types": ["rstack/types", "node", "svelte"]
   },
   "include": ["./"]
 }

--- a/packages/create-rstack/template-lib-svelte-ts/tsconfig.json
+++ b/packages/create-rstack/template-lib-svelte-ts/tsconfig.json
@@ -4,13 +4,12 @@
     "target": "ES2022",
     "declaration": true,
     "emitDeclarationOnly": true,
-    "isolatedModules": true,
+    "outDir": "dist",
     "skipLibCheck": true,
     "types": ["rstack/types", "node", "svelte"],
     "useDefineForClassFields": true,
 
     /* modules */
-    "module": "preserve",
     "moduleDetection": "force",
     "moduleResolution": "bundler",
     "verbatimModuleSyntax": true,
@@ -21,5 +20,5 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },
-  "include": ["src", "scripts", "*.config.ts"]
+  "include": ["src"]
 }

--- a/packages/create-rstack/template-lib-svelte-ts/tsconfig.json
+++ b/packages/create-rstack/template-lib-svelte-ts/tsconfig.json
@@ -8,6 +8,7 @@
     "skipLibCheck": true,
     "types": ["rstack/types", "node", "svelte"],
     "useDefineForClassFields": true,
+    "rootDir": "src",
 
     /* modules */
     "moduleDetection": "force",

--- a/packages/create-rstack/template-lib-vue-ts/tests/tsconfig.json
+++ b/packages/create-rstack/template-lib-vue-ts/tests/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "noEmit": true,
     "rootDir": "..",
-    "types": ["@testing-library/jest-dom"]
+    "types": ["rstack/types", "node", "@testing-library/jest-dom"]
   },
   "include": ["./"]
 }


### PR DESCRIPTION
## Summary

`types` and `include` in tsconfig are overridden, not merged.

- Restore `rstack/types` and `node` in lib templates' tests config, and `svelte` in app-svelte-ts.
- Add explicit `noEmit` to lib-svelte-ts and lib-vue-ts tests config, whose root config uses `emitDeclarationOnly`.
- Add the missing tests config to app-lit-ts and lib-node-ts.
- lib-svelte-ts root: add `outDir`, drop `isolatedModules` and `module`, narrow `include` to `src`.

Related to https://github.com/web-infra-dev/rslib/pull/1854
