### PR TITLE
fix(fmt): preserve Vue template bindings

### DIFF
--- a/packages/rstack/src/fmt/yukuPlugin.ts
+++ b/packages/rstack/src/fmt/yukuPlugin.ts
@@ -600,7 +600,29 @@ const createParser = (
   parse,
 });
 
+/** Match the AST root returned by Prettier's native Babel parser. */
+const parseBabel = (text: string, options: ParserOptions<AstNode>): AstNode => {
+  const program = parseJavaScript(text, options);
+  const comments = program.comments;
+  const start = locStart(program);
+  const end = locEndWithFullText(program);
+
+  // Babel stores comments on the File node rather than its Program child.
+  delete program.comments;
+
+  return {
+    type: 'File',
+    comments,
+    end,
+    errors: [],
+    program,
+    range: [start, end],
+    start,
+  };
+};
+
 const yukuParser = createParser(parseJavaScript);
+const yukuBabelParser = createParser(parseBabel);
 const yukuTypeScriptParser = createParser(parseTypeScript);
 
 const yukuPlugin: Plugin = {
@@ -608,7 +630,7 @@ const yukuPlugin: Plugin = {
   parsers: {
     // Prettier resolves parsers from the last plugin that provides the name.
     // Project plugins are loaded after this one, so parser wrappers take priority.
-    babel: yukuParser,
+    babel: yukuBabelParser,
     typescript: yukuTypeScriptParser,
     yuku: yukuParser,
     'yuku-ts': yukuTypeScriptParser,

--- a/packages/rstack/tests/cli/fmt/vue.test.ts
+++ b/packages/rstack/tests/cli/fmt/vue.test.ts
@@ -18,6 +18,13 @@ test.each([
     expected:
       '<script setup lang="tsx">\nconst view = <Component value={1} />;\n</script>\n',
   },
+  {
+    name: 'JavaScript template bindings',
+    source:
+      '<template>\n<div v-for="item in list.filter( Boolean )">{{item}}</div>\n</template>\n',
+    expected:
+      '<template>\n  <div v-for="item in list.filter(Boolean)">{{ item }}</div>\n</template>\n',
+  },
 ])('formats $name embedded in Vue files', ({ source, expected }) => {
   writeProjectFile('App.vue', source);
 

--- a/packages/rstack/tests/fmt/yukuPlugin.test.ts
+++ b/packages/rstack/tests/fmt/yukuPlugin.test.ts
@@ -21,7 +21,7 @@ const formatWithYuku = (
 
 test('overrides the default JavaScript and TypeScript parsers', async () => {
   expect(yukuPlugin.languages).toBeUndefined();
-  expect(yukuPlugin.parsers?.babel).toBe(yukuPlugin.parsers?.yuku);
+  expect(yukuPlugin.parsers?.babel).not.toBe(yukuPlugin.parsers?.yuku);
   expect(yukuPlugin.parsers?.typescript).toBe(yukuPlugin.parsers?.['yuku-ts']);
 
   await expect(
@@ -36,6 +36,23 @@ test('overrides the default JavaScript and TypeScript parsers', async () => {
     { ignored: false, inferredParser: 'typescript' },
     { ignored: false, inferredParser: 'typescript' },
   ]);
+});
+
+test('matches the native Babel AST root shape', async () => {
+  const parser = yukuPlugin.parsers?.babel;
+  if (!parser) {
+    throw new Error('The Babel-compatible Yuku parser is not registered.');
+  }
+
+  const ast = (await parser.parse('// comment\nconst value = 1', {
+    filepath: 'example.js',
+  } as ParserOptions)) as Record<string, unknown>;
+  const program = ast.program as Record<string, unknown>;
+
+  expect(ast.type).toBe('File');
+  expect(ast.comments).toHaveLength(1);
+  expect(program.type).toBe('Program');
+  expect(program.comments).toBeUndefined();
 });
 
 test.each(['babel', 'typescript'] as const)(


### PR DESCRIPTION
## Summary

`rs fmt` could leak Prettier's temporary `function _(item) {}` wrapper into Vue `v-for` bindings after Yuku was registered under the native `babel` parser name.

This PR makes the Yuku-backed `babel` parser return Babel's `File` AST shape while keeping the explicit `yuku` parser unchanged, and adds regression coverage for Vue template bindings and comment placement.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/433