### PR TITLE
docs: document rs fmt supported languages

### DIFF
--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -12,6 +12,7 @@ huskyrc
 indentable
 jsonline
 llms
+MJML
 napi
 noformat
 noprettier

--- a/website/docs/en/guide/formatting.mdx
+++ b/website/docs/en/guide/formatting.mdx
@@ -54,6 +54,19 @@ In addition to Prettier options and `overrides`, Rstack CLI provides two options
 
 :::
 
+## Supported languages
+
+`rs fmt` supports the same built-in languages as [Prettier](https://prettier.io/docs/) and normally infers the language from the file name:
+
+- [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript), [JSX](https://react.github.io/jsx/), [Flow](https://flow.org/), and [TypeScript](https://www.typescriptlang.org/)
+- [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS), [Less](https://lesscss.org/), and [SCSS](https://sass-lang.com/)
+- [HTML](https://en.wikipedia.org/wiki/HTML), [Angular](https://angular.dev/), [Vue](https://vuejs.org/), [Ember/Handlebars](https://emberjs.com/), [Lightning Web Components (LWC)](https://developer.salesforce.com/developer-centers/lightning-web-components), and [MJML](https://mjml.io/)
+- [JSON](https://json.org/) and [YAML](https://yaml.org/)
+- [GraphQL](https://graphql.org/)
+- [Markdown](https://commonmark.org/), including [GFM](https://github.github.com/gfm/) and [MDX v1](https://mdxjs.com/)
+
+You can add support for other languages with [Prettier plugins](#prettier-plugins).
+
 ## Formatting scope
 
 `rs fmt` determines the formatting scope from the paths passed on the command line. You can combine the following inputs:

--- a/website/docs/zh/guide/formatting.mdx
+++ b/website/docs/zh/guide/formatting.mdx
@@ -54,6 +54,19 @@ define.fmt({
 
 :::
 
+## 支持的语言 \{#supported-languages}
+
+`rs fmt` 支持与 [Prettier](https://prettier.io/docs/) 相同的内置语言，通常会根据文件名自动推断语言：
+
+- [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript)、[JSX](https://react.github.io/jsx/)、[Flow](https://flow.org/) 和 [TypeScript](https://www.typescriptlang.org/)
+- [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS)、[Less](https://lesscss.org/) 和 [SCSS](https://sass-lang.com/)
+- [HTML](https://en.wikipedia.org/wiki/HTML)、[Angular](https://angular.dev/)、[Vue](https://vuejs.org/)、[Ember/Handlebars](https://emberjs.com/)、[Lightning Web Components（LWC）](https://developer.salesforce.com/developer-centers/lightning-web-components) 和 [MJML](https://mjml.io/)
+- [JSON](https://json.org/) 和 [YAML](https://yaml.org/)
+- [GraphQL](https://graphql.org/)
+- [Markdown](https://commonmark.org/)，包括 [GFM](https://github.github.com/gfm/) 和 [MDX v1](https://mdxjs.com/)
+
+你可以通过 [Prettier 插件](#prettier-plugins)支持其他语言。
+
 ## 格式化范围 \{#formatting-scope}
 
 `rs fmt` 根据命令行中传入的路径确定格式化范围。以下输入可以组合使用：


### PR DESCRIPTION
## Summary

This PR documents the languages supported by `rs fmt` so users can see which files are handled without additional plugins. It adds a grouped, linked language list to the English and Chinese formatting guides.

## Related Links

- https://prettier.io/docs/