### PR TITLE
feat(cli): support file arguments in rs check

### DIFF
--- a/packages/rstack/src/cli/commandHelp.ts
+++ b/packages/rstack/src/cli/commandHelp.ts
@@ -148,7 +148,7 @@ const HELP_DEFINITIONS = {
     ],
   },
   check: {
-    usage: 'rs check [options]',
+    usage: 'rs check [options] [files...]',
     description: 'Run static checks, including lint and format',
     sections: [
       {

--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -141,16 +141,6 @@ async function runRspressCLI(args: string[]): Promise<void> {
 
 const RSLINT_CONFIG_PATH = join(import.meta.dirname, 'rslintConfig.js');
 
-const SHELL_SAFE_ARGUMENT_REGEXP = /^[\w@%+=:,./-]+$/u;
-
-const quoteShellArgument = (argument: string): string =>
-  SHELL_SAFE_ARGUMENT_REGEXP.test(argument)
-    ? argument
-    : `'${argument.replaceAll("'", "'\"'\"'")}'`;
-
-const formatCommand = (args: readonly string[]): string =>
-  args.map(quoteShellArgument).join(' ');
-
 async function runRslintCLI(args: string[]): Promise<void> {
   if (hasHelpFlag(args)) {
     return printCommandHelp('lint');
@@ -202,7 +192,7 @@ async function runCheckCLI(args: string[]): Promise<void> {
     '../fmt/cli.ts'
   );
   await runFmtCLI(['--check', ...fileArgs], {
-    fixCommand: formatCommand(['rs', 'fmt', ...fileArgs]),
+    fixCommand: 'rs fmt',
     loadedConfig,
   });
 }

--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -157,13 +157,13 @@ async function runRslintCLI(args: string[]): Promise<void> {
 }
 
 async function runCheckCLI(args: string[]): Promise<void> {
-  const { values } = parseArgs({
+  const { values, positionals } = parseArgs({
     args,
     options: {
       'type-check': { type: 'boolean' },
       help: { type: 'boolean', short: 'h' },
     },
-    allowPositionals: false,
+    allowPositionals: true,
     strict: true,
   });
 
@@ -171,7 +171,13 @@ async function runCheckCLI(args: string[]): Promise<void> {
     return printCommandHelp('check');
   }
 
-  await runRslintCLI(values.typeCheck ? ['--type-check'] : []);
+  // Keep file arguments after `--` when forwarding them so names beginning
+  // with a hyphen are not reinterpreted as child-command options.
+  const fileArgs = positionals.length > 0 ? ['--', ...positionals] : [];
+  await runRslintCLI([
+    ...(values.typeCheck ? ['--type-check'] : []),
+    ...fileArgs,
+  ]);
   if (process.exitCode) {
     return;
   }
@@ -185,7 +191,10 @@ async function runCheckCLI(args: string[]): Promise<void> {
     /* rspackChunkName: 'fmt' */
     '../fmt/cli.ts'
   );
-  await runFmtCLI(['--check'], { fixCommand: 'rs fmt', loadedConfig });
+  await runFmtCLI(['--check', ...fileArgs], {
+    fixCommand: 'rs fmt',
+    loadedConfig,
+  });
 }
 
 export async function setupCommands(): Promise<void> {

--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -141,6 +141,16 @@ async function runRspressCLI(args: string[]): Promise<void> {
 
 const RSLINT_CONFIG_PATH = join(import.meta.dirname, 'rslintConfig.js');
 
+const SHELL_SAFE_ARGUMENT_REGEXP = /^[\w@%+=:,./-]+$/u;
+
+const quoteShellArgument = (argument: string): string =>
+  SHELL_SAFE_ARGUMENT_REGEXP.test(argument)
+    ? argument
+    : `'${argument.replaceAll("'", "'\"'\"'")}'`;
+
+const formatCommand = (args: readonly string[]): string =>
+  args.map(quoteShellArgument).join(' ');
+
 async function runRslintCLI(args: string[]): Promise<void> {
   if (hasHelpFlag(args)) {
     return printCommandHelp('lint');
@@ -192,7 +202,7 @@ async function runCheckCLI(args: string[]): Promise<void> {
     '../fmt/cli.ts'
   );
   await runFmtCLI(['--check', ...fileArgs], {
-    fixCommand: 'rs fmt',
+    fixCommand: formatCommand(['rs', 'fmt', ...fileArgs]),
     loadedConfig,
   });
 }

--- a/packages/rstack/tests/cli/__snapshots__/check.test.ts.snap
+++ b/packages/rstack/tests/cli/__snapshots__/check.test.ts.snap
@@ -4,7 +4,7 @@ exports[`displays check help without loading config 1`] = `
 "Rstack v<version>
 
 Usage:
-  $ rs check [options]
+  $ rs check [options] [files...]
 
 Run static checks, including lint and format
 

--- a/packages/rstack/tests/cli/check.test.ts
+++ b/packages/rstack/tests/cli/check.test.ts
@@ -48,6 +48,33 @@ test('runs lint followed by a formatting check', () => {
   expect(formatted.stderr).toBe('');
 });
 
+test('passes file arguments to lint and the formatting check', () => {
+  writeLintConfig();
+  writeProjectFile('src/selected-a.ts', 'const selectedA = true;\n');
+  writeProjectFile('src/selected-b.ts', 'const selectedB = true;\n');
+  writeProjectFile('src/unselected-lint-error.ts', 'debugger;\n');
+  writeProjectFile('src/unselected-format-error.ts', 'const value=true');
+
+  const result = runCheck(['src/selected-a.ts', 'src/selected-b.ts']);
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('Format check passed in');
+  expect(result.stdout).toContain('(2 files)');
+  expect(result.stderr).toBe('');
+});
+
+test('supports file arguments after the option terminator', () => {
+  writeLintConfig();
+  writeProjectFile('--selected.ts', 'const selected = true;\n');
+
+  const result = runCheck(['--', '--selected.ts']);
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('Format check passed in');
+  expect(result.stdout).toContain('(1 file)');
+  expect(result.stderr).toBe('');
+});
+
 test('enables type checking only with --type-check', () => {
   writeLintConfig();
   writeProjectFile(

--- a/packages/rstack/tests/cli/check.test.ts
+++ b/packages/rstack/tests/cli/check.test.ts
@@ -63,16 +63,28 @@ test('passes file arguments to lint and the formatting check', () => {
   expect(result.stderr).toBe('');
 });
 
+test('preserves file arguments in the formatting fix command', () => {
+  writeLintConfig();
+  writeProjectFile("src/selected file's.ts", 'const selected=true');
+
+  const result = runCheck(["src/selected file's.ts"]);
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain(
+    `Run rs fmt -- 'src/selected file'"'"'s.ts' to fix.`,
+  );
+});
+
 test('supports file arguments after the option terminator', () => {
   writeLintConfig();
-  writeProjectFile('--selected.ts', 'const selected = true;\n');
+  writeProjectFile('--selected.ts', 'const selected=true');
 
   const result = runCheck(['--', '--selected.ts']);
 
-  expect(result.status).toBe(0);
-  expect(result.stdout).toContain('Format check passed in');
-  expect(result.stdout).toContain('(1 file)');
-  expect(result.stderr).toBe('');
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain(
+    'Formatting issues found in 1 file. Run rs fmt -- --selected.ts to fix.',
+  );
 });
 
 test('enables type checking only with --type-check', () => {

--- a/packages/rstack/tests/cli/check.test.ts
+++ b/packages/rstack/tests/cli/check.test.ts
@@ -63,28 +63,16 @@ test('passes file arguments to lint and the formatting check', () => {
   expect(result.stderr).toBe('');
 });
 
-test('preserves file arguments in the formatting fix command', () => {
-  writeLintConfig();
-  writeProjectFile("src/selected file's.ts", 'const selected=true');
-
-  const result = runCheck(["src/selected file's.ts"]);
-
-  expect(result.status).toBe(1);
-  expect(result.stderr).toContain(
-    `Run rs fmt -- 'src/selected file'"'"'s.ts' to fix.`,
-  );
-});
-
 test('supports file arguments after the option terminator', () => {
   writeLintConfig();
-  writeProjectFile('--selected.ts', 'const selected=true');
+  writeProjectFile('--selected.ts', 'const selected = true;\n');
 
   const result = runCheck(['--', '--selected.ts']);
 
-  expect(result.status).toBe(1);
-  expect(result.stderr).toContain(
-    'Formatting issues found in 1 file. Run rs fmt -- --selected.ts to fix.',
-  );
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('Format check passed in');
+  expect(result.stdout).toContain('(1 file)');
+  expect(result.stderr).toBe('');
 });
 
 test('enables type checking only with --type-check', () => {

--- a/website/docs/en/guide/cli/check.mdx
+++ b/website/docs/en/guide/cli/check.mdx
@@ -9,7 +9,19 @@ The `rs check` command combines linting, formatting, and optional TypeScript typ
 ## Usage
 
 ```bash
-rs check [options]
+rs check [options] [files...]
+```
+
+Pass files or directories to limit both linting and formatting to those paths:
+
+```bash
+rs check src/index.ts packages/utils
+```
+
+The same file arguments are passed to both commands, so the example above is equivalent to:
+
+```bash
+rs lint src/index.ts packages/utils && rs fmt --check src/index.ts packages/utils
 ```
 
 ## Checks

--- a/website/docs/zh/guide/cli/check.mdx
+++ b/website/docs/zh/guide/cli/check.mdx
@@ -9,7 +9,19 @@ description: '同时运行 lint 和格式检查，并可选启用 TypeScript 类
 ## 用法 \{#usage}
 
 ```bash
-rs check [options]
+rs check [options] [files...]
+```
+
+传入文件或目录，可以将 lint 和格式检查都限制在这些路径中：
+
+```bash
+rs check src/index.ts packages/utils
+```
+
+相同的文件参数会同时传给两个命令，因此上述示例等同于：
+
+```bash
+rs lint src/index.ts packages/utils && rs fmt --check src/index.ts packages/utils
 ```
 
 ## 检查内容 \{#checks}


### PR DESCRIPTION
## Summary

`rs check` previously only supported whole-project checks, which prevented callers from scoping the combined lint and format workflow. This PR accepts file and directory arguments, forwards the same scope to both `rs lint` and `rs fmt --check`, and preserves option-like file names passed after `--`. It also updates CLI help, tests, and the English and Chinese documentation.