### PR TITLE
fix(rstack): support latest Rstest CLI entry

### DIFF
--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -58,7 +58,14 @@ async function runRstestCLI(args: string[]): Promise<void> {
     ),
   ];
 
-  const { runCLI } = await import('@rstest/core');
+  type RunCLI = (options: { argv: string[] }) => void;
+  const rstestCore = (await import('@rstest/core')) as unknown as {
+    runCLI?: RunCLI;
+  };
+  const runCLI =
+    rstestCore.runCLI ??
+    ((await import('@rstest/core/api')) as unknown as { runCLI: RunCLI })
+      .runCLI;
   runCLI({ argv });
 }
 


### PR DESCRIPTION
## Summary

- keep using the root `runCLI` export with Rstest 0.11.x
- fall back to `@rstest/core/api` after the programmatic API rewrite moved the export
- restore compatibility for `rs test` consumers without changing command arguments

## Validation

- `pnpm --filter rstack build`
- `node packages/rstack/dist/index.js test --version`
- `pnpm check` reached and passed lint/type checking, then stopped because the local native binding was unavailable

## Ecosystem CI

This addresses the shared `runCLI is not a function` failure in Rstest ecosystem CI for Rsbuild and Rsdoctor, plus the declaration error in rstack-cli after web-infra-dev/rstest#1729.
