### PR TITLE
fix: correct Node.js engine range

### DIFF
--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -113,7 +113,7 @@
     }
   },
   "engines": {
-    "node": ">=22.18.0"
+    "node": "^22.18.0 || >=24.3.0"
   },
   "publishConfig": {
     "access": "public",

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -20,7 +20,7 @@ Use one of the following installation guides to set up a runtime:
 
 :::tip Version requirements
 
-Rstack CLI requires Node.js 22.18.0 or higher on the Node.js 22 release line, or Node.js 24.3.0 or higher. Node.js 23 is not supported.
+Rstack CLI requires Node.js 22.18.0+ (22.x) or 24.3.0+.
 
 :::
 

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -20,7 +20,7 @@ Use one of the following installation guides to set up a runtime:
 
 :::tip Version requirements
 
-Rstack CLI requires Node.js 22.18.0+ (22.x) or 24.3.0+.
+Rstack CLI requires Node.js 22.18.0+ or 24.3.0+.
 
 :::
 

--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -20,7 +20,7 @@ Use one of the following installation guides to set up a runtime:
 
 :::tip Version requirements
 
-Rstack CLI requires Node.js 22.18.0 or higher when using Node.js as the runtime.
+Rstack CLI requires Node.js 22.18.0 or higher on the Node.js 22 release line, or Node.js 24.3.0 or higher. Node.js 23 is not supported.
 
 :::
 

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -20,7 +20,7 @@ Rstack CLI 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com
 
 :::tip 版本要求
 
-使用 Node.js 作为运行时时，Rstack CLI 要求使用 Node.js 22 系列的 22.18.0 或更高版本，或者 Node.js 24.3.0 或更高版本。不支持 Node.js 23。
+Rstack CLI 要求 Node.js 22.18.0+（22.x）或 24.3.0+。
 
 :::
 

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -20,7 +20,7 @@ Rstack CLI 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com
 
 :::tip 版本要求
 
-Rstack CLI 要求 Node.js 22.18.0+（22.x）或 24.3.0+。
+Rstack CLI 要求 Node.js 22.18.0+ 或 24.3.0+。
 
 :::
 

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -20,7 +20,7 @@ Rstack CLI 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com
 
 :::tip 版本要求
 
-使用 Node.js 作为运行时时，Rstack CLI 要求 Node.js 版本为 22.18.0 或更高版本。
+使用 Node.js 作为运行时时，Rstack CLI 要求使用 Node.js 22 系列的 22.18.0 或更高版本，或者 Node.js 24.3.0 或更高版本。不支持 Node.js 23。
 
 :::
 


### PR DESCRIPTION
## Summary

Rstack does not support Node.js 23, and Node.js 24 only stops emitting the type-stripping experimental warning starting in 24.3.0.

This PR changes the supported engine range to `^22.18.0 || >=24.3.0` and aligns the English and Chinese quick-start docs.

## Related Links

- https://github.com/rstackjs/rstack-cli/issues/423
- https://github.com/rstackjs/rstack-cli/pull/426
- https://nodejs.org/en/blog/release/v24.3.0