### PR TITLE
docs: clarify ignore cleanup in migration skill

### DIFF
--- a/.agents/skills/migrate-to-rstack-cli/SKILL.md
+++ b/.agents/skills/migrate-to-rstack-cli/SKILL.md
@@ -34,6 +34,12 @@ Read every matching reference before editing. Load only the tools present in the
 
 Rsbuild, Rslib, Rstest, Rslint, and Prettier remain transitive `rstack` dependencies. Remove obsolete direct dependencies and imports from the migrated scope; do not expect their names to disappear from the lockfile.
 
+### Ignore cleanup
+
+After migrating lint or formatting, remove exclusions from lint `ignores` and fmt `ignorePatterns` when the same paths are already covered by effective `.gitignore` rules; both commands read `.gitignore` automatically. For fmt, also remove `package-lock.json` and `pnpm-lock.yaml` from `ignorePatterns`; `rs fmt` ignores them by default.
+
+Keep negations and fmt exclusions that must apply to explicitly passed files, which bypass `.gitignore`.
+
 ### Combined checks
 
 After migrating lint and formatting commands, prefer the shorter combined command when behavior is equivalent:

--- a/.agents/skills/migrate-to-rstack-cli/references/prettier.md
+++ b/.agents/skills/migrate-to-rstack-cli/references/prettier.md
@@ -16,8 +16,6 @@ Read this reference when the project uses the `prettier` CLI or API, `package.js
 8. Delete old config and ignore files only after their behavior is represented in `define.fmt`.
 9. Remove direct dependencies only when no script, config, API call, plugin peer requirement, or other tool still needs them.
 
-`rs fmt` ignores `package-lock.json` and `pnpm-lock.yaml` by default. Drop redundant ignore entries during migration, but keep intentional negations.
-
 Rstack creates `.rstack/cache/.gitignore` by default. Do not list `.rstack/cache` in the root `.gitignore`; add explicit rules only for custom cache paths.
 
 `rs fmt` does not read Prettier configuration files, `.prettierignore`, or `.editorconfig`.


### PR DESCRIPTION
Migration output can retain redundant lint and formatting ignore rules that Rstack already applies. This PR adds shared cleanup guidance for `.gitignore` overlap and the lock files ignored by `rs fmt` by default, while preserving negations and exclusions required for explicit fmt inputs. It also removes the duplicate formatter-specific note.