### PR TITLE
fix(rstack): clarify forced setup output

### DIFF
--- a/packages/rstack/src/setup/index.ts
+++ b/packages/rstack/src/setup/index.ts
@@ -32,23 +32,24 @@ export const runSetupCLI = async (args: string[]): Promise<void> => {
   const result = installHooks({ force: values.force, hooksDir });
 
   if (result.status === 'installed') {
-    // Warn when `--force` preserves an existing hooks setup but makes it inactive.
+    // Explain the result when `--force` preserves an existing hooks setup but makes it inactive.
     if (result.inactiveHooks) {
       const { hooks, path, restore } = result.inactiveHooks;
       const hooksMessage = hooks.length
         ? `: ${color.yellow(hooks.join(', '))}`
         : '';
-      logger.warn(
-        `The previous Git hooks path "${color.yellow(path)}" is now inactive${hooksMessage}.`,
+      logger.info(
+        `Rstack now manages Git hooks at "${color.yellow(result.hooksPath)}".`,
+      );
+      logger.info(
+        `Existing hooks in "${color.yellow(path)}" were preserved but will no longer run${hooksMessage}.`,
       );
 
       if (restore === 'unset') {
-        logger.info(
-          `The existing files were preserved and will become active again if ${color.yellow('core.hooksPath')} is unset.`,
-        );
+        logger.info(`Unset ${color.yellow('core.hooksPath')} to restore them.`);
       } else {
         logger.info(
-          `The existing files were preserved. Set ${color.yellow('core.hooksPath')} back to this path to use them again.`,
+          `Set ${color.yellow('core.hooksPath')} back to "${color.yellow(path)}" to restore them.`,
         );
       }
     }

--- a/packages/rstack/tests/cli/setup/index.test.ts
+++ b/packages/rstack/tests/cli/setup/index.test.ts
@@ -140,11 +140,12 @@ test('guides and forces setup while preserving existing hooks', ({
 
   const forcedOutput = runSetupSuccessfully(['--force']);
   expect(forcedOutput).toContain(
-    'The previous Git hooks path ".git/hooks" is now inactive: pre-commit.',
+    'info    Rstack now manages Git hooks at ".rstack/hooks/_".',
   );
   expect(forcedOutput).toContain(
-    'The existing files were preserved and will become active again if core.hooksPath is unset.',
+    'Existing hooks in ".git/hooks" were preserved but will no longer run: pre-commit.',
   );
+  expect(forcedOutput).toContain('Unset core.hooksPath to restore them.');
   expect(git(['config', '--local', '--get', 'core.hooksPath'])).toBe(hooksPath);
 
   git(['hook', 'run', 'pre-commit']);
@@ -155,7 +156,7 @@ test('guides and forces setup while preserving existing hooks', ({
   expect(existsSync(path.join(cwd, 'old-hook-ran'))).toBe(true);
 
   expect(runSetupSuccessfully(['-f'])).toContain(
-    'The previous Git hooks path ".git/hooks" is now inactive: pre-commit.',
+    'Existing hooks in ".git/hooks" were preserved but will no longer run: pre-commit.',
   );
 });
 
@@ -171,10 +172,13 @@ test('reports how to restore a replaced hooks path', ({ expect }) => {
 
   const output = runSetupSuccessfully(['--force']);
   expect(output).toContain(
-    'The previous Git hooks path ".husky/_" is now inactive: pre-commit.',
+    'info    Rstack now manages Git hooks at ".rstack/hooks/_".',
   );
   expect(output).toContain(
-    'The existing files were preserved. Set core.hooksPath back to this path to use them again.',
+    'Existing hooks in ".husky/_" were preserved but will no longer run: pre-commit.',
+  );
+  expect(output).toContain(
+    'Set core.hooksPath back to ".husky/_" to restore them.',
   );
 });
 


### PR DESCRIPTION
## Summary

`rs setup --force` currently emits a warning after successfully taking over an existing Git hooks setup, which can make an expected operation appear unsuccessful. This PR reports the takeover as informational output, clearly identifies which existing hooks will no longer run, and includes the exact path needed to restore custom hook configurations.