### PR TITLE
fix: support parser-wrapping Prettier plugins

### DIFF
--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -96,6 +96,7 @@
     "lint-staged": "catalog:",
     "micromatch": "catalog:",
     "prettier-plugin-svelte": "catalog:",
+    "prettier-plugin-tailwindcss": "catalog:",
     "rslog": "catalog:",
     "sort-package-json": "catalog:",
     "svelte": "catalog:",

--- a/packages/rstack/src/fmt/prettierPlugins.ts
+++ b/packages/rstack/src/fmt/prettierPlugins.ts
@@ -22,13 +22,18 @@ const getPrettierPlugins = async (
   options: ResolvedFmtOptions,
   filePath: string,
 ): Promise<PrettierPlugins> => {
+  // An explicit native parser is also the escape hatch for bypassing Yuku.
+  const defaultPlugins =
+    options.parser === 'babel' || options.parser === 'typescript'
+      ? [fmtOptionsPlugin]
+      : defaultFmtPlugins;
   const plugins =
     options.sortPackageJson === true && /(^|[/\\])package\.json$/.test(filePath)
       ? [
-          ...defaultFmtPlugins,
+          ...defaultPlugins,
           (await import('./sortPackageJsonPlugin.ts')).sortPackageJsonPlugin,
         ]
-      : defaultFmtPlugins;
+      : defaultPlugins;
 
   return options.plugins?.length ? [...plugins, ...options.plugins] : plugins;
 };

--- a/packages/rstack/src/fmt/yukuPlugin.ts
+++ b/packages/rstack/src/fmt/yukuPlugin.ts
@@ -1,5 +1,5 @@
 import * as prettierEstreePlugin from 'prettier/plugins/estree';
-import type { Parser, ParserOptions, Plugin, SupportLanguage } from 'prettier';
+import type { Parser, ParserOptions, Plugin } from 'prettier';
 import {
   langFromPath,
   parse as parseWithYuku,
@@ -43,7 +43,6 @@ type PrettierComment = Comment & {
 };
 
 type EstreePlugin = typeof prettierEstreePlugin & {
-  languages: SupportLanguage[];
   options: NonNullable<Plugin['options']>;
 };
 
@@ -601,31 +600,18 @@ const createParser = (
   parse,
 });
 
-const parserNames = new Map([
-  ['babel', 'yuku'],
-  ['typescript', 'yuku-ts'],
-]);
-
-const languages: SupportLanguage[] = estreePlugin.languages.flatMap(
-  (language) => {
-    const parsers = [
-      ...new Set(
-        language.parsers
-          .map((parser) => parserNames.get(parser))
-          .filter((parser): parser is string => parser !== undefined),
-      ),
-    ];
-
-    return parsers.length > 0 ? [{ ...language, parsers }] : [];
-  },
-);
+const yukuParser = createParser(parseJavaScript);
+const yukuTypeScriptParser = createParser(parseTypeScript);
 
 const yukuPlugin: Plugin = {
-  languages,
   options: estreePlugin.options,
   parsers: {
-    yuku: createParser(parseJavaScript),
-    'yuku-ts': createParser(parseTypeScript),
+    // Prettier resolves parsers from the last plugin that provides the name.
+    // Project plugins are loaded after this one, so parser wrappers take priority.
+    babel: yukuParser,
+    typescript: yukuTypeScriptParser,
+    yuku: yukuParser,
+    'yuku-ts': yukuTypeScriptParser,
   },
   printers: {
     [AST_FORMAT]: estreePrinter,

--- a/packages/rstack/tests/cli/fmt/config.test.ts
+++ b/packages/rstack/tests/cli/fmt/config.test.ts
@@ -211,6 +211,31 @@ define.fmt({
   expect(readProjectFile('second.fixture')).toBe('{ "second": true }\n');
 });
 
+test('runs prettier-plugin-tailwindcss for JavaScript and TypeScript', () => {
+  writeProjectFile(
+    'rstack.config.ts',
+    `import { define } from 'rstack';
+
+define.fmt({
+  plugins: ['prettier-plugin-tailwindcss'],
+  tailwindFunctions: ['cn'],
+});
+`,
+  );
+  const unsortedClasses = `const classes = cn("px-4 flex items-center");\n`;
+  writeProjectFile('index.js', unsortedClasses);
+  writeProjectFile('index.ts', unsortedClasses);
+
+  const result = runFmt(['index.js', 'index.ts']);
+
+  expect(result.status).toBe(0);
+  expectWriteSummary(result.stdout, 2, 2);
+  expect(result.stderr).toBe('');
+  const sortedClasses = `const classes = cn("flex items-center px-4");\n`;
+  expect(readProjectFile('index.js')).toBe(sortedClasses);
+  expect(readProjectFile('index.ts')).toBe(sortedClasses);
+});
+
 test('formats mixed plugin overrides in workers', () => {
   writeProjectFile(
     'rstack.config.ts',

--- a/packages/rstack/tests/fmt/yukuPlugin.test.ts
+++ b/packages/rstack/tests/fmt/yukuPlugin.test.ts
@@ -5,6 +5,7 @@ import {
   type ParserOptions,
 } from 'prettier';
 import { expect, test } from 'rstack/test';
+import { getPrettierPlugins } from '../../src/fmt/prettierPlugins.ts';
 import { yukuPlugin } from '../../src/fmt/yukuPlugin.ts';
 
 const formatWithYuku = (
@@ -18,15 +19,10 @@ const formatWithYuku = (
       options.filepath ?? `example.${options.parser === 'yuku' ? 'js' : 'ts'}`,
   });
 
-test('exposes the same JavaScript and TypeScript language mappings as the official plugin', async () => {
-  expect(
-    yukuPlugin.languages?.map(({ name, parsers }) => ({ name, parsers })),
-  ).toEqual([
-    { name: 'JavaScript', parsers: ['yuku', 'yuku-ts'] },
-    { name: 'JSX', parsers: ['yuku', 'yuku-ts'] },
-    { name: 'TypeScript', parsers: ['yuku-ts'] },
-    { name: 'TSX', parsers: ['yuku-ts'] },
-  ]);
+test('overrides the default JavaScript and TypeScript parsers', async () => {
+  expect(yukuPlugin.languages).toBeUndefined();
+  expect(yukuPlugin.parsers?.babel).toBe(yukuPlugin.parsers?.yuku);
+  expect(yukuPlugin.parsers?.typescript).toBe(yukuPlugin.parsers?.['yuku-ts']);
 
   await expect(
     Promise.all(
@@ -35,12 +31,24 @@ test('exposes the same JavaScript and TypeScript language mappings as the offici
       ),
     ),
   ).resolves.toEqual([
-    { ignored: false, inferredParser: 'yuku' },
-    { ignored: false, inferredParser: 'yuku' },
-    { ignored: false, inferredParser: 'yuku-ts' },
-    { ignored: false, inferredParser: 'yuku-ts' },
+    { ignored: false, inferredParser: 'babel' },
+    { ignored: false, inferredParser: 'babel' },
+    { ignored: false, inferredParser: 'typescript' },
+    { ignored: false, inferredParser: 'typescript' },
   ]);
 });
+
+test.each(['babel', 'typescript'] as const)(
+  'does not override an explicitly selected %s parser',
+  async (parser) => {
+    await expect(
+      getPrettierPlugins(
+        { parser },
+        `example.${parser === 'babel' ? 'js' : 'ts'}`,
+      ),
+    ).resolves.not.toContain(yukuPlugin);
+  },
+);
 
 test('parses JSX in JavaScript files', async () => {
   await expect(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ catalogs:
     prettier-plugin-svelte:
       specifier: ^4.1.1
       version: 4.1.1
+    prettier-plugin-tailwindcss:
+      specifier: 0.8.1
+      version: 0.8.1
     react:
       specifier: ^19.2.8
       version: 19.2.8
@@ -422,6 +425,9 @@ importers:
       prettier-plugin-svelte:
         specifier: 'catalog:'
         version: 4.1.1(prettier@3.9.6)(svelte@5.56.10)
+      prettier-plugin-tailwindcss:
+        specifier: 'catalog:'
+        version: 0.8.1(prettier-plugin-svelte@4.1.1)(prettier@3.9.6)
       rslog:
         specifier: 'catalog:'
         version: 2.3.0
@@ -2680,6 +2686,61 @@ packages:
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^5.0.0
+
+  prettier-plugin-tailwindcss@0.8.1:
+    resolution: {integrity: sha512-iaFMYqDsE4ffdDkn5qup0j5f2aCEBFZrdrZnvu9QKTlWx/iGPeQ4HHu7b7fCPMxeo9nwQBiOAh2nSypdFYWJkw==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
 
   prettier@3.9.6:
     resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
@@ -5473,6 +5534,12 @@ snapshots:
     dependencies:
       prettier: 3.9.6
       svelte: 5.56.10
+
+  prettier-plugin-tailwindcss@0.8.1(prettier-plugin-svelte@4.1.1)(prettier@3.9.6):
+    dependencies:
+      prettier: 3.9.6
+    optionalDependencies:
+      prettier-plugin-svelte: 4.1.1(prettier@3.9.6)(svelte@5.56.10)
 
   prettier@3.9.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ catalog:
   'lint-staged': '^17.3.0'
   'micromatch': '4.0.8'
   prettier: '3.9.6'
+  'prettier-plugin-tailwindcss': '0.8.1'
   'prettier-plugin-svelte': '^4.1.1'
   'react': '^19.2.8'
   'react-dom': '^19.2.8'

--- a/website/docs/en/guide/formatting.mdx
+++ b/website/docs/en/guide/formatting.mdx
@@ -211,7 +211,9 @@ You can safely delete `.rstack/cache` to clear cached results. Do not treat the 
 
 To add formatting capabilities that are not built into Rstack CLI, install the corresponding [Prettier plugin](https://prettier.io/docs/plugins) and add it to `plugins`. Plugins can be referenced by package name, file path, or URL. Package names and relative paths are resolved from the directory containing the Rstack configuration file.
 
-Because `rs fmt` loads plugins in workers, plugin objects cannot be passed directly. Reference each plugin by package name, path, or URL instead. For example, install and enable [`prettier-plugin-tailwindcss`](https://github.com/tailwindlabs/prettier-plugin-tailwindcss):
+Because `rs fmt` loads plugins in workers, plugin objects cannot be passed directly. Reference each plugin by package name, path, or URL instead.
+
+For example, install and enable [`prettier-plugin-tailwindcss`](https://github.com/tailwindlabs/prettier-plugin-tailwindcss):
 
 <PackageManagerTabs command="install -D prettier-plugin-tailwindcss" />
 

--- a/website/docs/zh/guide/formatting.mdx
+++ b/website/docs/zh/guide/formatting.mdx
@@ -211,7 +211,9 @@ rs fmt --no-cache
 
 如果需要使用 Rstack CLI 未内置的格式化能力，可以安装相应的 [Prettier 插件](https://prettier.io/docs/plugins)，并添加到 `plugins` 中。插件支持通过包名、文件路径或 URL 引用，其中包名和相对路径基于 Rstack 配置文件所在的目录解析。
 
-由于 `rs fmt` 会在 worker 中加载插件，因此不支持直接传入插件对象。请通过包名、路径或 URL 引用插件。例如，安装并启用 [`prettier-plugin-tailwindcss`](https://github.com/tailwindlabs/prettier-plugin-tailwindcss)：
+由于 `rs fmt` 会在 worker 中加载插件，因此不支持直接传入插件对象。请通过包名、路径或 URL 引用插件。
+
+例如，安装并启用 [`prettier-plugin-tailwindcss`](https://github.com/tailwindlabs/prettier-plugin-tailwindcss)：
 
 <PackageManagerTabs command="install -D prettier-plugin-tailwindcss" />
 


### PR DESCRIPTION
## Summary

Prettier plugins that wrap JavaScript or TypeScript parsers were bypassed because `rs fmt` inferred Yuku-specific parser names. This change registers Yuku under Prettier's native parser names so later project plugins can override it, while preserving explicit `babel` and `typescript` parsers as escape hatches. It adds a real `prettier-plugin-tailwindcss` integration test for both JavaScript and TypeScript.

## Related Links

- Closes https://github.com/rstackjs/rstack-cli/issues/422