### PR TITLE
fix: refresh bundled docs before packing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,6 @@ jobs:
       - name: Build
         run: node --run build
 
-      - name: Prepare release
-        run: node --run release:prepare
-
       - name: Download native packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/packages/rstack/package.json
+++ b/packages/rstack/package.json
@@ -69,6 +69,7 @@
     "build:native:ci": "napi build --config-path napi.json --platform --profile ci --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts",
     "build:native:release": "napi build --config-path napi.json --platform --release --manifest-path ../../Cargo.toml --package rstack-binding --package-json-path package.json --output-dir . --js binding.cjs --dts binding.d.cts -- --config ../../.cargo/release.toml",
     "dev": "rslib -w",
+    "prepack": "node ../../scripts/prepare-release.js",
     "package:native": "napi create-npm-dirs --config-path napi.json",
     "test": "rs test"
   },


### PR DESCRIPTION
Refresh bundled Markdown docs from the `rstack` package's `prepack` lifecycle so every package and staged publish removes stale generated files and reflects `rs hooks`. Remove the now-redundant explicit release workflow step.