### PR TITLE
docs(skills): migrate VS Code extension settings

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/references/prettier.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/prettier.md
@@ -6,14 +6,15 @@ Read this reference when the project uses the `prettier` CLI or API, `package.js
 
 ## Steps
 
-1. Inventory formatting commands and inputs, Prettier options and overrides, ignore rules, `.editorconfig`, plugins, package.json sorting, and programmatic API calls.
+1. Inventory formatting commands and inputs, Prettier options and overrides, ignore rules, `.editorconfig`, plugins, package.json sorting, programmatic API calls, and tracked VS Code settings.
 2. Move Prettier options and overrides into `define.fmt` in `rstack.config.*`.
 3. Move `.prettierignore` or custom `--ignore-path` rules into `ignorePatterns`. Rebase patterns from each ignore file's directory to the Rstack configuration directory when they differ, preserving rule order and negations. Translate relevant `.editorconfig` values into explicit formatting options.
 4. Replace Prettier CLI commands with the matching `rs fmt` commands and preserve their file or glob arguments.
 5. Reference plugins by package name, file path, or URL. Do not pass imported plugin objects, and keep each plugin package as a direct dependency.
 6. When replacing `prettier-plugin-packagejson`, enable `sortPackageJson` and preserve the original manifest paths.
-7. Delete old config and ignore files only after their behavior is represented in `define.fmt`.
-8. Remove direct dependencies only when no script, config, API call, plugin peer requirement, or other tool still needs them.
+7. If tracked VS Code configuration recommends `esbenp.prettier-vscode` or selects it with `editor.defaultFormatter`, replace it with `rstack.rstack` for scopes migrated to `rs fmt`, and move supported `prettier.*` formatting options into `define.fmt`. Preserve `editor.formatOnSave`, remove `source.fixAll.prettier` when no remaining scope uses it, and keep the Prettier extension for any scope that still does.
+8. Delete old config and ignore files only after their behavior is represented in `define.fmt`.
+9. Remove direct dependencies only when no script, config, API call, plugin peer requirement, or other tool still needs them.
 
 `rs fmt` ignores `package-lock.json` and `pnpm-lock.yaml` by default. Drop redundant ignore entries during migration, but keep intentional negations.
 

--- a/.agents/skills/migrate-to-rstack-cli/references/rslint.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rslint.md
@@ -8,6 +8,7 @@ Read this reference when the project uses `@rslint/core`, `rslint.config.*`, `rs
 2. Move the old config into `define.lint`, replacing Rslint's `defineConfig()` wrapper and import. Receive `@rslint/core` exports from the factory parameter.
 3. Replace custom `--config` paths with the migrated `rstack.config.*` path.
 4. Remove `@rslint/core` only when no uncovered direct runtime API remains. Delete `rslint.config.*`.
+5. If tracked VS Code configuration recommends `rstack.rslint`, replace it with the unified `rstack.rstack` extension. Move relevant `rslint.*` settings to their current `rstack.rslint.*` equivalents according to the [Rstack extension documentation](https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md). Keep `source.fixAll.rslint` unchanged.
 
 ## Config Pattern
 

--- a/.agents/skills/migrate-to-rstack-cli/references/rstest.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rstest.md
@@ -14,6 +14,7 @@ Read this reference when the project uses `@rstest/core`, `@rstest/adapter-rsbui
    - `@rstest/core/importMeta` to `rstack/test/importMeta`
 6. Search for remaining direct core or adapter imports. Remove `@rstest/core` and adapter dependencies only when no direct use remains.
 7. Delete `rstest.config.*` after all behavior is represented or intentionally supplied by automatic app/library extension.
+8. If tracked VS Code configuration recommends `rstack.rstest`, replace it with the unified `rstack.rstack` extension. Move supported `rstest.*` settings to `rstack.rstest.*` according to the [Rstack extension documentation](https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md); `rstest.nodeExecutable` instead becomes the shared `rstack.nodeExecutable` setting.
 
 ## Config Pattern
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -6,6 +6,7 @@ dirents
 editmsg
 errexit
 esac
+esbenp
 extglob
 fnames
 huskyrc


### PR DESCRIPTION
This PR keeps editor migration within each tool-specific `migrate-to-rstack-cli` flow.

It updates the Prettier, Rslint, and Rstest references to recommend the unified Rstack extension, migrate relevant VS Code settings, and preserve tool-specific behavior such as `source.fixAll.rslint`.