### PR TITLE
feat(fmt): align successful format check output

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -205,7 +205,7 @@ const logFmtResult = (
     return;
   }
 
-  const time = color.bold(formatDuration(durationMilliseconds));
+  const time = formatDuration(durationMilliseconds);
 
   if (mode === 'write') {
     if (writtenCount === 0 && result.exitCode !== 0) {
@@ -230,9 +230,8 @@ const logFmtResult = (
     logger.error(`Formatting issues found in ${differentFiles}. ${fixHint}`);
     logger.info(`Checked ${processedFiles} in ${time}.`);
   } else if (result.exitCode === 0) {
-    logger.success(
-      `Checked ${formatFileCount(processedFileCount)} in ${time}. No issues found.`,
-    );
+    const files = `${processedFileCount} ${processedFileCount === 1 ? 'file' : 'files'}`;
+    logger.success(`Format check passed in ${time} ${color.dim(`(${files})`)}`);
   }
 };
 

--- a/packages/rstack/tests/cli/check.test.ts
+++ b/packages/rstack/tests/cli/check.test.ts
@@ -44,7 +44,7 @@ test('runs lint followed by a formatting check', () => {
   const formatted = runCheck();
 
   expect(formatted.status).toBe(0);
-  expect(formatted.stdout).toContain('No issues found.');
+  expect(formatted.stdout).toContain('Format check passed in');
   expect(formatted.stderr).toBe('');
 });
 

--- a/packages/rstack/tests/cli/fmt/files.test.ts
+++ b/packages/rstack/tests/cli/fmt/files.test.ts
@@ -117,7 +117,7 @@ test('checks formatting without writing files', () => {
 
   expect(formattedResult.status).toBe(0);
   expect(normalizeDuration(formattedResult.stdout)).toBe(
-    'start   Checking formatting...\nsuccess Checked 1 file in <duration>. No issues found.\n',
+    'start   Checking formatting...\nsuccess Format check passed in <duration> (1 file)\n',
   );
   expect(formattedResult.stderr).toBe('');
 });

--- a/packages/rstack/tests/cli/fmt/patterns.test.ts
+++ b/packages/rstack/tests/cli/fmt/patterns.test.ts
@@ -33,13 +33,14 @@ test('allows no files to match with --no-error-on-unmatched-pattern', () => {
 
 test('counts only supported files', () => {
   writeProjectFile('index.ts', 'const value = 1;\n');
+  writeProjectFile('other.ts', 'const other = 2;\n');
   writeProjectFile('notes.unknown', 'plain text');
 
-  const result = runFmt(['--check', 'index.ts', 'notes.unknown']);
+  const result = runFmt(['--check', 'index.ts', 'other.ts', 'notes.unknown']);
 
   expect(result.status).toBe(0);
   expect(normalizeDuration(result.stdout)).toBe(
-    'start   Checking formatting...\nsuccess Checked 1 file in <duration>. No issues found.\n',
+    'start   Checking formatting...\nsuccess Format check passed in <duration> (2 files)\n',
   );
   expect(result.stderr).toBe('');
 });


### PR DESCRIPTION
Successful format checks currently use a different summary structure from lint output. This updates the message to `Format check passed in ... (N files)`, dims the file count, and removes bold styling from formatter durations.