### PR TITLE
docs: simplify Rstack CLI agent guidance

### DIFF
--- a/packages/create-rstack/template-common/AGENTS.md
+++ b/packages/create-rstack/template-common/AGENTS.md
@@ -3,5 +3,5 @@
 This project uses Rstack CLI as its JS toolchain:
 
 - Read the docs linked from `node_modules/rstack/docs/llms.txt` when needed
-- Online docs: [https://rstack.rs/llms.txt](https://rstack.rs/llms.txt)
+- Online docs: https://rstack.rs/llms.txt
 - Run `rs -h` for CLI help

--- a/packages/create-rstack/template-common/AGENTS.md
+++ b/packages/create-rstack/template-common/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
-This project uses Rstack CLI as its JavaScript toolchain.
+This project uses Rstack CLI as its JS toolchain:
 
-- Before working with `rs` commands, `rstack.config.*` files, or imports from `rstack`, start with `node_modules/rstack/docs/llms.txt`, then read only the linked pages relevant to the task.
-- For command details, use `rs -h` or `rs <command> -h`.
-- If the local documentation is unavailable, use https://rstack.rs/llms.txt and `rs <command> -h`.
+- Read the docs linked from `node_modules/rstack/docs/llms.txt` when needed
+- Online docs: [https://rstack.rs/llms.txt](https://rstack.rs/llms.txt)
+- Run `rs -h` for CLI help

--- a/website/docs/en/guide/ai.mdx
+++ b/website/docs/en/guide/ai.mdx
@@ -20,11 +20,11 @@ Projects created with [create-rstack](https://www.npmjs.com/package/create-rstac
 You can also copy the following content into your own `AGENTS.md`:
 
 ```markdown wrapCode title="AGENTS.md"
-This project uses Rstack CLI as its JavaScript toolchain.
+This project uses Rstack CLI as its JS toolchain:
 
-- Before working with `rs` commands, `rstack.config.*` files, or imports from `rstack`, start with `node_modules/rstack/docs/llms.txt`, then read only the linked pages relevant to the task.
-- For command details, use `rs -h` or `rs <command> -h`.
-- If the local documentation is unavailable, use https://rstack.rs/llms.txt and `rs <command> -h`.
+- Read the docs linked from `node_modules/rstack/docs/llms.txt` when needed
+- Online docs: [https://rstack.rs/llms.txt](https://rstack.rs/llms.txt)
+- Run `rs -h` for CLI help
 ```
 
 This content serves a similar purpose to the [rstack-cli-docs](#rstack-cli-docs) Skill, helping coding agents use Rstack CLI and find relevant documentation. Add it to `AGENTS.md` or install the Skill; either is sufficient.

--- a/website/docs/en/guide/ai.mdx
+++ b/website/docs/en/guide/ai.mdx
@@ -23,7 +23,7 @@ You can also copy the following content into your own `AGENTS.md`:
 This project uses Rstack CLI as its JS toolchain:
 
 - Read the docs linked from `node_modules/rstack/docs/llms.txt` when needed
-- Online docs: [https://rstack.rs/llms.txt](https://rstack.rs/llms.txt)
+- Online docs: https://rstack.rs/llms.txt
 - Run `rs -h` for CLI help
 ```
 

--- a/website/docs/zh/guide/ai.mdx
+++ b/website/docs/zh/guide/ai.mdx
@@ -20,11 +20,11 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 你也可以将以下内容复制到自己的 `AGENTS.md` 中：
 
 ```markdown wrapCode title="AGENTS.md"
-This project uses Rstack CLI as its JavaScript toolchain.
+This project uses Rstack CLI as its JS toolchain:
 
-- Before working with `rs` commands, `rstack.config.*` files, or imports from `rstack`, start with `node_modules/rstack/docs/llms.txt`, then read only the linked pages relevant to the task.
-- For command details, use `rs -h` or `rs <command> -h`.
-- If the local documentation is unavailable, use https://rstack.rs/llms.txt and `rs <command> -h`.
+- Read the docs linked from `node_modules/rstack/docs/llms.txt` when needed
+- Online docs: [https://rstack.rs/llms.txt](https://rstack.rs/llms.txt)
+- Run `rs -h` for CLI help
 ```
 
 这段内容与 [rstack-cli-docs](#rstack-cli-docs) Skill 作用相似，都能指导 Coding Agent 使用 Rstack CLI 并查找相关文档。将其添加到 `AGENTS.md` 或安装该 Skill，任选其一即可。

--- a/website/docs/zh/guide/ai.mdx
+++ b/website/docs/zh/guide/ai.mdx
@@ -23,7 +23,7 @@ import { PackageManagerTabs } from '@rspress/core/theme';
 This project uses Rstack CLI as its JS toolchain:
 
 - Read the docs linked from `node_modules/rstack/docs/llms.txt` when needed
-- Online docs: [https://rstack.rs/llms.txt](https://rstack.rs/llms.txt)
+- Online docs: https://rstack.rs/llms.txt
 - Run `rs -h` for CLI help
 ```
 


### PR DESCRIPTION
This PR makes the Rstack CLI guidance for coding agents shorter and less likely to trigger unnecessary documentation reads. It keeps the local and online documentation indexes discoverable and points agents to `rs -h` for CLI help. The create-rstack template and English and Chinese docs remain aligned.