### PR TITLE
docs: clarify config imports in migration skill

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/SKILL.md
+++ b/.agents/skills/migrate-to-rstack-cli/SKILL.md
@@ -72,23 +72,22 @@ define.test({
 
 ### Modules and imports
 
-Keep type-only and Node.js built-in imports at the top level. In async config functions, use a separate `await import(...)` for each tool-specific runtime dependency.
+Rstack loads every top-level import when it reads `rstack.config.*`. Prefer static imports when a config is only for an application and its tests, a library and its tests, or a documentation site.
+
+If the same config also includes lint, formatting, or staged-file checks, dynamically import dependencies inside the relevant async config function to avoid loading them during checks. Keep type-only and Node.js built-in imports at the top level.
 
 ```ts
 define.app(async () => {
   const { pluginReact } = await import('@rsbuild/plugin-react');
-  const { pluginSass } = await import('@rsbuild/plugin-sass');
 
   return {
-    plugins: [pluginReact(), pluginSass()],
+    plugins: [pluginReact()],
   };
 });
-```
 
-`define.lint` provides `@rslint/core` APIs to its config factory, so no manual import is needed:
-
-```ts
 define.lint(({ js }) => [js.configs.recommended]);
 ```
+
+`define.lint` provides `@rslint/core` APIs to its config factory, so no manual import is needed.
 
 Rstack loads TypeScript configs as native ESM. Preserve runtime-resolvable file extensions, replace CommonJS globals such as `__dirname`.

--- a/.agents/skills/migrate-to-rstack-cli/references/rsbuild.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rsbuild.md
@@ -18,17 +18,17 @@ Read this reference when the project uses `@rsbuild/core`, `rsbuild.config.*`, `
 ## Config pattern
 
 ```ts
+import { pluginReact } from '@rsbuild/plugin-react';
 import { define } from 'rstack';
 
-define.app(async () => {
-  const { pluginReact } = await import('@rsbuild/plugin-react');
-  return {
-    plugins: [pluginReact()],
-  };
+define.app({
+  plugins: [pluginReact()],
 });
 ```
 
 If tests also use Rstest, read [rstest.md](rstest.md). `rs test` derives an Rsbuild test extension from `define.app` unless `define.test` sets `extends`.
+
+Follow [Modules and imports](../SKILL.md#modules-and-imports) when the config imports plugins or themes.
 
 ## Validate
 

--- a/.agents/skills/migrate-to-rstack-cli/references/rspress.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/rspress.md
@@ -22,7 +22,7 @@ define.doc({
 });
 ```
 
-Use an async config and dynamic imports when plugins or themes require runtime imports.
+Follow [Modules and imports](../SKILL.md#modules-and-imports) when the config imports plugins or themes.
 
 ## Validate
 


### PR DESCRIPTION
Rstack config files may serve both build workflows and lightweight checks, so always using dynamic imports adds unnecessary complexity to focused configs. This PR updates the migration skill to prefer static imports for app-and-test, lib-and-test, and documentation configs, while recommending dynamic imports when a shared config also handles lint, formatting, or staged-file checks. The Rsbuild and Rspress references now follow the same guidance.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/449