### PR TITLE
perf(fmt): optimize Yuku type cast lookup

### DIFF
--- a/packages/rstack/src/fmt/yukuPlugin.ts
+++ b/packages/rstack/src/fmt/yukuPlugin.ts
@@ -260,6 +260,29 @@ const isTypeCastComment = (comment: PrettierComment): boolean =>
   comment.value.startsWith('*') &&
   /@(?:type|satisfies)\b/.test(comment.value);
 
+/**
+ * Returns the greatest value less than or equal to `target` from an ascending
+ * array, or `undefined` when no such value exists.
+ */
+const findLastAtOrBefore = (
+  sortedValues: number[],
+  target: number,
+): number | undefined => {
+  let lower = 0;
+  let upper = sortedValues.length;
+
+  while (lower < upper) {
+    const middle = lower + Math.floor((upper - lower) / 2);
+    if (sortedValues[middle] <= target) {
+      lower = middle + 1;
+    } else {
+      upper = middle;
+    }
+  }
+
+  return sortedValues[lower - 1];
+};
+
 type VisitOptions = {
   onEnter?: (node: AstNode) => AstNode | undefined;
   onLeave?: (node: AstNode) => AstNode | undefined;
@@ -362,12 +385,14 @@ const postprocess = (
           const expression = asAstNode(node.expression);
           const start = locStart(node);
 
+          // Yuku comments are in source order, so these end offsets are sorted.
           typeCastCommentEnds ??= comments
             .filter(isTypeCastComment)
             .map((comment) => locEnd(comment));
 
-          const previousCommentEnd = typeCastCommentEnds.findLast(
-            (end) => end <= start,
+          const previousCommentEnd = findLastAtOrBefore(
+            typeCastCommentEnds,
+            start,
           );
           const shouldKeepParentheses =
             previousCommentEnd !== undefined &&


### PR DESCRIPTION
Yuku postprocessing currently scans later type-cast comments for each parenthesized expression, causing quadratic growth in comment-heavy files. This PR replaces the reverse linear lookup with an upper-bound binary search over source-ordered comment offsets, reducing the lookup cost to O(n log n) without changing formatting behavior.

Performance was measured on Node.js v24.12.0 with synthetic Closure-style `@type` inputs. Each value is the median parse + postprocess time from 10 measured runs after 3 warmup runs.

| Type casts | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 2,000 | 10.568 ms | 1.655 ms | 6.4x |
| 4,000 | 39.358 ms | 3.075 ms | 12.8x |
| 8,000 | 149.026 ms | 6.242 ms | 23.9x |

At 8,000 entries, the median time decreases by 95.8% and becomes close to the 5.629 ms control input containing equally sized ordinary comments.