### PR TITLE
fix: require Node.js 22.18 or higher

### DIFF
--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -113,7 +113,7 @@
     }
   },
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.18.0"
   },
   "publishConfig": {
     "access": "public",

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -20,7 +20,7 @@ Use one of the following installation guides to set up a runtime:
 
 :::tip Version requirements
 
-Rstack CLI requires Node.js 22.12.0 or higher when using Node.js as the runtime.
+Rstack CLI requires Node.js 22.18.0 or higher when using Node.js as the runtime.
 
 :::
 

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -20,7 +20,7 @@ Rstack CLI 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com
 
 :::tip 版本要求
 
-使用 Node.js 作为运行时时，Rstack CLI 要求 Node.js 版本为 22.12.0 或更高版本。
+使用 Node.js 作为运行时时，Rstack CLI 要求 Node.js 版本为 22.18.0 或更高版本。
 
 :::
 


### PR DESCRIPTION
Rstack's native TypeScript config loading depends on type stripping being enabled by default, which starts in Node.js 22.18.

This PR raises `rstack`'s minimum Node.js version from 22.12 to 22.18 and aligns the English and Chinese quick-start documentation. The typeless-package warning on Node.js 22.18 and later will be handled separately.

## Related Links

- https://github.com/rstackjs/rstack-cli/issues/423