### PR TITLE
fix(fmt): clarify formatting fix command

### DIFF
--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -185,7 +185,7 @@ async function runCheckCLI(args: string[]): Promise<void> {
     /* rspackChunkName: 'fmt' */
     '../fmt/cli.ts'
   );
-  await runFmtCLI(['--check'], { loadedConfig });
+  await runFmtCLI(['--check'], { fixCommand: 'rs fmt', loadedConfig });
 }
 
 export async function setupCommands(): Promise<void> {

--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -248,9 +248,9 @@ const logFmtResult = (
   if (differentCount > 0) {
     const differentFiles = formatFileCount(differentCount, true);
     const processedFiles = formatFileCount(processedFileCount);
-    const checkOption = color.cyan('--check');
+    const fmtCommand = color.cyan('rs fmt');
     logger.error(
-      `Formatting issues found in ${differentFiles}. Run without ${checkOption} to fix.`,
+      `Formatting issues found in ${differentFiles}. Run ${fmtCommand} to fix.`,
     );
     logger.info(`Checked ${processedFiles} in ${prettyTime(durationSeconds)}.`);
   } else if (result.exitCode === 0) {

--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -30,6 +30,8 @@ interface ParsedFmtCLIArgs {
 }
 
 type RunFmtCLIOptions = {
+  /** Command shown to fix formatting issues found in check mode. */
+  fixCommand?: string;
   /** Rstack config already loaded by the lint phase of `rs check`. */
   loadedConfig?: LoadedRstackConfig;
 };
@@ -206,6 +208,7 @@ const logFmtResult = (
   cwd: string,
   processedFileCount: number,
   durationSeconds: number,
+  fixCommand?: string,
 ): void => {
   let writtenCount = 0;
   let differentCount = 0;
@@ -248,10 +251,10 @@ const logFmtResult = (
   if (differentCount > 0) {
     const differentFiles = formatFileCount(differentCount, true);
     const processedFiles = formatFileCount(processedFileCount);
-    const fmtCommand = color.cyan('rs fmt');
-    logger.error(
-      `Formatting issues found in ${differentFiles}. Run ${fmtCommand} to fix.`,
-    );
+    const fixHint = fixCommand
+      ? `Run ${color.cyan(fixCommand)} to fix.`
+      : `Rerun this command without ${color.cyan('--check')} to fix.`;
+    logger.error(`Formatting issues found in ${differentFiles}. ${fixHint}`);
     logger.info(`Checked ${processedFiles} in ${prettyTime(durationSeconds)}.`);
   } else if (result.exitCode === 0) {
     logger.success(
@@ -276,7 +279,7 @@ const loadFmtConfig = async (
 
 const runFmtCLI = async (
   args: string[],
-  { loadedConfig }: RunFmtCLIOptions = {},
+  { fixCommand, loadedConfig }: RunFmtCLIOptions = {},
 ): Promise<void> => {
   const cwd = process.cwd();
   const startTime = performance.now();
@@ -413,7 +416,14 @@ const runFmtCLI = async (
     }
 
     const durationSeconds = (performance.now() - startTime) / 1000;
-    logFmtResult(result, mode, cwd, result.processedFileCount, durationSeconds);
+    logFmtResult(
+      result,
+      mode,
+      cwd,
+      result.processedFileCount,
+      durationSeconds,
+      fixCommand,
+    );
     process.exitCode = result.exitCode;
   } catch (error) {
     logger.error(error);

--- a/packages/rstack/tests/cli/check.test.ts
+++ b/packages/rstack/tests/cli/check.test.ts
@@ -36,7 +36,9 @@ test('runs lint followed by a formatting check', () => {
 
   expect(unformatted.status).toBe(1);
   expect(unformatted.stdout).toContain('Checking formatting...');
-  expect(unformatted.stderr).toContain('Formatting issues found in 1 file.');
+  expect(unformatted.stderr).toContain(
+    'Formatting issues found in 1 file. Run rs fmt to fix.',
+  );
 
   writeProjectFile('src/index.ts', 'const value = true;\n');
   const formatted = runCheck();

--- a/packages/rstack/tests/cli/fmt/files.test.ts
+++ b/packages/rstack/tests/cli/fmt/files.test.ts
@@ -108,7 +108,7 @@ test('checks formatting without writing files', () => {
   );
   expect(result.stderr).toContain('error   index.ts');
   expect(normalizeDuration(result.stderr)).toContain(
-    'error   Formatting issues found in 1 file. Run without --check to fix.',
+    'error   Formatting issues found in 1 file. Run rs fmt to fix.',
   );
   expect(readProjectFile('index.ts')).toBe(source);
 

--- a/packages/rstack/tests/cli/fmt/files.test.ts
+++ b/packages/rstack/tests/cli/fmt/files.test.ts
@@ -108,7 +108,7 @@ test('checks formatting without writing files', () => {
   );
   expect(result.stderr).toContain('error   index.ts');
   expect(normalizeDuration(result.stderr)).toContain(
-    'error   Formatting issues found in 1 file. Run rs fmt to fix.',
+    'error   Formatting issues found in 1 file. Rerun this command without --check to fix.',
   );
   expect(readProjectFile('index.ts')).toBe(source);
 


### PR DESCRIPTION
## Summary

`rs check` internally runs formatting in check mode, so its failure message previously told users to rerun without `--check` even though they had not provided that option. This PR recommends `rs fmt` for `rs check`, while direct `rs fmt --check` failures tell users to rerun the same command without `--check` so scoped paths and options are preserved.