### PR TITLE
fix(create-rstack): use pnpm for the Turborepo template

### DIFF
--- a/packages/create-rstack/src/index.ts
+++ b/packages/create-rstack/src/index.ts
@@ -8,7 +8,6 @@ import {
 import {
   access,
   appendFile,
-  copyFile,
   mkdir,
   readFile,
   writeFile,
@@ -229,29 +228,13 @@ const injectStagedSetup = async ({
   ]);
 };
 
-const configureTurborepo = async ({
-  templateName,
-  distFolder,
-}: GitResolvedContext): Promise<void> => {
-  if (templateName !== 'turborepo') {
-    return;
-  }
-
-  // The toolkit may skip this file based on the invoking package manager.
-  await copyFile(
-    path.join(packageRoot, 'template-turborepo/pnpm-workspace.yaml'),
-    path.join(distFolder, 'pnpm-workspace.yaml'),
-  );
-};
-
 await create({
   root: packageRoot,
   name: 'rstack',
   templates: templateNames,
   builtinTools: [],
   getTemplateName,
-  onGitResolved: async (context) => {
-    await configureTurborepo(context);
-    await injectStagedSetup(context);
-  },
+  getPackageManager: ({ templateName }) =>
+    templateName === 'turborepo' ? 'pnpm' : undefined,
+  onGitResolved: injectStagedSetup,
 });

--- a/packages/create-rstack/tests/create.test.ts
+++ b/packages/create-rstack/tests/create.test.ts
@@ -210,9 +210,11 @@ const createProject = async (
   {
     args = [],
     initializeGitIn,
+    userAgent = 'pnpm/11.20.0',
   }: {
     args?: string[];
     initializeGitIn?: 'parent' | 'project';
+    userAgent?: string;
   } = {},
 ) => {
   const tempDirectory = await mkdtemp(path.join(tmpdir(), 'create-rstack-'));
@@ -233,7 +235,7 @@ const createProject = async (
       cwd: tempDirectory,
       env: {
         ...process.env,
-        npm_config_user_agent: 'pnpm/11.20.0',
+        npm_config_user_agent: userAgent,
       },
     },
   );
@@ -296,8 +298,10 @@ test.each(docTemplates)(
   },
 );
 
-test('creates the Turborepo template with pnpm', async () => {
-  const projectDirectory = await createProject('turborepo');
+test('creates the Turborepo template with pnpm when invoked using npm', async () => {
+  const projectDirectory = await createProject('turborepo', {
+    userAgent: 'npm/11.0.0',
+  });
   const packageJson = await readProjectPackage(projectDirectory);
   const appPackage = await readProjectPackage(
     path.join(projectDirectory, 'apps/web'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ catalogs:
       specifier: ^2.0.21
       version: 2.0.21
     '@rstackjs/create-toolkit':
-      specifier: 2.2.4
-      version: 2.2.4
+      specifier: 2.2.6
+      version: 2.2.6
     '@rstackjs/doc-ui':
       specifier: 1.14.11
       version: 1.14.11
@@ -347,7 +347,7 @@ importers:
     dependencies:
       '@rstackjs/create-toolkit':
         specifier: 'catalog:'
-        version: 2.2.4
+        version: 2.2.6
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1494,8 +1494,8 @@ packages:
   '@rspress/shared@2.0.21':
     resolution: {integrity: sha512-siCWkv1a4n6y7JdVRII+fwCRZGZtG5KGFfKi2w/Tt33UnIgh4XGqozZ5F/K0iZ/QUwg0wi93SoVdOQm2Q+wf8w==}
 
-  '@rstackjs/create-toolkit@2.2.4':
-    resolution: {integrity: sha512-YVnA9aTZKPTql8Hzyf9o5chWAICNJ46CYoPwADrSObyBxF1jlvB5gO5M+yXYoZT/VNWh1Abm0TvTtmAh4EeT3A==}
+  '@rstackjs/create-toolkit@2.2.6':
+    resolution: {integrity: sha512-kBJ6btUXKpJEqq1c6sSCfukjb2NK4zWpl3sKj4pk91cdI6L5If7NFaov6RRpTP/EuVW37wkVV5FlXJKZQPEC3Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@rstackjs/doc-ui@1.14.11':
@@ -4061,7 +4061,7 @@ snapshots:
       - core-js
       - supports-color
 
-  '@rstackjs/create-toolkit@2.2.4': {}
+  '@rstackjs/create-toolkit@2.2.6': {}
 
   '@rstackjs/doc-ui@1.14.11(@rspress/core@2.0.21)':
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@rspress/plugin-client-redirects': '^2.0.21'
   '@rspress/plugin-sitemap': '^2.0.21'
   '@rstackjs/doc-ui': '1.14.11'
-  '@rstackjs/create-toolkit': '2.2.4'
+  '@rstackjs/create-toolkit': '2.2.6'
   '@rstackjs/load-config': ^0.1.2
   '@rstackjs/test-utils': ^0.2.0
   '@rstest/adapter-rsbuild': '~0.11.12'


### PR DESCRIPTION
## Summary

Creating the Turborepo template through npm currently prints npm next-step commands even though the template requires pnpm. Upgrade `@rstackjs/create-toolkit` to 2.2.6 and use `getPackageManager` to select pnpm, removing the manual workspace-file copy while preserving package manager detection for other templates.

## Related Links

https://github.com/rstackjs/create-toolkit/releases/tag/v2.2.6