### PR TITLE
docs: improve migration skill workflow

### DIFF
--- a/website/docs/en/guide/migration.mdx
+++ b/website/docs/en/guide/migration.mdx
@@ -4,21 +4,39 @@ description: 'Migrate an existing project to Rstack CLI with the recommended mig
 
 # Migrate to Rstack CLI
 
-To migrate an existing project, we recommend using the `migrate-to-rstack-cli` Skill. It inspects the project and automatically migrates supported tools used in the repository—including Rstack tools, Prettier, and Husky—to Rstack CLI.
+To migrate an existing project, we recommend using the `migrate-to-rstack-cli` Skill. It inspects the repository and migrates supported tooling—including the Rstack toolchain, Prettier, and Husky—to Rstack CLI.
 
 ## Use the migration skill
 
-First, install the Skill:
+### Migrate in one pass
+
+To migrate all supported tools in one pass, send this prompt to your coding agent:
+
+```text
+Run `npx --yes skills@latest use rstackjs/rstack-cli@migrate-to-rstack-cli` and follow the generated Skill instructions to migrate this project to Rstack CLI.
+```
+
+### Migrate in stages
+
+If you want to keep each set of changes small and easy to review, migrate one tool at a time. Start by installing the Skill in your repository:
 
 ```bash
 npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
 ```
 
-Then ask your coding agent to perform the migration with this prompt:
+Then ask your coding agent to migrate a single tool. For example, start with Rslint:
 
 ```text
-Use the migrate-to-rstack-cli Skill to migrate this project to Rstack CLI.
+Use the migrate-to-rstack-cli Skill to migrate Rslint in this project to Rstack CLI, leaving all other tools unchanged.
 ```
+
+Once you have reviewed and validated the changes, move on to Rstest:
+
+```text
+Use the migrate-to-rstack-cli Skill to migrate Rstest in this project to Rstack CLI, leaving all other tools unchanged.
+```
+
+Repeat this process for each remaining tool.
 
 ## Supported tools
 

--- a/website/docs/en/guide/migration.mdx
+++ b/website/docs/en/guide/migration.mdx
@@ -4,7 +4,7 @@ description: 'Migrate an existing project to Rstack CLI with the recommended mig
 
 # Migrate to Rstack CLI
 
-To migrate an existing project, we recommend using the `migrate-to-rstack-cli` Skill. It inspects the repository and migrates supported tooling—including the Rstack toolchain, Prettier, and Husky—to Rstack CLI.
+To migrate an existing project, we recommend using the `migrate-to-rstack-cli` Skill. It inspects the repository and migrates the Rstack toolchain, Prettier, Husky, and other supported tools to Rstack CLI.
 
 ## Use the migration skill
 

--- a/website/docs/zh/guide/migration.mdx
+++ b/website/docs/zh/guide/migration.mdx
@@ -4,7 +4,7 @@ description: '使用推荐的迁移 Skill，将现有项目迁移到 Rstack CLI�
 
 # 迁移到 Rstack CLI \{#migrate-to-rstack-cli}
 
-迁移现有项目时，推荐使用 `migrate-to-rstack-cli` Skill。该 Skill 会分析仓库，并将其中受支持的工具（包括 Rstack 工具链、Prettier 和 Husky）迁移到 Rstack CLI。
+迁移现有项目时，推荐使用 `migrate-to-rstack-cli` Skill。该 Skill 会分析仓库，并将其中受支持的工具（包括 Rstack 工具链、Prettier 和 Husky 等）迁移到 Rstack CLI。
 
 ## 使用迁移 Skill \{#use-the-migration-skill}
 

--- a/website/docs/zh/guide/migration.mdx
+++ b/website/docs/zh/guide/migration.mdx
@@ -4,21 +4,39 @@ description: '使用推荐的迁移 Skill，将现有项目迁移到 Rstack CLI�
 
 # 迁移到 Rstack CLI \{#migrate-to-rstack-cli}
 
-迁移现有项目时，推荐使用 `migrate-to-rstack-cli` Skill。该 Skill 会分析项目，并自动将仓库中使用的 Rstack 工具及 Prettier、Husky 等受支持工具迁移到 Rstack CLI。
+迁移现有项目时，推荐使用 `migrate-to-rstack-cli` Skill。该 Skill 会分析仓库，并将其中受支持的工具（包括 Rstack 工具链、Prettier 和 Husky）迁移到 Rstack CLI。
 
 ## 使用迁移 Skill \{#use-the-migration-skill}
 
-首先安装该 Skill：
+### 一次性迁移 \{#migrate-in-one-pass}
+
+如需一次性迁移所有受支持的工具，请向 Coding Agent 发送以下 Prompt：
+
+```text
+运行 `npx --yes skills@latest use rstackjs/rstack-cli@migrate-to-rstack-cli`，然后按照生成的 Skill 指令将当前项目迁移到 Rstack CLI。
+```
+
+### 分批迁移 \{#migrate-in-stages}
+
+如果希望每次改动更小、更便于审查，可以按工具分批迁移。首先，将 Skill 安装到当前仓库：
 
 ```bash
 npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
 ```
 
-安装完成后，向 Coding Agent 发送以下 Prompt：
+然后让 Coding Agent 每次只迁移一种工具。例如，可以先迁移 Rslint：
 
 ```text
-使用 migrate-to-rstack-cli Skill 将当前项目迁移到 Rstack CLI。
+使用 migrate-to-rstack-cli Skill 将当前项目中的 Rslint 迁移到 Rstack CLI，并保持其他工具不变。
 ```
+
+审查并验证本次改动后，再迁移 Rstest：
+
+```text
+使用 migrate-to-rstack-cli Skill 将当前项目中的 Rstest 迁移到 Rstack CLI，并保持其他工具不变。
+```
+
+其余工具也可以按此方式依次迁移。
 
 ## 支持的工具 \{#supported-tools}
 


### PR DESCRIPTION
This PR streamlines the migration guide so users can start a complete Rstack CLI migration with a single prompt.

It also documents a staged workflow for migrating one tool at a time when smaller, easier-to-review changes are preferred. The English and Chinese guides remain aligned.