### PR TITLE
perf(rstack): load config once during rs check

### DIFF
--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -156,7 +156,7 @@ async function runRslintCLI(args: string[]): Promise<void> {
   await runCLI({ argv });
 }
 
-const getLoadedRslintRstackConfig = async (): Promise<LoadedRstackConfig> => {
+const getLoadedConfig = async (): Promise<LoadedRstackConfig> => {
   // Rslint loads its one-shot config through Node's module cache. Import the
   // same URL to read the Rstack config exported for the following fmt phase.
   const configModule = (await import(
@@ -186,7 +186,7 @@ async function runCheckCLI(args: string[]): Promise<void> {
     return;
   }
 
-  const loadedConfig = await getLoadedRslintRstackConfig();
+  const loadedConfig = await getLoadedConfig();
   const { runFmtCLI } = await import(
     /* rspackChunkName: 'fmt' */
     '../fmt/cli.ts'

--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -1,5 +1,6 @@
 import { join, resolve } from 'node:path';
-import { getConfigState } from '../config.ts';
+import { pathToFileURL } from 'node:url';
+import { getConfigState, type LoadedRstackConfig } from '../config.ts';
 import { insertConfigArg, parseArgs, parseCliArgs } from './args.ts';
 import { hasHelpFlag, printCommandHelp } from './help.ts';
 
@@ -138,6 +139,8 @@ async function runRspressCLI(args: string[]): Promise<void> {
   }
 }
 
+const RSLINT_CONFIG_PATH = join(import.meta.dirname, 'rslintConfig.js');
+
 async function runRslintCLI(args: string[]): Promise<void> {
   if (hasHelpFlag(args)) {
     return printCommandHelp('lint');
@@ -146,16 +149,22 @@ async function runRslintCLI(args: string[]): Promise<void> {
   const argv = [
     process.execPath,
     'rslint',
-    ...insertConfigArg(
-      args,
-      '--config',
-      join(import.meta.dirname, 'rslintConfig.js'),
-    ),
+    ...insertConfigArg(args, '--config', RSLINT_CONFIG_PATH),
   ];
 
   const { runCLI } = await import('@rslint/core');
   await runCLI({ argv });
 }
+
+const getLoadedRslintRstackConfig = async (): Promise<LoadedRstackConfig> => {
+  // Rslint loads its one-shot config through Node's module cache. Import the
+  // same URL to read the Rstack config exported for the following fmt phase.
+  const configModule = (await import(
+    pathToFileURL(RSLINT_CONFIG_PATH).href
+  )) as typeof import('../rslintConfig.ts');
+
+  return configModule.loadedConfig;
+};
 
 async function runCheckCLI(args: string[]): Promise<void> {
   const { values } = parseArgs({
@@ -177,11 +186,12 @@ async function runCheckCLI(args: string[]): Promise<void> {
     return;
   }
 
+  const loadedConfig = await getLoadedRslintRstackConfig();
   const { runFmtCLI } = await import(
     /* rspackChunkName: 'fmt' */
     '../fmt/cli.ts'
   );
-  await runFmtCLI(['--check']);
+  await runFmtCLI(['--check'], { loadedConfig });
 }
 
 export async function setupCommands(): Promise<void> {

--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { getConfigState, type LoadedRstackConfig } from '../config.ts';
+import { getConfigState } from '../config.ts';
 import { insertConfigArg, parseArgs, parseCliArgs } from './args.ts';
 import { hasHelpFlag, printCommandHelp } from './help.ts';
 
@@ -156,16 +156,6 @@ async function runRslintCLI(args: string[]): Promise<void> {
   await runCLI({ argv });
 }
 
-const getLoadedConfig = async (): Promise<LoadedRstackConfig> => {
-  // Rslint loads its one-shot config through Node's module cache. Import the
-  // same URL to read the Rstack config exported for the following fmt phase.
-  const configModule = (await import(
-    pathToFileURL(RSLINT_CONFIG_PATH).href
-  )) as typeof import('../rslintConfig.ts');
-
-  return configModule.loadedConfig;
-};
-
 async function runCheckCLI(args: string[]): Promise<void> {
   const { values } = parseArgs({
     args,
@@ -186,7 +176,11 @@ async function runCheckCLI(args: string[]): Promise<void> {
     return;
   }
 
-  const loadedConfig = await getLoadedConfig();
+  // Rslint loads its one-shot config through Node's module cache. Import the
+  // same URL to read the Rstack config exported for the following fmt phase.
+  const { loadedConfig } = (await import(
+    pathToFileURL(RSLINT_CONFIG_PATH).href
+  )) as typeof import('../rslintConfig.ts');
   const { runFmtCLI } = await import(
     /* rspackChunkName: 'fmt' */
     '../fmt/cli.ts'

--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -3,7 +3,7 @@ import { performance } from 'node:perf_hooks';
 import { color, logger } from 'rslog';
 import { parseArgs } from '../cli/args.ts';
 import { printCommandHelp } from '../cli/help.ts';
-import { loadRstackConfig } from '../config.ts';
+import { loadRstackConfig, type LoadedRstackConfig } from '../config.ts';
 import { ensureProjectCacheDir } from '../projectCache.ts';
 import { fmtCacheFileName } from './cacheStore.ts';
 import { resolveFmtConfig } from './config.ts';
@@ -28,6 +28,11 @@ interface ParsedFmtCLIArgs {
   /** Serve formatting over the Language Server Protocol instead of exiting. */
   lsp: boolean;
 }
+
+type RunFmtCLIOptions = {
+  /** Rstack config already loaded by the lint phase of `rs check`. */
+  loadedConfig?: LoadedRstackConfig;
+};
 
 const parseMaxWorkers = (value: string | undefined): number | undefined => {
   if (value === undefined) {
@@ -255,8 +260,12 @@ const logFmtResult = (
   }
 };
 
-const loadFmtConfig = async (cwd: string): Promise<ResolvedFmtConfig> => {
-  const { configs, filePath } = await loadRstackConfig({ cwd });
+const loadFmtConfig = async (
+  cwd: string,
+  loadedConfig?: LoadedRstackConfig,
+): Promise<ResolvedFmtConfig> => {
+  const { configs, filePath } =
+    loadedConfig ?? (await loadRstackConfig({ cwd }));
 
   return resolveFmtConfig({
     definition: configs.fmt,
@@ -265,7 +274,10 @@ const loadFmtConfig = async (cwd: string): Promise<ResolvedFmtConfig> => {
   });
 };
 
-const runFmtCLI = async (args: string[]): Promise<void> => {
+const runFmtCLI = async (
+  args: string[],
+  { loadedConfig }: RunFmtCLIOptions = {},
+): Promise<void> => {
   const cwd = process.cwd();
   const startTime = performance.now();
 
@@ -337,7 +349,7 @@ const runFmtCLI = async (args: string[]): Promise<void> => {
       }
     }
 
-    const config = await loadFmtConfig(cwd);
+    const config = await loadFmtConfig(cwd, loadedConfig);
     const files = await discoverFmtFiles({
       cwd,
       patterns,

--- a/packages/rstack/src/rslintConfig.ts
+++ b/packages/rstack/src/rslintConfig.ts
@@ -1,7 +1,10 @@
-import { loadRstackConfig } from './config.ts';
+import { loadRstackConfig, type LoadedRstackConfig } from './config.ts';
 import type { RslintConfig } from '@rslint/core';
 
-const { configs } = await loadRstackConfig();
+// Expose the loaded config so `rs check` can pass it to fmt instead of loading
+// and executing the Rstack config a second time.
+export const loadedConfig: LoadedRstackConfig = await loadRstackConfig();
+const { configs } = loadedConfig;
 const lintDefinition = configs.lint ?? [];
 
 let lintConfig: RslintConfig;


### PR DESCRIPTION
Running `rs check` currently evaluates the Rstack config once for lint and again for formatting. This PR exposes the config already loaded by the Rslint adapter and passes it explicitly to the formatter, avoiding the second evaluation while keeping standalone `rs fmt` config loading unchanged.