### PR TITLE
fix: track Rstack config files in Rsbuild

### DIFF
--- a/packages/rstack/src/rsbuildConfig.ts
+++ b/packages/rstack/src/rsbuildConfig.ts
@@ -1,8 +1,4 @@
-import type {
-  ConfigParams,
-  RsbuildConfigDefinition,
-  WatchFiles,
-} from '@rsbuild/core';
+import type { ConfigParams, RsbuildConfigDefinition } from '@rsbuild/core';
 import { withConfigMeta } from '@rstackjs/load-config';
 import { loadRstackConfig, type Configs } from './config.ts';
 
@@ -21,33 +17,7 @@ const loadRsbuildConfig: RsbuildConfigDefinition = async (params) => {
   const { configs, filePath, dependencies } = await loadRstackConfig();
   const config = await resolveRsbuildConfig(configs, params);
 
-  if (!filePath) {
-    return config;
-  }
-
-  const watchFiles = config.dev?.watchFiles;
-  const watchConfig: WatchFiles = {
-    paths: [filePath, ...dependencies],
-    type: 'reload-server',
-  };
-
-  return withConfigMeta(
-    {
-      ...config,
-      dev: {
-        ...config.dev,
-        watchFiles: [
-          ...(watchFiles
-            ? Array.isArray(watchFiles)
-              ? watchFiles
-              : [watchFiles]
-            : []),
-          watchConfig,
-        ],
-      },
-    },
-    { filePath, dependencies },
-  );
+  return withConfigMeta(config, { filePath, dependencies });
 };
 
 export default loadRsbuildConfig;

--- a/packages/rstack/src/rsbuildConfig.ts
+++ b/packages/rstack/src/rsbuildConfig.ts
@@ -3,6 +3,7 @@ import type {
   RsbuildConfigDefinition,
   WatchFiles,
 } from '@rsbuild/core';
+import { withConfigMeta } from '@rstackjs/load-config';
 import { loadRstackConfig, type Configs } from './config.ts';
 
 const resolveRsbuildConfig = async (configs: Configs, params: ConfigParams) => {
@@ -30,20 +31,23 @@ const loadRsbuildConfig: RsbuildConfigDefinition = async (params) => {
     type: 'reload-server',
   };
 
-  return {
-    ...config,
-    dev: {
-      ...config.dev,
-      watchFiles: [
-        ...(watchFiles
-          ? Array.isArray(watchFiles)
-            ? watchFiles
-            : [watchFiles]
-          : []),
-        watchConfig,
-      ],
+  return withConfigMeta(
+    {
+      ...config,
+      dev: {
+        ...config.dev,
+        watchFiles: [
+          ...(watchFiles
+            ? Array.isArray(watchFiles)
+              ? watchFiles
+              : [watchFiles]
+            : []),
+          watchConfig,
+        ],
+      },
     },
-  };
+    { filePath, dependencies },
+  );
 };
 
 export default loadRsbuildConfig;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ catalogs:
       specifier: 1.14.11
       version: 1.14.11
     '@rstackjs/load-config':
-      specifier: ^0.1.2
-      version: 0.1.2
+      specifier: ^1.0.0
+      version: 1.0.0
     '@rstackjs/test-utils':
       specifier: ^1.0.0
       version: 1.0.0
@@ -492,7 +492,7 @@ importers:
         version: 2.0.21(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
       '@rstackjs/load-config':
         specifier: 'catalog:'
-        version: 0.1.2
+        version: 1.0.0
       '@rstackjs/test-utils':
         specifier: 'catalog:'
         version: 1.0.0
@@ -1709,8 +1709,8 @@ packages:
       '@rspress/core':
         optional: true
 
-  '@rstackjs/load-config@0.1.2':
-    resolution: {integrity: sha512-6hChPVosmh2rzEt1M1CvGpsaE/+gGlt51ci5pbyd4Bd1FXyH+Owlg99ECvdcWtD7zdDwDM3jGkQL05xn9oWSIA==}
+  '@rstackjs/load-config@1.0.0':
+    resolution: {integrity: sha512-eLp6lGEngk43kU6Z0iQNlGwgy4lLx/wtKdaBgoewHmWN0HHJRgQypewagqGxo+iNP4Yyf7pOXxAbsbH+L9Ay6A==}
     peerDependencies:
       jiti: ^2.0.0
     peerDependenciesMeta:
@@ -4349,7 +4349,7 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.21(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
-  '@rstackjs/load-config@0.1.2': {}
+  '@rstackjs/load-config@1.0.0': {}
 
   '@rstackjs/test-utils@1.0.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ catalogs:
       specifier: ^3.9.0
       version: 3.9.0
     '@rsbuild/core':
-      specifier: ~2.2.4
-      version: 2.2.4
+      specifier: ~2.2.5
+      version: 2.2.5
     '@rsbuild/plugin-react':
       specifier: ^2.1.0
       version: 2.1.0
@@ -464,7 +464,7 @@ importers:
     dependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.4
+        version: 2.2.5
       '@rslib/core':
         specifier: 'catalog:'
         version: 1.0.0(typescript@7.0.2)
@@ -498,7 +498,7 @@ importers:
         version: 1.0.0
       '@rstest/adapter-rsbuild':
         specifier: 'catalog:'
-        version: 0.11.12(@rsbuild/core@2.2.4)(@rstest/core@0.11.12)
+        version: 0.11.12(@rsbuild/core@2.2.5)(@rstest/core@0.11.12)
       '@rstest/adapter-rslib':
         specifier: 'catalog:'
         version: 0.11.12(@rslib/core@1.0.0)(@rstest/core@0.11.12)(typescript@7.0.2)
@@ -1392,8 +1392,8 @@ packages:
       core-js:
         optional: true
 
-  '@rsbuild/core@2.2.4':
-    resolution: {integrity: sha512-36Znklavtu2iSp7tGsn4VLRmMik60N50SFrimSORypBaGHHreDq/IpdSFJiu9xXdy4SmzK9LkTlmvSJ9L4gvfQ==}
+  '@rsbuild/core@2.2.5':
+    resolution: {integrity: sha512-nf34ri1iZduYhHUr5Vc79L7Eml+IlN0nFIaF/g3OW4WR/gShxuf5wVXS69/H8FTHJYN4SdYlNcefSZQluEMKgA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4058,7 +4058,7 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.2.4':
+  '@rsbuild/core@2.2.5':
     dependencies:
       '@rspack/core': 2.2.3(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
@@ -4086,8 +4086,8 @@ snapshots:
 
   '@rslib/core@1.0.0(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/core': 2.2.4
-      rsbuild-plugin-dts: 1.0.0(@rsbuild/core@2.2.4)(typescript@7.0.2)
+      '@rsbuild/core': 2.2.5
+      rsbuild-plugin-dts: 1.0.0(@rsbuild/core@2.2.5)(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
@@ -4353,9 +4353,9 @@ snapshots:
 
   '@rstackjs/test-utils@1.0.0': {}
 
-  '@rstest/adapter-rsbuild@0.11.12(@rsbuild/core@2.2.4)(@rstest/core@0.11.12)':
+  '@rstest/adapter-rsbuild@0.11.12(@rsbuild/core@2.2.5)(@rstest/core@0.11.12)':
     dependencies:
-      '@rsbuild/core': 2.2.4
+      '@rsbuild/core': 2.2.5
       '@rstest/core': 0.11.12(happy-dom@20.14.0)
 
   '@rstest/adapter-rslib@0.11.12(@rslib/core@1.0.0)(@rstest/core@0.11.12)(typescript@7.0.2)':
@@ -4367,7 +4367,7 @@ snapshots:
 
   '@rstest/core@0.11.12(happy-dom@20.14.0)':
     dependencies:
-      '@rsbuild/core': 2.2.4
+      '@rsbuild/core': 2.2.5
       '@types/chai': 5.2.3
     optionalDependencies:
       happy-dom: 20.14.0
@@ -5838,10 +5838,10 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  rsbuild-plugin-dts@1.0.0(@rsbuild/core@2.2.4)(typescript@7.0.2):
+  rsbuild-plugin-dts@1.0.0(@rsbuild/core@2.2.5)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.45.2
-      '@rsbuild/core': 2.2.4
+      '@rsbuild/core': 2.2.5
     optionalDependencies:
       typescript: 7.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ catalog:
   '@rspress/plugin-sitemap': '^2.0.21'
   '@rstackjs/doc-ui': '1.14.11'
   '@rstackjs/create-toolkit': '2.2.6'
-  '@rstackjs/load-config': ^0.1.2
+  '@rstackjs/load-config': ^1.0.0
   '@rstackjs/test-utils': ^1.0.0
   '@rstest/adapter-rsbuild': '~0.11.12'
   '@rstest/adapter-rslib': '~0.11.12'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ cleanupUnusedCatalogs: true
 
 catalog:
   '@napi-rs/cli': '^3.9.0'
-  '@rsbuild/core': '~2.2.4'
+  '@rsbuild/core': '~2.2.5'
   '@rsbuild/plugin-react': '^2.1.0'
   '@rsbuild/plugin-sass': '^2.0.1'
   '@rslib/core': '~1.0.0'


### PR DESCRIPTION
## Motivation

Rsbuild should track the real Rstack config file and its imports in its context, config watcher, and persistent cache dependencies.

## Changes

Upgrade Rsbuild to [v2.2.5](https://github.com/web-infra-dev/rsbuild/releases/tag/v2.2.5) and `@rstackjs/load-config` to v1.0.0. Pass config metadata with `withConfigMeta` and remove the redundant `dev.watchFiles` injection.

Verified default and custom config metadata and cache dependencies with the published Rsbuild version. Existing config reload tests, builds, type and format checks passed (373 tests passed, 1 skipped).