### PR TITLE
fix(rstack): pass compatible Rstest CLI args

### DIFF
--- a/packages/rstack/src/cli/commands.ts
+++ b/packages/rstack/src/cli/commands.ts
@@ -62,11 +62,15 @@ async function runRstestCLI(args: string[]): Promise<void> {
   const rstestCore = (await import('@rstest/core')) as unknown as {
     runCLI?: RunCLI;
   };
-  const runCLI =
-    rstestCore.runCLI ??
-    ((await import('@rstest/core/api')) as unknown as { runCLI: RunCLI })
-      .runCLI;
-  runCLI({ argv });
+  if (rstestCore.runCLI) {
+    rstestCore.runCLI({ argv });
+    return;
+  }
+
+  const { runCLI } = (await import('@rstest/core/api')) as unknown as {
+    runCLI: RunCLI;
+  };
+  runCLI({ argv: argv.slice(2) });
 }
 
 async function runRslibCLI(args: string[]): Promise<void> {


### PR DESCRIPTION
## Summary

- preserve the full Node.js argv shape for Rstest 0.11.x's root `runCLI` export
- pass only command arguments to the rewritten `@rstest/core/api` entry
- restore test discovery for Rstest ecosystem consumers using Rstack CLI 0.7.3

## Validation

- `pnpm --filter rstack build`
- `pnpm check` (lint and type check passed; formatting then stopped because the local native binding was unavailable)
- `node dist/index.js test list` from `packages/rstack` with Rstest 0.11.12
- `git diff --check`

The local native build could not complete because the Rust toolchain download ran out of disk space. The current ecosystem failure was verified against Rstest commit `d9622c3e`: the full argv was interpreted as the filters `node` and `rstest`, producing `No test files found` in rstack-cli and Rsbuild.

Related: #460 and web-infra-dev/rstest#1729.
