### PR TITLE
docs: link npm README to documentation

### DIFF
--- a/packages/create-rstack/README.md
+++ b/packages/create-rstack/README.md
@@ -53,7 +53,7 @@ npx create-rstack --dir my-project --template app-vanilla-ts --no-git
 
 ## Documentation
 
-See the [Rstack CLI documentation](https://rstack.rs).
+See the [Quick start documentation](https://rstack.rs/guide/quick-start).
 
 ## License
 

--- a/packages/rstack/README.md
+++ b/packages/rstack/README.md
@@ -2,6 +2,12 @@
 
 One CLI for JavaScript development, powered by Rstack.
 
+## Documentation
+
+See the [documentation](https://rstack.rs/).
+
+The package also includes Markdown docs in `node_modules/rstack/docs/`, with an index at `node_modules/rstack/docs/llms.txt`.
+
 ## License
 
 [MIT](./LICENSE).


### PR DESCRIPTION
## Summary

The npm README currently provides no path to Rstack documentation. This PR links the documentation site and points to the bundled Markdown docs and `llms.txt` index.

## Related Links

- Closes https://github.com/rstackjs/rstack-cli/issues/424