### PR TITLE
docs: improve migration prompts

### DIFF
--- a/website/docs/en/guide/migration.mdx
+++ b/website/docs/en/guide/migration.mdx
@@ -12,7 +12,7 @@ To migrate an existing project, we recommend using the `migrate-to-rstack-cli` S
 
 To migrate all supported tools in one pass, send this prompt to your coding agent:
 
-```text
+```text wrapCode
 Run `npx --yes skills@latest use rstackjs/rstack-cli@migrate-to-rstack-cli` and follow the generated Skill instructions to migrate this project to Rstack CLI.
 ```
 
@@ -26,14 +26,14 @@ npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
 
 Then ask your coding agent to migrate a single tool. For example, start with Rslint:
 
-```text
-Use the migrate-to-rstack-cli Skill to migrate Rslint in this project to Rstack CLI, leaving all other tools unchanged.
+```text wrapCode
+Use the migrate-to-rstack-cli Skill to migrate Rslint to Rstack CLI, leaving all other tools unchanged.
 ```
 
 Once you have reviewed and validated the changes, move on to Rstest:
 
-```text
-Use the migrate-to-rstack-cli Skill to migrate Rstest in this project to Rstack CLI, leaving all other tools unchanged.
+```text wrapCode
+Use the migrate-to-rstack-cli Skill to migrate Rstest to Rstack CLI, leaving all other tools unchanged.
 ```
 
 Repeat this process for each remaining tool.

--- a/website/docs/zh/guide/migration.mdx
+++ b/website/docs/zh/guide/migration.mdx
@@ -12,7 +12,7 @@ description: '使用推荐的迁移 Skill，将现有项目迁移到 Rstack CLI�
 
 如需一次性迁移所有受支持的工具，请向 Coding Agent 发送以下 Prompt：
 
-```text
+```text wrapCode
 运行 `npx --yes skills@latest use rstackjs/rstack-cli@migrate-to-rstack-cli`，然后按照生成的 Skill 指令将当前项目迁移到 Rstack CLI。
 ```
 
@@ -26,14 +26,14 @@ npx skills add rstackjs/rstack-cli --skill migrate-to-rstack-cli
 
 然后让 Coding Agent 每次只迁移一种工具。例如，可以先迁移 Rslint：
 
-```text
-使用 migrate-to-rstack-cli Skill 将当前项目中的 Rslint 迁移到 Rstack CLI，并保持其他工具不变。
+```text wrapCode
+使用 migrate-to-rstack-cli Skill 将 Rslint 迁移到 Rstack CLI，并保持其他工具不变。
 ```
 
 审查并验证本次改动后，再迁移 Rstest：
 
-```text
-使用 migrate-to-rstack-cli Skill 将当前项目中的 Rstest 迁移到 Rstack CLI，并保持其他工具不变。
+```text wrapCode
+使用 migrate-to-rstack-cli Skill 将 Rstest 迁移到 Rstack CLI，并保持其他工具不变。
 ```
 
 其余工具也可以按此方式依次迁移。


### PR DESCRIPTION
## Summary

This PR improves the migration guide prompts so long commands wrap in the documentation UI. It also removes redundant wording from the staged migration prompts while keeping the English and Chinese guides aligned.