### PR TITLE
docs: add typed linting guidance for monorepos

### DIFF
--- a/website/docs/en/guide/cli/lint.mdx
+++ b/website/docs/en/guide/cli/lint.mdx
@@ -39,3 +39,7 @@ define.lint(({ js, ts }) => [
   ts.configs.recommendedTypeChecked,
 ]);
 ```
+
+## Typed linting
+
+Type-aware presets such as `ts.configs.recommendedTypeChecked` apply only to files included by a `tsconfig.json`. In a monorepo, list the project `tsconfig.json` files through Rslint's [`parserOptions.project`](https://rslint.rs/config/language-options#languageoptionsparseroptionsproject). See [Root configuration](../monorepo#root-configuration) for an example.

--- a/website/docs/en/guide/monorepo.mdx
+++ b/website/docs/en/guide/monorepo.mdx
@@ -49,6 +49,13 @@ import { define } from 'rstack';
 define.lint(({ js, ts }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./apps/*/tsconfig.json', './packages/*/tsconfig.json'],
+      },
+    },
+  },
 ]);
 
 define.fmt({
@@ -61,6 +68,8 @@ define.staged({
   '*.{json,md,mdx,css,html,yml,yaml}': 'rs fmt',
 });
 ```
+
+`parserOptions.project` lists the `tsconfig.json` of each project for type-aware presets and `rs check --type-check`. See [Typed linting](./cli/lint#typed-linting).
 
 Expose these tasks through scripts in the root `package.json`:
 

--- a/website/docs/zh/guide/cli/lint.mdx
+++ b/website/docs/zh/guide/cli/lint.mdx
@@ -39,3 +39,7 @@ define.lint(({ js, ts }) => [
   ts.configs.recommendedTypeChecked,
 ]);
 ```
+
+## 类型感知检查 \{#typed-linting}
+
+`ts.configs.recommendedTypeChecked` 等类型感知预设只对 `tsconfig.json` 包含的文件生效。在 Monorepo 中，可以通过 Rslint 的 [`parserOptions.project`](https://rslint.rs/config/language-options#languageoptionsparseroptionsproject) 列出各个子项目的 `tsconfig.json`。示例请参考[根配置](../monorepo#root-configuration)。

--- a/website/docs/zh/guide/monorepo.mdx
+++ b/website/docs/zh/guide/monorepo.mdx
@@ -49,6 +49,13 @@ import { define } from 'rstack';
 define.lint(({ js, ts }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./apps/*/tsconfig.json', './packages/*/tsconfig.json'],
+      },
+    },
+  },
 ]);
 
 define.fmt({
@@ -61,6 +68,8 @@ define.staged({
   '*.{json,md,mdx,css,html,yml,yaml}': 'rs fmt',
 });
 ```
+
+`parserOptions.project` 列出各个子项目的 `tsconfig.json`，供类型感知预设和 `rs check --type-check` 使用。详见[类型感知检查](./cli/lint#typed-linting)。
 
 在根目录的 `package.json` 中提供对应脚本：
 


### PR DESCRIPTION
## Summary

Document that type-aware presets only cover files included by a `tsconfig.json`, and add `parserOptions.project` to the monorepo root configuration example.

- `guide/cli/lint`: new "Typed linting" section, linking to Rslint's `parserOptions.project` and to the monorepo example.
- `guide/monorepo`: the root `define.lint()` example now lists the project `tsconfig.json` files, with a one-line note.

## Background

While migrating [storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild) (a pnpm monorepo) to Rstack CLI, I followed the Monorepo guide and put `ts.configs.recommendedTypeChecked` in the root `rstack.config.ts`, as shown in the docs. `rs lint --type-check` passed, but it turned out no type-aware rule was actually running: the summary line reported 66 rules instead of 92 and `type-checked 0 files`. A floating promise, an `await` on a number, and a plain `TS2322` in `packages/*` all went unreported.

The cause is Rslint's default: without `parserOptions.project`, it reads only the `tsconfig.json` in the current directory and does not follow `references`. A monorepo root usually has no `tsconfig.json`, or one that only references the projects, so every project file is linted without type information and no warning is printed. This repository's own `rstack.config.ts` already sets `parserOptions.project`, but the docs example did not.

## Measurements

rstack 0.6.5. Root with two packages (`packages/a`, `packages/b`, each with its own `tsconfig.json`), the root `define.lint()` from the Monorepo guide, and three seeded problems: a floating promise, `await 42`, and a `TS2322`. Full `rs lint --type-check` summary line per root `tsconfig.json` shape:

| Root `tsconfig.json` | `parserOptions` | Result |
| --- | --- | --- |
| none | — | 0 errors, 66 rules, type-checked 0 files |
| `files: []` + `references` | — | 0 errors, 66 rules, type-checked 0 files |
| `files: []` + `references` | `projectService: true` | 0 errors, 66 rules, type-checked 0 files |
| `include: ['*.ts']` (root files only) | — | 0 lint errors, 92 rules, type-checked 2 files (package files skipped) |
| no `include` / `files` (default `**/*`) | — | 6 lint errors, 92 rules, type-checked 5 files, using the root compiler options |
| `files: []` + `references` | `project: ['./packages/*/tsconfig.json']` | 6 lint errors, 1 type error, 92 rules, type-checked 3 files |

Only the last two shapes lint the packages with type information, and only `parserOptions.project` does so with each package's own `tsconfig.json`.
