### PR TITLE
chore(vscode): use Rstack extension as default formatter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["rstack.rslint", "rstack.rstack"]
+  "recommendations": ["rstack.rstack"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["rstack.rslint", "esbenp.prettier-vscode"]
+  "recommendations": ["rstack.rslint", "rstack.rstack"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,17 +13,21 @@
     "**/.DS_Store": true
   },
   "mdx.validate.validateFileLinks": "ignore",
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  // Temporary workaround until we switch to the Rstack VS Code extension.
-  "prettier.singleQuote": true,
+  "editor.defaultFormatter": "rstack.rstack",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "rstack.rstack"
   },
   "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "rstack.rstack"
   },
   "[mdx]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "rstack.rstack"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "rstack.rstack"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "rstack.rstack"
   }
 }


### PR DESCRIPTION
## Summary

- Replace `esbenp.prettier-vscode` with `rstack.rstack` as the default formatter in `.vscode/settings.json` (default + typescript/javascript/mdx/json/jsonc)
- Remove the temporary `prettier.singleQuote` workaround
- Recommend `rstack.rstack` instead of Prettier in `.vscode/extensions.json`