### PR TITLE
chore(deps): upgrade Rslint to 0.9.1

### DIFF
--- a/packages/rstack/src/fmt/yukuPlugin.ts
+++ b/packages/rstack/src/fmt/yukuPlugin.ts
@@ -558,12 +558,7 @@ const parseJavaScript = (
   );
   const { program, comments } = tryCombinations(combinations);
 
-  return postprocess(
-    program as unknown as AstNode,
-    comments as PrettierComment[],
-    text,
-    'yuku-js',
-  );
+  return postprocess(program as unknown as AstNode, comments, text, 'yuku-js');
 };
 
 const parseTypeScript = (
@@ -581,12 +576,7 @@ const parseTypeScript = (
   );
   const { program, comments } = tryCombinations(combinations);
 
-  return postprocess(
-    program as unknown as AstNode,
-    comments as PrettierComment[],
-    text,
-    'yuku-ts',
-  );
+  return postprocess(program as unknown as AstNode, comments, text, 'yuku-ts');
 };
 
 const createParser = (

--- a/packages/rstack/tests/fmt/cacheIdentity.test.ts
+++ b/packages/rstack/tests/fmt/cacheIdentity.test.ts
@@ -15,8 +15,7 @@ import type { ResolvedFmtOptions } from '../../src/fmt/types.ts';
 
 const rootPath = path.join(import.meta.dirname, 'project');
 
-const asOptions = (value: Record<string, unknown>): ResolvedFmtOptions =>
-  value as ResolvedFmtOptions;
+const asOptions = (value: Record<string, unknown>): ResolvedFmtOptions => value;
 
 test('creates stable SHA-256-derived option hashes', () => {
   const hashOptions = createOptionsHasher();

--- a/packages/rstack/tests/fmt/yukuPlugin.test.ts
+++ b/packages/rstack/tests/fmt/yukuPlugin.test.ts
@@ -332,24 +332,20 @@ test('matches the official hashbang AST shape', async () => {
 });
 
 test('reports Yuku diagnostics with Prettier locations', async () => {
-  try {
-    await formatWithYuku('\n\nconst = 1', { parser: 'yuku-ts' });
-    throw new Error('Expected Yuku to report a syntax error.');
-  } catch (error) {
-    if (!(error instanceof SyntaxError)) {
-      throw error;
-    }
+  const error = await formatWithYuku('\n\nconst = 1', {
+    parser: 'yuku-ts',
+  }).catch((error: unknown) => error);
+  expect(error).toBeInstanceOf(SyntaxError);
 
-    const parseError = error as SyntaxError & {
-      loc: {
-        end: { column: number; line: number };
-        start: { column: number; line: number };
-      };
+  const parseError = error as SyntaxError & {
+    loc: {
+      end: { column: number; line: number };
+      start: { column: number; line: number };
     };
-    expect(Object.keys(parseError.loc)).toEqual(['start', 'end']);
-    expect(parseError.loc).toEqual({
-      start: { column: 7, line: 3 },
-      end: { column: 8, line: 3 },
-    });
-  }
+  };
+  expect(Object.keys(parseError.loc)).toEqual(['start', 'end']);
+  expect(parseError.loc).toEqual({
+    start: { column: 7, line: 3 },
+    end: { column: 8, line: 3 },
+  });
 });

--- a/packages/rstack/tests/setup/install.test.ts
+++ b/packages/rstack/tests/setup/install.test.ts
@@ -37,12 +37,22 @@ test('installs generated hooks and configures the repository', () => {
     for (const [name, content] of Object.entries(createHookFiles())) {
       const filePath = path.join(directory, name);
       expect(readFileSync(filePath, 'utf8')).toBe(content);
-      if (process.platform !== 'win32') {
-        expect(statSync(filePath).mode & 0o777).toBe(0o755);
-      }
     }
   });
 });
+
+test.runIf(process.platform !== 'win32')(
+  'installs executable hook shims',
+  () => {
+    withRepository((cwd) => {
+      expect(installHooks({ cwd })).toEqual({ status: 'installed', hooksPath });
+      for (const name of Object.keys(createHookFiles())) {
+        const filePath = path.join(cwd, hooksPath, name);
+        expect(statSync(filePath).mode & 0o777).toBe(0o755);
+      }
+    });
+  },
+);
 
 test('is idempotent and preserves user hooks', () => {
   withRepository((cwd) => {

--- a/packages/rstack/tests/setup/install.test.ts
+++ b/packages/rstack/tests/setup/install.test.ts
@@ -37,22 +37,14 @@ test('installs generated hooks and configures the repository', () => {
     for (const [name, content] of Object.entries(createHookFiles())) {
       const filePath = path.join(directory, name);
       expect(readFileSync(filePath, 'utf8')).toBe(content);
+      if (process.platform !== 'win32') {
+        // The platform guard intentionally skips POSIX permissions on Windows.
+        // rslint-disable-next-line rstest/no-conditional-expect
+        expect(statSync(filePath).mode & 0o777).toBe(0o755);
+      }
     }
   });
 });
-
-test.runIf(process.platform !== 'win32')(
-  'installs executable hook shims',
-  () => {
-    withRepository((cwd) => {
-      expect(installHooks({ cwd })).toEqual({ status: 'installed', hooksPath });
-      for (const name of Object.keys(createHookFiles())) {
-        const filePath = path.join(cwd, hooksPath, name);
-        expect(statSync(filePath).mode & 0o777).toBe(0o755);
-      }
-    });
-  },
-);
 
 test('is idempotent and preserves user hooks', () => {
   withRepository((cwd) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ catalogs:
       specifier: ~1.0.0
       version: 1.0.0
     '@rslint/core':
-      specifier: 0.9.0
-      version: 0.9.0
+      specifier: 0.9.1
+      version: 0.9.1
     '@rspress/core':
       specifier: ^2.0.21
       version: 2.0.21
@@ -369,7 +369,7 @@ importers:
         version: 1.0.0(typescript@7.0.2)
       '@rslint/core':
         specifier: 'catalog:'
-        version: 0.9.0
+        version: 0.9.1
       '@rstest/core':
         specifier: 'catalog:'
         version: 0.11.12(happy-dom@20.13.2)
@@ -1320,8 +1320,8 @@ packages:
       typescript:
         optional: true
 
-  '@rslint/core@0.9.0':
-    resolution: {integrity: sha512-rY8F6kdQ/XkBiflaNzglJdMfxl0Lv/NFXppK0kAhx2P2CvogsXIA/z82Wxtk+Cg9uFHou67N9/iqmWXgdtSoDw==}
+  '@rslint/core@0.9.1':
+    resolution: {integrity: sha512-MRS6lS+GiobBr+iIl5iFAYfwhhxVJX28lB6uVnwH40U49DCPUF0J2qlKI7RewPKDmKp5uosKJcvpxE8Rm7aVcg==}
     hasBin: true
     peerDependencies:
       jiti: ^2.7.0
@@ -1329,47 +1329,47 @@ packages:
       jiti:
         optional: true
 
-  '@rslint/native-darwin-arm64@0.9.0':
-    resolution: {integrity: sha512-xhdBrVALZTX0v4ZghKY7RGO87DpItk4DVvKm3MGih4w1o2WF2u+6n/mohvG7/ts7c8T88HIbLfK4luQ8kMDCsg==}
+  '@rslint/native-darwin-arm64@0.9.1':
+    resolution: {integrity: sha512-WuWZObUanaYI+93vnld+3LNXJeCkMA5ntkBs8VMptBrPa64H4K/WEm4BN1Z8NLjW5TnYWhG1wVgRE2Ie8UeSYg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rslint/native-darwin-x64@0.9.0':
-    resolution: {integrity: sha512-xuluXYUKizRZD/70WILvn+OeNdBT6izU81vhiNHVYdEQmfsqaqE8fthKGmQvaRu/DNL3CgVRPR+PzOAcQzPpOw==}
+  '@rslint/native-darwin-x64@0.9.1':
+    resolution: {integrity: sha512-Pce+LuyMmqBNwPjXMg5MEgo3nu36H3p7FyAwWEn8dlmUAQPhe3BQQ73fa7TT/97I9yfXY+YmJVRjLuctHQKmbw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rslint/native-linux-arm64-gnu@0.9.0':
-    resolution: {integrity: sha512-J9uHBg/8Z9WanEKBXaPNZz0h+P8qtOLwjVqwEcOwYm1yLHRY70A7XqI6cRVIx72gXKGWtNBT2BRw9p8CWQUhgg==}
+  '@rslint/native-linux-arm64-gnu@0.9.1':
+    resolution: {integrity: sha512-pzt13FMri+oYevnR1xXo8CJkwr+RjxCFGJnYxoJ4C3jUKJLK+aJTlREDX1gnCMAXxx02YIUAqBrc4zQ09PAKsw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rslint/native-linux-arm64-musl@0.9.0':
-    resolution: {integrity: sha512-3ICIPH1oZOuMuZp+4hRhU+Af34U/2MNFB1yN+yi/jfJP+qBEExQbeBOS4J6HOecx9RJXcFvPF2ZI68l4g8/DPQ==}
+  '@rslint/native-linux-arm64-musl@0.9.1':
+    resolution: {integrity: sha512-+fe6CNu+C5mshQ0hDyi/NakM3rqMyvMqKUf5ldNTQhaNUYavdb9cP7yXJw/H6qwHB6wbZIqSDo3b6HohzgnBkw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rslint/native-linux-x64-gnu@0.9.0':
-    resolution: {integrity: sha512-vlzcruA/t+0XvdK2S0bIS00H9Mpkrwo/hIFvpyUONgxi2WaO7XNDtgTWAsajB40WmvezYYLKs45LgkVXpxSCFA==}
+  '@rslint/native-linux-x64-gnu@0.9.1':
+    resolution: {integrity: sha512-119QVNJATOI21fGB5OsYfu0DXo7UMyyEpLi9TCogiZQF1X9QkPDdH0DXVQb2yi/H8H6FlNXak91G5vJ2W0SY2w==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rslint/native-linux-x64-musl@0.9.0':
-    resolution: {integrity: sha512-+gPExuOtSPaP7jAWeMRnTobvQOhaqo9857K/7T2qvc15ksnYqqygMhzcVzm9Wt7L4KBoW6PR1uvwgmPaK4B0IA==}
+  '@rslint/native-linux-x64-musl@0.9.1':
+    resolution: {integrity: sha512-eUkiywQGG0umzYU86n1ZetCPBS1bLUFJZkFB+MovbDQQF+V9R6xA7x2mJvODnA7laOB3e7VK/uF56RvUebtzXQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rslint/native-win32-arm64-msvc@0.9.0':
-    resolution: {integrity: sha512-YK5uTuk6zNXru2cOwivbZPH25C7u8RSQlKm5tOqwhaQ0ShCVDdh7z0SXvHvLdQ2VJen+30Vp1izAMZ7Zp/8KaQ==}
+  '@rslint/native-win32-arm64-msvc@0.9.1':
+    resolution: {integrity: sha512-e0GLvCYh2XiQtVoFxbeU/QuM1mC6PWQATZbPN6fxfB4ZFH3S8KbcYCNFJyTEHp5WbU4XFJnut1qEf2u8pBoADA==}
     cpu: [arm64]
     os: [win32]
 
-  '@rslint/native-win32-x64-msvc@0.9.0':
-    resolution: {integrity: sha512-7elW5V8zm3McqA0LCjBBR7SDwQ5hRW+hrnJcCmrspSnBeUPFqnJfvUvsQPgbJz3pdrkBzzjZMvUgEYyBQ9dl8A==}
+  '@rslint/native-win32-x64-msvc@0.9.1':
+    resolution: {integrity: sha512-pofbo2UYBjK/OwNstlBEH89/XMUllp3PVTz21wQ7ryu3yH8atCzP2CX4Jv8IQ7eWpDJyMALhkXeEy5bsbI04xw==}
     cpu: [x64]
     os: [win32]
 
@@ -3881,41 +3881,41 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rslint/core@0.9.0':
+  '@rslint/core@0.9.1':
     dependencies:
       picomatch: 4.0.7
     optionalDependencies:
-      '@rslint/native-darwin-arm64': 0.9.0
-      '@rslint/native-darwin-x64': 0.9.0
-      '@rslint/native-linux-arm64-gnu': 0.9.0
-      '@rslint/native-linux-arm64-musl': 0.9.0
-      '@rslint/native-linux-x64-gnu': 0.9.0
-      '@rslint/native-linux-x64-musl': 0.9.0
-      '@rslint/native-win32-arm64-msvc': 0.9.0
-      '@rslint/native-win32-x64-msvc': 0.9.0
+      '@rslint/native-darwin-arm64': 0.9.1
+      '@rslint/native-darwin-x64': 0.9.1
+      '@rslint/native-linux-arm64-gnu': 0.9.1
+      '@rslint/native-linux-arm64-musl': 0.9.1
+      '@rslint/native-linux-x64-gnu': 0.9.1
+      '@rslint/native-linux-x64-musl': 0.9.1
+      '@rslint/native-win32-arm64-msvc': 0.9.1
+      '@rslint/native-win32-x64-msvc': 0.9.1
 
-  '@rslint/native-darwin-arm64@0.9.0':
+  '@rslint/native-darwin-arm64@0.9.1':
     optional: true
 
-  '@rslint/native-darwin-x64@0.9.0':
+  '@rslint/native-darwin-x64@0.9.1':
     optional: true
 
-  '@rslint/native-linux-arm64-gnu@0.9.0':
+  '@rslint/native-linux-arm64-gnu@0.9.1':
     optional: true
 
-  '@rslint/native-linux-arm64-musl@0.9.0':
+  '@rslint/native-linux-arm64-musl@0.9.1':
     optional: true
 
-  '@rslint/native-linux-x64-gnu@0.9.0':
+  '@rslint/native-linux-x64-gnu@0.9.1':
     optional: true
 
-  '@rslint/native-linux-x64-musl@0.9.0':
+  '@rslint/native-linux-x64-musl@0.9.1':
     optional: true
 
-  '@rslint/native-win32-arm64-msvc@0.9.0':
+  '@rslint/native-win32-arm64-msvc@0.9.1':
     optional: true
 
-  '@rslint/native-win32-x64-msvc@0.9.0':
+  '@rslint/native-win32-x64-msvc@0.9.1':
     optional: true
 
   '@rspack/binding-darwin-arm64@2.2.2':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@rsbuild/plugin-react': '^2.1.0'
   '@rsbuild/plugin-sass': '^2.0.1'
   '@rslib/core': '~1.0.0'
-  '@rslint/core': '0.9.0'
+  '@rslint/core': '0.9.1'
   '@rspress/core': '^2.0.21'
   '@rspress/plugin-client-redirects': '^2.0.21'
   '@rspress/plugin-sitemap': '^2.0.21'

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -22,12 +22,7 @@ define.lint(({ globals, js, ts, rstestPlugin }) => {
       files: ['**/*.test.{ts,tsx}'],
       ...rstestPlugin.configs.recommended,
       rules: {
-        ...rstestPlugin.configs.recommended.rules,
-        'rstest/expect-expect': [
-          'warn',
-          { assertFunctionNames: ['expect', 'assert', 'expect*'] },
-        ],
-        // CLI fixtures re-export an extended test from #test-helpers.
+        'rstest/expect-expect': ['error', { assertFunctionNames: ['expect*'] }],
         'rstest/no-standalone-expect': [
           'error',
           { additionalTestBlockFunctions: ['test'] },

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -21,6 +21,18 @@ define.lint(({ globals, js, ts, rstestPlugin }) => {
     {
       files: ['**/*.test.{ts,tsx}'],
       ...rstestPlugin.configs.recommended,
+      rules: {
+        ...rstestPlugin.configs.recommended.rules,
+        'rstest/expect-expect': [
+          'warn',
+          { assertFunctionNames: ['expect', 'assert', 'expect*'] },
+        ],
+        // CLI fixtures re-export an extended test from #test-helpers.
+        'rstest/no-standalone-expect': [
+          'error',
+          { additionalTestBlockFunctions: ['test'] },
+        ],
+      },
     },
     // Source imports use .ts for Node.js native TypeScript execution; builds rewrite them to .js.
     {


### PR DESCRIPTION
## Summary

Upgrades Rslint from 0.9.0 to 0.9.1 for upstream fixes and Rstest linting support for `rstack/test` imports.
Configures recognition of existing test helpers, removes redundant type assertions, and adjusts tests to satisfy the newly enforced rules.

## Related Links

- [Rslint v0.9.1 release notes](https://github.com/web-infra-dev/rslint/releases/tag/v0.9.1)
