### PR TITLE
chore(native): remove Rust version declaration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ resolver = "2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/rstackjs/rstack-cli"
-rust-version = "1.88"
 
 [workspace.dependencies]
 ignore = { version = "0.4.33", default-features = false }

--- a/crates/rstack-binding/Cargo.toml
+++ b/crates/rstack-binding/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
 publish = false
 
 [lib]

--- a/crates/rstack-ignore/Cargo.toml
+++ b/crates/rstack-ignore/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
 publish = false
 
 [dependencies]


### PR DESCRIPTION
## Summary

The native workspace declares Rust 1.88 as supported even though builds use a pinned nightly toolchain and do not verify Rust 1.88 compatibility. This PR removes the workspace `rust-version` declaration and its inheritance from both private crates, leaving compiler selection to `rust-toolchain.toml`.