### PR TITLE
fix: pin Rslint to 0.8.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ catalogs:
       specifier: ~1.0.0-rc.2
       version: 1.0.0-rc.2
     '@rslint/core':
-      specifier: ~0.8.1
+      specifier: 0.8.1
       version: 0.8.1
     '@rspress/core':
       specifier: ^2.0.20

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@rsbuild/plugin-react': '^2.1.0'
   '@rsbuild/plugin-sass': '^2.0.1'
   '@rslib/core': '~1.0.0-rc.2'
-  '@rslint/core': '~0.8.1'
+  '@rslint/core': '0.8.1'
   '@rspress/core': '^2.0.20'
   '@rspress/plugin-client-redirects': '^2.0.20'
   '@rspress/plugin-sitemap': '^2.0.20'


### PR DESCRIPTION
## Summary

Rslint 0.8.2 changes explicit config path resolution and causes rs lint to resolve the internal proxy config from the wrong directory. This pins @rslint/core to 0.8.1 until Rstack supports the new resolution semantics.

## Related Links

- https://github.com/web-infra-dev/rslint/pull/1851