### PR TITLE
docs: clarify migration import guidance

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/SKILL.md
+++ b/.agents/skills/migrate-to-rstack-cli/SKILL.md
@@ -72,13 +72,15 @@ define.test({
 
 ### Modules and imports
 
-Use dynamic imports in async config functions only for external plugins, presets, and other dependencies:
+Keep type-only and Node.js built-in imports at the top level. In async config functions, use a separate `await import(...)` for each tool-specific runtime dependency.
 
 ```ts
 define.app(async () => {
   const { pluginReact } = await import('@rsbuild/plugin-react');
+  const { pluginSass } = await import('@rsbuild/plugin-sass');
+
   return {
-    plugins: [pluginReact()],
+    plugins: [pluginReact(), pluginSass()],
   };
 });
 ```


### PR DESCRIPTION
This PR clarifies import guidance in the Rstack CLI migration skill so unrelated commands do not load tool-specific runtime dependencies. It keeps type-only and Node.js built-in imports at the top level and recommends a separate dynamic import for each tool-specific dependency.