### PR TITLE
docs: rename Rstack CLI agent skill

### DIFF
--- a/.agents/skills/rstack-cli-docs/SKILL.md
+++ b/.agents/skills/rstack-cli-docs/SKILL.md
@@ -1,18 +1,18 @@
 ---
-name: rstack-cli-best-practices
-description: Guidance for Rstack CLI work involving `rs` commands, `rstack.config.*`, package APIs, or Rstack-based projects and tooling.
+name: rstack-cli-docs
+description: Consult installed, version-matched Rstack docs only for user-facing `rs` command behavior, `rstack.config.*` semantics, or public `rstack` APIs. Do not use for purely internal implementation, tests, performance, or repository maintenance.
 ---
 
-# Rstack CLI Best Practices
+# Rstack CLI Docs
 
 Rstack CLI is the `rstack` package, exposed through the `rs` binaries. It provides one CLI, one
 config file, and a consistent workflow for the Rstack JavaScript toolchain.
 
 It covers web app, library, docs, test, lint, formatting, Git hook, and staged-file workflows.
 
-## ALWAYS read installed docs before working
+## Read installed docs when this skill applies
 
-Before any Rstack work, find and read the relevant Markdown documentation shipped with the installed `rstack` package.
+When this skill applies, find and read the relevant Markdown documentation shipped with the installed `rstack` package.
 
 Model knowledge can be outdated; the installed documentation is the source of truth for the project's Rstack version.
 

--- a/website/docs/en/guide/ai.mdx
+++ b/website/docs/en/guide/ai.mdx
@@ -27,20 +27,20 @@ This project uses Rstack CLI as its JavaScript toolchain.
 - If the local documentation is unavailable, use https://rstack.rs/llms.txt and `rs <command> -h`.
 ```
 
-This content serves a similar purpose to the [rstack-cli-best-practices](#rstack-cli-best-practices) Skill, helping coding agents use Rstack CLI and find relevant documentation. Add it to `AGENTS.md` or install the Skill; either is sufficient.
+This content serves a similar purpose to the [rstack-cli-docs](#rstack-cli-docs) Skill, helping coding agents use Rstack CLI and find relevant documentation. Add it to `AGENTS.md` or install the Skill; either is sufficient.
 
 ## Agent Skills
 
 Rstack CLI provides domain-specific Agent Skills that help coding agents give more accurate guidance and perform relevant tasks.
 
-### rstack-cli-best-practices
+### rstack-cli-docs
 
-The [rstack-cli-best-practices](https://github.com/rstackjs/rstack-cli/tree/main/.agents/skills/rstack-cli-best-practices) Skill provides guidance and best practices for using Rstack CLI.
+The [rstack-cli-docs](https://github.com/rstackjs/rstack-cli/tree/main/.agents/skills/rstack-cli-docs) Skill helps coding agents consult version-matched documentation for Rstack CLI commands, configuration, and public APIs.
 
 Install it with the [skills](https://www.npmjs.com/package/skills) package:
 
 <PackageManagerTabs
-  command="skills add rstackjs/rstack-cli --skill rstack-cli-best-practices"
+  command="skills add rstackjs/rstack-cli --skill rstack-cli-docs"
   dlx
 />
 

--- a/website/docs/zh/guide/ai.mdx
+++ b/website/docs/zh/guide/ai.mdx
@@ -27,20 +27,20 @@ This project uses Rstack CLI as its JavaScript toolchain.
 - If the local documentation is unavailable, use https://rstack.rs/llms.txt and `rs <command> -h`.
 ```
 
-这段内容与 [rstack-cli-best-practices](#rstack-cli-best-practices) Skill 作用相似，都能指导 Coding Agent 使用 Rstack CLI 并查找相关文档。将其添加到 `AGENTS.md` 或安装该 Skill，任选其一即可。
+这段内容与 [rstack-cli-docs](#rstack-cli-docs) Skill 作用相似，都能指导 Coding Agent 使用 Rstack CLI 并查找相关文档。将其添加到 `AGENTS.md` 或安装该 Skill，任选其一即可。
 
 ## Agent Skills
 
 Rstack CLI 提供面向特定领域的 Agent Skills，帮助 Coding Agent 更准确地提供建议并执行相关任务。
 
-### rstack-cli-best-practices
+### rstack-cli-docs
 
-[rstack-cli-best-practices](https://github.com/rstackjs/rstack-cli/tree/main/.agents/skills/rstack-cli-best-practices) Skill 提供 Rstack CLI 的使用指南和最佳实践。
+[rstack-cli-docs](https://github.com/rstackjs/rstack-cli/tree/main/.agents/skills/rstack-cli-docs) Skill 帮助 Coding Agent 查阅与当前版本匹配的 Rstack CLI 命令、配置和公共 API 文档。
 
 使用 [skills](https://www.npmjs.com/package/skills) 包安装该 Skill：
 
 <PackageManagerTabs
-  command="skills add rstackjs/rstack-cli --skill rstack-cli-best-practices"
+  command="skills add rstackjs/rstack-cli --skill rstack-cli-docs"
   dlx
 />
 


### PR DESCRIPTION
The Rstack CLI documentation skill was broad enough to activate for unrelated repository work. This PR renames it to `rstack-cli-docs`, limits discovery to user-facing CLI, configuration, and public API semantics, and updates the English and Chinese documentation. Users should now install it with `--skill rstack-cli-docs`.