### PR TITLE
feat(fmt): align successful format write output

### DIFF
--- a/packages/rstack/src/fmt/cli.ts
+++ b/packages/rstack/src/fmt/cli.ts
@@ -212,12 +212,22 @@ const logFmtResult = (
       return;
     }
 
+    if (result.exitCode === 0) {
+      const files = `${processedFileCount} ${processedFileCount === 1 ? 'file' : 'files'}`;
+      const details =
+        writtenCount > 0
+          ? `${files}, ${writtenCount} formatted`
+          : `${files}, no changes`;
+      logger.success(
+        `Formatting completed in ${time} ${color.dim(`(${details})`)}`,
+      );
+      return;
+    }
+
     const processedFiles = formatFileCount(processedFileCount);
-    const message =
-      writtenCount > 0
-        ? `Formatted ${formatCount(writtenCount)} of ${processedFiles} in ${time}.`
-        : `Checked ${processedFiles} in ${time}. No changes needed.`;
-    logger[result.exitCode === 0 ? 'success' : 'info'](message);
+    logger.info(
+      `Formatted ${formatCount(writtenCount)} of ${processedFiles} in ${time}.`,
+    );
     return;
   }
 

--- a/packages/rstack/tests/cli/fmt/helpers.ts
+++ b/packages/rstack/tests/cli/fmt/helpers.ts
@@ -53,11 +53,11 @@ export const expectWriteSummary = (
   writtenCount: number,
 ): void => {
   const files = matchedFileCount === 1 ? 'file' : 'files';
-  const message = writtenCount
-    ? `Formatted ${writtenCount} of ${matchedFileCount} ${files} in <duration>.`
-    : `Checked ${matchedFileCount} ${files} in <duration>. No changes needed.`;
+  const details = writtenCount
+    ? `${matchedFileCount} ${files}, ${writtenCount} formatted`
+    : `${matchedFileCount} ${files}, no changes`;
   expect(normalizeDuration(output)).toBe(
-    `start   Formatting...\nsuccess ${message}\n`,
+    `start   Formatting...\nsuccess Formatting completed in <duration> (${details})\n`,
   );
 };
 


### PR DESCRIPTION
Successful format writes currently use a different summary structure from successful format checks. This changes them to `Formatting completed in ... (N files, no changes|N formatted)`, with dimmed details, while preserving the existing partial-failure summary.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/440