### PR TITLE
refactor(create-rstack): align library templates with Rslib

### DIFF
--- a/packages/create-rstack/template-lib-node-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-node-ts/rstack.config.ts
@@ -2,7 +2,6 @@
 import { define } from 'rstack';
 
 define.lib({
-  syntax: ['node 22'],
   dts: true,
 });
 

--- a/packages/create-rstack/template-lib-node/package.json
+++ b/packages/create-rstack/template-lib-node/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.0",
   "sideEffects": false,
   "type": "module",
-  "exports": {
-    ".": {
-      "default": "./dist/index.js"
-    }
-  },
+  "exports": "./dist/index.js",
   "files": [
     "dist",
     "README.md"

--- a/packages/create-rstack/template-lib-node/rstack.config.js
+++ b/packages/create-rstack/template-lib-node/rstack.config.js
@@ -2,9 +2,7 @@
 // Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
-define.lib({
-  syntax: ['node 22'],
-});
+define.lib({});
 
 define.lint(({ js, rstestPlugin }) => [
   js.configs.recommended,

--- a/packages/create-rstack/template-lib-react-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-react-ts/rstack.config.ts
@@ -6,11 +6,6 @@ define.lib(async () => {
   return {
     bundle: false,
     dts: true,
-    source: {
-      entry: {
-        index: ['./src/**'],
-      },
-    },
     output: {
       target: 'web',
     },

--- a/packages/create-rstack/template-lib-react/package.json
+++ b/packages/create-rstack/template-lib-react/package.json
@@ -2,11 +2,7 @@
   "name": "rstack-lib-react",
   "version": "0.0.0",
   "type": "module",
-  "exports": {
-    ".": {
-      "default": "./dist/index.js"
-    }
-  },
+  "exports": "./dist/index.js",
   "files": [
     "dist",
     "README.md"

--- a/packages/create-rstack/template-lib-react/rstack.config.js
+++ b/packages/create-rstack/template-lib-react/rstack.config.js
@@ -6,11 +6,6 @@ define.lib(async () => {
   const { pluginReact } = await import('@rsbuild/plugin-react');
   return {
     bundle: false,
-    source: {
-      entry: {
-        index: ['./src/**'],
-      },
-    },
     output: {
       target: 'web',
     },

--- a/packages/create-rstack/template-lib-solid-ts/package.json
+++ b/packages/create-rstack/template-lib-solid-ts/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "solid": "./dist/index.jsx",
       "types": "./dist/index.d.ts",
+      "solid": "./dist/index.jsx",
       "default": "./dist/index.js"
     }
   },

--- a/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-solid-ts/rstack.config.ts
@@ -8,7 +8,6 @@ define.lib(async () => {
     lib: [
       {
         id: 'compiled',
-        bundle: false,
         dts: true,
         plugins: [
           pluginBabel({
@@ -19,7 +18,6 @@ define.lib(async () => {
       },
       {
         id: 'source',
-        bundle: false,
         output: {
           filename: {
             js: '[name].jsx',
@@ -48,11 +46,7 @@ define.lib(async () => {
         },
       },
     ],
-    source: {
-      entry: {
-        index: ['./src/**'],
-      },
-    },
+    bundle: false,
     output: {
       target: 'web',
     },

--- a/packages/create-rstack/template-lib-solid/rstack.config.js
+++ b/packages/create-rstack/template-lib-solid/rstack.config.js
@@ -9,7 +9,6 @@ define.lib(async () => {
     lib: [
       {
         id: 'compiled',
-        bundle: false,
         plugins: [
           pluginBabel({
             include: /\.(?:jsx|tsx)$/,
@@ -19,7 +18,6 @@ define.lib(async () => {
       },
       {
         id: 'source',
-        bundle: false,
         output: {
           filename: {
             js: '[name].jsx',
@@ -48,11 +46,7 @@ define.lib(async () => {
         },
       },
     ],
-    source: {
-      entry: {
-        index: ['./src/**'],
-      },
-    },
+    bundle: false,
     output: {
       target: 'web',
     },

--- a/packages/create-rstack/template-lib-svelte-ts/package.json
+++ b/packages/create-rstack/template-lib-svelte-ts/package.json
@@ -6,7 +6,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./style.css": "./dist/index.css"
   },
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-svelte-ts/rstack.config.ts
@@ -5,12 +5,6 @@ import { svelteDtsPlugin } from './scripts/rslib-plugin-svelte-dts.ts';
 define.lib(async () => {
   const { pluginSvelte } = await import('@rsbuild/plugin-svelte');
   return {
-    bundle: false,
-    source: {
-      entry: {
-        index: ['./src/**'],
-      },
-    },
     output: {
       target: 'web',
     },

--- a/packages/create-rstack/template-lib-svelte/package.json
+++ b/packages/create-rstack/template-lib-svelte/package.json
@@ -3,9 +3,8 @@
   "version": "0.0.0",
   "type": "module",
   "exports": {
-    ".": {
-      "default": "./dist/index.js"
-    }
+    ".": "./dist/index.js",
+    "./style.css": "./dist/index.css"
   },
   "files": [
     "dist",

--- a/packages/create-rstack/template-lib-svelte/rstack.config.js
+++ b/packages/create-rstack/template-lib-svelte/rstack.config.js
@@ -5,12 +5,6 @@ import { define } from 'rstack';
 define.lib(async () => {
   const { pluginSvelte } = await import('@rsbuild/plugin-svelte');
   return {
-    bundle: false,
-    source: {
-      entry: {
-        index: ['./src/**'],
-      },
-    },
     output: {
       target: 'web',
     },

--- a/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
+++ b/packages/create-rstack/template-lib-vue-ts/rstack.config.ts
@@ -5,11 +5,6 @@ define.lib(async () => {
   const { pluginVue } = await import('@rsbuild/plugin-vue');
   return {
     bundle: false,
-    source: {
-      entry: {
-        index: ['./src/**'],
-      },
-    },
     output: {
       target: 'web',
     },

--- a/packages/create-rstack/template-lib-vue-ts/tests/index.test.ts
+++ b/packages/create-rstack/template-lib-vue-ts/tests/index.test.ts
@@ -10,8 +10,9 @@ test('The button should have correct background color', () => {
       label: 'Demo Button',
     },
   });
-  expect(wrapper.get('button').element).toHaveStyle({
+  const button = wrapper.get('button');
+  expect(button.text()).toBe('Demo Button');
+  expect(button.element).toHaveStyle({
     backgroundColor: '#ccc',
   });
-  wrapper.unmount();
 });

--- a/packages/create-rstack/template-lib-vue/package.json
+++ b/packages/create-rstack/template-lib-vue/package.json
@@ -2,11 +2,7 @@
   "name": "rstack-lib-vue",
   "version": "0.0.0",
   "type": "module",
-  "exports": {
-    ".": {
-      "default": "./dist/index.js"
-    }
-  },
+  "exports": "./dist/index.js",
   "files": [
     "dist",
     "README.md"

--- a/packages/create-rstack/template-lib-vue/rstack.config.js
+++ b/packages/create-rstack/template-lib-vue/rstack.config.js
@@ -6,11 +6,6 @@ define.lib(async () => {
   const { pluginVue } = await import('@rsbuild/plugin-vue');
   return {
     bundle: false,
-    source: {
-      entry: {
-        index: ['./src/**'],
-      },
-    },
     output: {
       target: 'web',
     },

--- a/packages/create-rstack/template-lib-vue/tests/index.test.js
+++ b/packages/create-rstack/template-lib-vue/tests/index.test.js
@@ -10,8 +10,9 @@ test('The button should have correct background color', () => {
       label: 'Demo Button',
     },
   });
-  expect(wrapper.get('button').element).toHaveStyle({
+  const button = wrapper.get('button');
+  expect(button.text()).toBe('Demo Button');
+  expect(button.element).toHaveStyle({
     backgroundColor: '#ccc',
   });
-  wrapper.unmount();
 });


### PR DESCRIPTION
## Summary

Align create-rstack library templates with current Rslib defaults so generated projects use the supported output and package export conventions. This removes redundant source and syntax configuration, shares Solid's bundleless settings, and switches Svelte templates to bundle mode with an explicit stylesheet export. Vue tests now rely on the existing automatic unmount setup.

## Related Links

- https://github.com/web-infra-dev/rslib/commit/f85250606cf806dd07f9dcdaca666a614039203f
- https://github.com/web-infra-dev/rslib/commit/1f9c41f529ca5efbe67f2815e78b42c5bf5682c3
- https://github.com/web-infra-dev/rslib/commit/92c0e20650817358baa0e4efa7826228263d42ee