### PR TITLE
fix(types): preserve config factory contextual typing

### DIFF
--- a/packages/rstack/src/config.ts
+++ b/packages/rstack/src/config.ts
@@ -1,7 +1,13 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { loadConfig } from '@rstackjs/load-config';
-import type { RsbuildConfigDefinition } from '@rsbuild/core';
-import type { RslibConfigDefinition } from '@rslib/core';
+import type {
+  defineConfig as defineAppConfig,
+  RsbuildConfigDefinition,
+} from '@rsbuild/core';
+import type {
+  defineConfig as defineRslibConfig,
+  RslibConfigDefinition,
+} from '@rslib/core';
 import type { RslintConfig } from '@rslint/core';
 import type { UserConfig, UserConfigAsyncFn } from '@rspress/core';
 import type { RstestConfigExport } from '@rstest/core';
@@ -99,7 +105,7 @@ type Define = {
    *
    * @see {@link https://rstack.rs/config | Configuration guide}
    */
-  app: (config: RsbuildConfigDefinition) => void;
+  app: typeof defineAppConfig;
   /**
    * Defines the Rslib config for libraries.
    *
@@ -107,7 +113,7 @@ type Define = {
    *
    * @see {@link https://rstack.rs/config | Configuration guide}
    */
-  lib: (config: RslibConfigDefinition) => void;
+  lib: typeof defineRslibConfig;
   /**
    * Defines the Rspress config for documentation.
    *
@@ -174,8 +180,14 @@ const setConfig = <T extends keyof Configs>(
 };
 
 export const define: Define = {
-  app: (config) => setConfig('app', config),
-  lib: (config) => setConfig('lib', config),
+  app: ((config) => {
+    setConfig('app', config);
+    return config;
+  }) as typeof defineAppConfig,
+  lib: <Config extends RslibConfigDefinition>(config: Config) => {
+    setConfig('lib', config);
+    return config;
+  },
   doc: (config) => setConfig('doc', config),
   test: (config) => setConfig('test', config),
   lint: (config) =>

--- a/packages/rstack/tests/types/resolution-bundler/index.ts
+++ b/packages/rstack/tests/types/resolution-bundler/index.ts
@@ -28,12 +28,43 @@ void configs;
 
 void createRsbuild({ config: appConfig });
 define.app(appConfig);
+
+// App config factories should accept `html.meta` entries with different keys.
+define.app(() => ({
+  html: {
+    meta: [
+      {
+        viewport: {
+          width: 'device-width',
+        },
+      },
+      { description: 'Rstack' },
+    ],
+  },
+}));
+
 define.lib(libConfig);
+
+// Lib config factories should accept multiple entries with different names.
+define.lib(() => ({
+  lib: [
+    {
+      format: 'esm',
+      source: { entry: { index: './src/index.ts' } },
+    },
+    {
+      format: 'esm',
+      source: { entry: { worker: './src/worker.ts' } },
+    },
+  ],
+}));
+
 define.lint(lintConfig);
 define.lint(({ js, ts }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
 ]);
+
 define.doc({});
 define.test({});
 define.staged({});

--- a/packages/rstack/tests/types/resolution-nodenext/index.ts
+++ b/packages/rstack/tests/types/resolution-nodenext/index.ts
@@ -28,12 +28,43 @@ void configs;
 
 void createRsbuild({ config: appConfig });
 define.app(appConfig);
+
+// App config factories should accept `html.meta` entries with different keys.
+define.app(() => ({
+  html: {
+    meta: [
+      {
+        viewport: {
+          width: 'device-width',
+        },
+      },
+      { description: 'Rstack' },
+    ],
+  },
+}));
+
 define.lib(libConfig);
+
+// Lib config factories should accept multiple entries with different names.
+define.lib(() => ({
+  lib: [
+    {
+      format: 'esm',
+      source: { entry: { index: './src/index.ts' } },
+    },
+    {
+      format: 'esm',
+      source: { entry: { worker: './src/worker.ts' } },
+    },
+  ],
+}));
+
 define.lint(lintConfig);
 define.lint(({ js, ts }) => [
   js.configs.recommended,
   ts.configs.recommendedTypeChecked,
 ]);
+
 define.doc({});
 define.test({});
 define.staged({});


### PR DESCRIPTION
Config factories passed to `define.app` and `define.lib` could lose upstream contextual typing, causing valid configurations with differently shaped entries to fail type checking.

This PR reuses the Rsbuild and Rslib `defineConfig` signatures while continuing to register and return the original definitions. It adds type coverage for both bundler and NodeNext module resolution.