### PR TITLE
docs: prefer rs check in migration skill

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/SKILL.md
+++ b/.agents/skills/migrate-to-rstack-cli/SKILL.md
@@ -34,6 +34,19 @@ Read every matching reference before editing. Load only the tools present in the
 
 Rsbuild, Rslib, Rstest, Rslint, and Prettier remain transitive `rstack` dependencies. Remove obsolete direct dependencies and imports from the migrated scope; do not expect their names to disappear from the lockfile.
 
+### Combined checks
+
+After migrating lint and formatting commands, prefer the shorter combined command when behavior is equivalent:
+
+| Separate commands                        | Preferred command       |
+| ---------------------------------------- | ----------------------- |
+| `rs lint && rs fmt --check`              | `rs check`              |
+| `rs lint --type-check && rs fmt --check` | `rs check --type-check` |
+
+`rs check` preserves the order and short-circuit behavior of these `&&` chains.
+
+Combine only when both commands use the same working directory and Rstack config, with no positional inputs or command-specific options beyond those shown. Move a shared `-c` or `--config` to `rs check`. Keep the commands separate when their environment, wrappers, scope, execution order, concurrency, or output handling differs.
+
 ## Configuration
 
 ### Config files

--- a/.agents/skills/migrate-to-rstack-cli/references/rslint.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rslint.md
@@ -39,16 +39,19 @@ define.lint(({ globals }) => [
 
 ## Script pattern
 
-If a script also runs Prettier, migrate its formatting command as described in [prettier.md](prettier.md).
+For example:
 
 ```json
 {
   "scripts": {
-    "lint": "rs lint && rs fmt --check",
-    "lint:write": "rs lint --fix && rs fmt"
+    "check": "rs check",
+    "format": "rs fmt",
+    "lint": "rs lint"
   }
 }
 ```
+
+Preserve existing script names unless renaming is requested. For scripts that also run Prettier, follow [prettier.md](prettier.md), then apply the [combined-check rules](../SKILL.md#combined-checks).
 
 ## Validate
 


### PR DESCRIPTION
This PR improves the Rstack CLI migration skill so equivalent lint and formatting check chains use the shorter `rs check` command. It documents the equivalence boundaries, including typed linting and shared config handling, and updates the Rslint script example without prescribing script renames.