### PR TITLE
chore: use heading-case as a formatter plugin

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/SKILL.md
+++ b/.agents/skills/migrate-to-rstack-cli/SKILL.md
@@ -7,7 +7,7 @@ description: Use when migrating projects from standalone Rsbuild, Rslib, Rstest,
 
 Rstack CLI is the `rstack` package, exposed through the `rs` binaries. It provides one CLI, one config file, and a consistent workflow for the Rstack JavaScript toolchain.
 
-## Tool References
+## Tool references
 
 Read every matching reference before editing. Load only the tools present in the project.
 
@@ -36,7 +36,7 @@ Rsbuild, Rslib, Rstest, Rslint, and Prettier remain transitive `rstack` dependen
 
 ## Configuration
 
-### Config Files
+### Config files
 
 Treat each workspace or config root independently. A monorepo may need multiple Rstack config files when commands run from different package directories; validate config discovery from each directory.
 
@@ -57,7 +57,7 @@ define.test({
 });
 ```
 
-### Modules and Imports
+### Modules and imports
 
 Use dynamic imports in async config functions only for external plugins, presets, and other dependencies:
 

--- a/.agents/skills/migrate-to-rstack-cli/references/git-hooks.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/git-hooks.md
@@ -1,8 +1,8 @@
-# Git Hook Migration
+# Git hook migration
 
 Migrate [Husky](https://typicode.github.io/husky/), [Lefthook](https://lefthook.dev/), or [simple-git-hooks](https://github.com/toplenboren/simple-git-hooks#readme) to [`rs hooks`](https://rstack.rs/guide/cli/hooks). If a hook works with staged files, also read [lint-staged.md](lint-staged.md).
 
-## Shared Steps
+## Shared steps
 
 1. Inspect the hook manager configuration, hook scripts, lifecycle scripts, custom paths, environment overrides, and `git config --show-scope --get core.hooksPath`.
 2. Inventory every active hook before editing. Confirm each hook is [supported by `rs hooks`](https://rstack.rs/guide/cli/hooks#supported-hooks); stop or design an explicit alternative for unsupported hooks.

--- a/.agents/skills/migrate-to-rstack-cli/references/lint-staged.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/lint-staged.md
@@ -14,7 +14,7 @@ If staged tasks invoke Prettier, also read [prettier.md](prettier.md).
 4. Remove the old manifest key or config file.
 5. Remove the direct staged-file dependency only when no script, config, or programmatic API still uses it.
 
-## Config Pattern
+## Config pattern
 
 ```ts
 import { define } from 'rstack';
@@ -27,6 +27,6 @@ define.staged({
 
 Function configs are supported.
 
-## CLI Options
+## CLI options
 
 Run `rs staged -h` for supported options.

--- a/.agents/skills/migrate-to-rstack-cli/references/prettier.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/prettier.md
@@ -1,4 +1,4 @@
-# Prettier Migration
+# Prettier migration
 
 `rs fmt` is Rstack's faster, Prettier-based formatter. See the [formatting guide](https://rstack.rs/guide/formatting) for supported options, file discovery, overrides, plugins, and Rstack-specific capabilities.
 
@@ -24,7 +24,7 @@ Rstack creates `.rstack/cache/.gitignore` by default. Do not list `.rstack/cache
 
 Keep `.editorconfig` when editors or other tools use it. Keep Prettier when application code uses APIs such as `prettier.format()`; `rs fmt` is not a drop-in replacement for the programmatic API.
 
-## Command Mapping
+## Command mapping
 
 | Prettier                      | Rstack CLI                |
 | ----------------------------- | ------------------------- |

--- a/.agents/skills/migrate-to-rstack-cli/references/rsbuild.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rsbuild.md
@@ -1,4 +1,4 @@
-# Rsbuild Migration
+# Rsbuild migration
 
 Read this reference when the project uses `@rsbuild/core`, `rsbuild.config.*`, `rsbuild` commands, Rsbuild client types, or `@rsbuild/core/types`.
 
@@ -15,7 +15,7 @@ Read this reference when the project uses `@rsbuild/core`, `rsbuild.config.*`, `
 6. Search for remaining direct `@rsbuild/core` imports. Remove the direct dependency when no source or runtime API still needs it.
 7. Delete `rsbuild.config.*` after the migrated app commands load equivalent config.
 
-## Config Pattern
+## Config pattern
 
 ```ts
 import { define } from 'rstack';

--- a/.agents/skills/migrate-to-rstack-cli/references/rslib.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rslib.md
@@ -1,4 +1,4 @@
-# Rslib Migration
+# Rslib migration
 
 Read this reference when the project uses `@rslib/core`, `rslib.config.*`, `rslib` commands, library build config, or Rslib type imports.
 
@@ -12,7 +12,7 @@ Read this reference when the project uses `@rslib/core`, `rslib.config.*`, `rsli
 6. Search for remaining direct `@rslib/core` imports. Remove the direct dependency only when no source or runtime API still needs it.
 7. Delete `rslib.config.*` after the migrated library commands load equivalent config.
 
-## Config Pattern
+## Config pattern
 
 ```ts
 import { define } from 'rstack';

--- a/.agents/skills/migrate-to-rstack-cli/references/rslint.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rslint.md
@@ -1,4 +1,4 @@
-# Rslint Migration
+# Rslint migration
 
 Read this reference when the project uses `@rslint/core`, `rslint.config.*`, `rslint` commands, or Rslint config imports.
 
@@ -11,7 +11,7 @@ Read this reference when the project uses `@rslint/core`, `rslint.config.*`, `rs
 5. Remove `@rslint/core` only when no uncovered direct runtime API remains. Delete `rslint.config.*`.
 6. If tracked VS Code configuration recommends `rstack.rslint`, replace it with the unified `rstack.rstack` extension. Move relevant `rslint.*` settings to their current `rstack.rslint.*` equivalents according to the [Rstack extension documentation](https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md). Keep `source.fixAll.rslint` unchanged.
 
-## Config Pattern
+## Config pattern
 
 ```ts
 import { define } from 'rstack';
@@ -37,7 +37,7 @@ define.lint(({ globals }) => [
 ]);
 ```
 
-## Script Pattern
+## Script pattern
 
 If a script also runs Prettier, migrate its formatting command as described in [prettier.md](prettier.md).
 

--- a/.agents/skills/migrate-to-rstack-cli/references/rspress.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rspress.md
@@ -1,4 +1,4 @@
-# Rspress Migration
+# Rspress migration
 
 Read this reference when the project uses `@rspress/core`, `rspress.config.*`, `rspress` commands, docs config, themes, or plugins.
 
@@ -11,7 +11,7 @@ Read this reference when the project uses `@rspress/core`, `rspress.config.*`, `
 5. Keep Rspress-specific type imports from `@rspress/core`; Rstack does not re-export them.
 6. Keep themes, plugins, and docs UI packages. Delete `rspress.config.*` only after the migrated docs commands load equivalent config.
 
-## Config Pattern
+## Config pattern
 
 ```ts
 import { define } from 'rstack';

--- a/.agents/skills/migrate-to-rstack-cli/references/rstest.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rstest.md
@@ -1,4 +1,4 @@
-# Rstest Migration
+# Rstest migration
 
 Read this reference when the project uses `@rstest/core`, `@rstest/adapter-rsbuild`, `@rstest/adapter-rslib`, `rstest.config.*`, `rstest` commands, or Rstest imports and types.
 
@@ -16,7 +16,7 @@ Read this reference when the project uses `@rstest/core`, `@rstest/adapter-rsbui
 7. Delete `rstest.config.*` after all behavior is represented or intentionally supplied by automatic app/library extension.
 8. If tracked VS Code configuration recommends `rstack.rstest`, replace it with the unified `rstack.rstack` extension. Move supported `rstest.*` settings to `rstack.rstest.*` according to the [Rstack extension documentation](https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md); `rstest.nodeExecutable` instead becomes the shared `rstack.nodeExecutable` setting.
 
-## Config Pattern
+## Config pattern
 
 ```ts
 import { define } from 'rstack';

--- a/.agents/skills/rstack-cli-docs/SKILL.md
+++ b/.agents/skills/rstack-cli-docs/SKILL.md
@@ -3,7 +3,7 @@ name: rstack-cli-docs
 description: Consult installed, version-matched Rstack docs only for user-facing `rs` command behavior, `rstack.config.*` semantics, or public `rstack` APIs. Do not use for purely internal implementation, tests, performance, or repository maintenance.
 ---
 
-# Rstack CLI Docs
+# Rstack CLI docs
 
 Rstack CLI is the `rstack` package, exposed through the `rs` binaries. It provides one CLI, one
 config file, and a consistent workflow for the Rstack JavaScript toolchain.

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "build": "pnpm --filter \"./packages/**\" build",
     "check": "rs check --type-check",
-    "check:spell": "pnpm dlx cspell && heading-case",
+    "check:spell": "pnpm dlx cspell",
     "doc": "pnpm --dir website dev",
     "doc:build": "node --run build && pnpm --dir website build",
-    "format": "rs fmt && heading-case --write",
+    "format": "rs fmt",
     "lint": "rs lint --type-check",
     "prepare": "node scripts/rs.js hooks",
     "release:prepare": "node scripts/prepare-release.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ catalogs:
       specifier: ^20.11.6
       version: 20.11.6
     heading-case:
-      specifier: ^1.1.8
-      version: 1.1.8
+      specifier: ^2.0.0
+      version: 2.0.0
     import-meta-resolve:
       specifier: 4.2.0
       version: 4.2.0
@@ -161,7 +161,7 @@ importers:
         version: 0.0.4
       heading-case:
         specifier: 'catalog:'
-        version: 1.1.8
+        version: 2.0.0(prettier@3.9.6)
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -2304,9 +2304,11 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  heading-case@1.1.8:
-    resolution: {integrity: sha512-zGhfkYlKqTbkXyu6RluO4DFyD3fEGHOMl/16UZcXX315drkUa/sg8vlvQXm3trqpnoj8LhPsYCrg5R6oP9mtyQ==}
+  heading-case@2.0.0:
+    resolution: {integrity: sha512-yznMB5NlBOlCqGL68oRa9gvA8vINQB56D1rTQwCRNoh2aLjtEAK4UKYD5mZ4rXJ0GCuyRmzGCgP1/3To1Mj/vA==}
     hasBin: true
+    peerDependencies:
+      prettier: ^3.0.0
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
@@ -4843,7 +4845,9 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
-  heading-case@1.1.8: {}
+  heading-case@2.0.0(prettier@3.9.6):
+    dependencies:
+      prettier: 3.9.6
 
   hookable@6.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,7 +39,7 @@ catalog:
   'cspell-ban-words': '^0.0.4'
   'fast-json-stable-stringify': '2.1.0'
   'happy-dom': '^20.11.6'
-  'heading-case': '^1.1.8'
+  'heading-case': '^2.0.0'
   'import-meta-resolve': '4.2.0'
   is-binary-path: 3.0.0
   'lint-staged': '^17.3.0'

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -1,5 +1,6 @@
 // Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
+import skillsLock from './skills-lock.json' with { type: 'json' };
 
 define.lint(({ globals, js, ts, rstestPlugin }) => {
   return [
@@ -58,7 +59,10 @@ define.fmt({
   ignorePatterns: [
     'packages/rstack/binding.cjs',
     'packages/rstack/binding.d.cts',
+    // Ignore installed Skills because their formatting may differ from this repository.
+    ...Object.keys(skillsLock.skills).map((name) => `.agents/skills/${name}`),
   ],
+  plugins: ['heading-case'],
   singleQuote: true,
   sortPackageJson: true,
 });


### PR DESCRIPTION
## Summary

This PR integrates `heading-case` v2 into `rs fmt` so heading normalization runs through the repository's standard formatting workflow. It removes standalone `heading-case` commands, normalizes repository-owned Skill headings, and derives ignore patterns from `skills-lock.json` to avoid rewriting externally managed Skills.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8398
- https://github.com/web-infra-dev/rsbuild/pull/8399
- https://github.com/rstackjs/heading-case/releases/tag/v2.0.0