### PR TITLE
docs: update website brand colors

### DIFF
--- a/website/theme/theme.scss
+++ b/website/theme/theme.scss
@@ -1,10 +1,10 @@
 :root {
-  --rp-c-brand: #f93920;
-  --rp-c-brand-light: #fa6552;
-  --rp-c-brand-lighter: #fc9183;
-  --rp-c-brand-dark: #f82307;
-  --rp-c-brand-darker: #e01f06;
-  --rp-c-brand-tint: rgba(249, 57, 32, 0.15);
+  --rp-c-brand: #ff5e00;
+  --rp-c-brand-dark: var(--rp-c-brand);
+  --rp-c-brand-darker: #ff704d;
+  --rp-c-brand-light: #ff7524;
+  --rp-c-brand-lighter: #ff7524;
+  --rp-c-brand-tint: rgba(255, 94, 0, 0.07);
   --rp-c-text-code: var(--rp-c-text-1);
 }
 


### PR DESCRIPTION
This PR refreshes the documentation site's brand palette so the theme uses the current orange accent. It updates the main, light, dark, and tint variables used across the Rspress theme.