### PR TITLE
refactor: use rs hooks in generated projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "doc:build": "node --run build && pnpm --dir website build",
     "format": "rs fmt && heading-case --write",
     "lint": "rs lint --type-check",
-    "prepare": "node scripts/rs.js setup",
+    "prepare": "node scripts/rs.js hooks",
     "release:prepare": "node scripts/prepare-release.js",
     "test": "pnpm --parallel --filter \"./packages/**\" test"
   },

--- a/packages/create-rstack/src/index.ts
+++ b/packages/create-rstack/src/index.ts
@@ -198,7 +198,7 @@ const injectStagedSetup = async ({
   };
 
   packageJson.scripts = Object.fromEntries(
-    Object.entries({ ...packageJson.scripts, prepare: 'rs setup' }).sort(
+    Object.entries({ ...packageJson.scripts, prepare: 'rs hooks' }).sort(
       ([left], [right]) => left.localeCompare(right),
     ),
   );

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -137,7 +137,7 @@ const expectStagedSetup = async (
   configExtension: string,
   scripts: Record<string, string>,
 ): Promise<void> => {
-  expect(scripts.prepare).toBe('rs setup');
+  expect(scripts.prepare).toBe('rs hooks');
   expect(
     await readFile(
       path.join(projectDirectory, '.rstack', 'hooks', 'pre-commit'),


### PR DESCRIPTION
## Summary

`rs hooks` is now the canonical command for the Git hooks lifecycle, while `rs setup` remains a compatibility alias. This PR updates create-rstack projects and the repository's source-based `prepare` script to use `rs hooks`, without changing unrelated templates or compatibility behavior.