### PR TITLE
docs: move LLMs UI to page outline

### DIFF
--- a/website/rstack.config.ts
+++ b/website/rstack.config.ts
@@ -78,6 +78,7 @@ define.doc(async () => {
     ],
     themeConfig: {
       llmsUI: {
+        placement: 'outline',
         injectLlmsHint,
       },
       socialLinks: [


### PR DESCRIPTION
## Summary

This PR moves the LLMs UI action into the documentation page outline so it stays accessible alongside page navigation. It sets `themeConfig.llmsUI.placement` to `outline`.