### PR TITLE
chore: avoid unnecessary config dynamic imports

### DIFF
--- a/examples/test-inline-projects/rstack.config.ts
+++ b/examples/test-inline-projects/rstack.config.ts
@@ -1,11 +1,9 @@
 // Configuration guide: https://rstack.rs/config
+import { pluginReact } from '@rsbuild/plugin-react';
 import { define } from 'rstack';
 
-define.app(async () => {
-  const { pluginReact } = await import('@rsbuild/plugin-react');
-  return {
-    plugins: [pluginReact()],
-  };
+define.app({
+  plugins: [pluginReact()],
 });
 
 define.test(async () => {

--- a/packages/rstack/rstack.config.ts
+++ b/packages/rstack/rstack.config.ts
@@ -1,9 +1,8 @@
 // Configuration guide: https://rstack.rs/config
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { define } from 'rstack';
 
-define.test(async () => {
-  const { withRslibConfig } = await import('@rstest/adapter-rslib');
-
+define.test(() => {
   // Disable color in test
   process.env.NO_COLOR = '1';
 

--- a/website/rstack.config.ts
+++ b/website/rstack.config.ts
@@ -1,6 +1,16 @@
 // Configuration guide: https://rstack.rs/config
+import { pluginSass } from '@rsbuild/plugin-sass';
+import { pluginClientRedirects } from '@rspress/plugin-client-redirects';
+import { pluginSitemap } from '@rspress/plugin-sitemap';
+import {
+  transformerNotationDiff,
+  transformerNotationFocus,
+  transformerNotationHighlight,
+} from '@shikijs/transformers';
 import path from 'node:path';
 import { define } from 'rstack';
+import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
+import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
 
 const title = 'Rstack CLI';
 const description =
@@ -9,115 +19,102 @@ const descriptionZh =
   'Rstack CLI 通过统一的命令行、配置和工作流整合 Rstack 工具链。';
 const injectLlmsHint = process.env.RSPRESS_INJECT_LLMS_HINT !== 'false';
 
-define.doc(async () => {
-  const { pluginSass } = await import('@rsbuild/plugin-sass');
-  const {
-    transformerNotationDiff,
-    transformerNotationFocus,
-    transformerNotationHighlight,
-  } = await import('@shikijs/transformers');
-  const { pluginClientRedirects } =
-    await import('@rspress/plugin-client-redirects');
-  const { pluginSitemap } = await import('@rspress/plugin-sitemap');
-  const { pluginOpenGraph } = await import('rsbuild-plugin-open-graph');
-  const { pluginFontOpenSans } = await import('rspress-plugin-font-open-sans');
-  const siteUrl = 'https://rstack.rs';
+const siteUrl = 'https://rstack.rs';
 
-  return {
-    root: path.join(import.meta.dirname, 'docs'),
-    title,
-    icon: 'https://assets.rspack.rs/rspack/rspack-claw-logo.svg',
-    logo: '/horizontal-logo.svg',
-    description,
-    lang: 'en',
-    llms: true,
-    search: {
-      codeBlocks: true,
+define.doc({
+  root: path.join(import.meta.dirname, 'docs'),
+  title,
+  icon: 'https://assets.rspack.rs/rspack/rspack-claw-logo.svg',
+  logo: '/horizontal-logo.svg',
+  description,
+  lang: 'en',
+  llms: true,
+  search: {
+    codeBlocks: true,
+  },
+  markdown: {
+    link: {
+      checkAnchors: true,
+      checkDeadLinks: true,
     },
-    markdown: {
-      link: {
-        checkAnchors: true,
-        checkDeadLinks: true,
+    shiki: {
+      transformers: [
+        transformerNotationDiff(),
+        transformerNotationHighlight(),
+        transformerNotationFocus(),
+      ],
+    },
+  },
+  route: {
+    cleanUrls: true,
+  },
+  plugins: [
+    pluginClientRedirects({
+      redirects: [
+        {
+          from: '^/config/?$',
+          to: '/guide/configuration',
+        },
+      ],
+    }),
+    pluginFontOpenSans(),
+    pluginSitemap({ siteUrl }),
+  ],
+  locales: [
+    {
+      lang: 'en',
+      label: 'English',
+      title,
+      description,
+    },
+    {
+      lang: 'zh',
+      label: '简体中文',
+      title,
+      description: descriptionZh,
+    },
+  ],
+  themeConfig: {
+    llmsUI: {
+      placement: 'outline',
+      injectLlmsHint,
+    },
+    socialLinks: [
+      {
+        icon: 'github',
+        mode: 'link',
+        content: 'https://github.com/rstackjs/rstack-cli',
       },
-      shiki: {
-        transformers: [
-          transformerNotationDiff(),
-          transformerNotationHighlight(),
-          transformerNotationFocus(),
-        ],
+      {
+        icon: 'discord',
+        mode: 'link',
+        content: 'https://discord.gg/XsaKEEk4mW',
       },
+    ],
+    editLink: {
+      docRepoBaseUrl:
+        'https://github.com/rstackjs/rstack-cli/tree/main/website/docs',
     },
-    route: {
-      cleanUrls: true,
-    },
+  },
+  builderConfig: {
     plugins: [
-      pluginClientRedirects({
-        redirects: [
-          {
-            from: '^/config/?$',
-            to: '/guide/configuration',
-          },
-        ],
-      }),
-      pluginFontOpenSans(),
-      pluginSitemap({ siteUrl }),
-    ],
-    locales: [
-      {
-        lang: 'en',
-        label: 'English',
+      pluginSass(),
+      pluginOpenGraph({
         title,
+        type: 'website',
+        url: siteUrl,
         description,
-      },
-      {
-        lang: 'zh',
-        label: '简体中文',
-        title,
-        description: descriptionZh,
-      },
+      }),
     ],
-    themeConfig: {
-      llmsUI: {
-        placement: 'outline',
-        injectLlmsHint,
-      },
-      socialLinks: [
-        {
-          icon: 'github',
-          mode: 'link',
-          content: 'https://github.com/rstackjs/rstack-cli',
-        },
-        {
-          icon: 'discord',
-          mode: 'link',
-          content: 'https://discord.gg/XsaKEEk4mW',
-        },
-      ],
-      editLink: {
-        docRepoBaseUrl:
-          'https://github.com/rstackjs/rstack-cli/tree/main/website/docs',
-      },
+    server: {
+      open: true,
     },
-    builderConfig: {
-      plugins: [
-        pluginSass(),
-        pluginOpenGraph({
-          title,
-          type: 'website',
-          url: siteUrl,
-          description,
-        }),
-      ],
-      server: {
-        open: true,
-      },
-      tools: {
-        rspack: {
-          experiments: {
-            nativeWatcher: true,
-          },
+    tools: {
+      rspack: {
+        experiments: {
+          nativeWatcher: true,
         },
       },
     },
-  };
+  },
 });


### PR DESCRIPTION
Some Rstack configs use dynamic imports even though every normal command loading those configs also needs the imported dependencies, adding unnecessary async wrappers. This PR uses static imports for those cases while preserving command-scoped dynamic imports where they still avoid work.