### PR TITLE
fix: ignore skills-lock.json in rs fmt by default

### DIFF
--- a/packages/rstack/src/fmt/ignore.ts
+++ b/packages/rstack/src/fmt/ignore.ts
@@ -8,12 +8,16 @@ import { loadNativeBinding } from '../native/index.ts';
 import type { ResolvedFmtConfig } from './types.ts';
 
 /**
- * Common lock files that Prettier can format but `rs fmt` leaves to package managers.
+ * Common lock files that Prettier can format but `rs fmt` leaves to their generating tools.
  *
  * Prettier already skips other generated lock files when it cannot infer a parser, so this list
  * contains only the additional defaults owned by `rs fmt`.
  */
-const defaultIgnoreNames = ['package-lock.json', 'pnpm-lock.yaml'];
+const defaultIgnoreNames = [
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'skills-lock.json',
+];
 
 type IgnorePredicate = (filePath: string, isDirectory?: boolean) => boolean;
 

--- a/website/docs/en/guide/formatting.mdx
+++ b/website/docs/en/guide/formatting.mdx
@@ -105,7 +105,7 @@ Patterns follow Gitignore syntax and are resolved relative to the directory cont
 
 ### Lock files
 
-By default, `rs fmt` ignores common lock files, including `package-lock.json` and `pnpm-lock.yaml`.
+By default, `rs fmt` ignores common lock files, including `package-lock.json`, `pnpm-lock.yaml`, and `skills-lock.json`.
 
 To format these files, use a negated pattern to explicitly include them:
 

--- a/website/docs/zh/guide/formatting.mdx
+++ b/website/docs/zh/guide/formatting.mdx
@@ -105,7 +105,7 @@ define.fmt({
 
 ### Lock 文件 \{#lock-files}
 
-`rs fmt` 默认忽略常见的 lock 文件，包括 `package-lock.json` 和 `pnpm-lock.yaml`。
+`rs fmt` 默认忽略常见的 lock 文件，包括 `package-lock.json`、`pnpm-lock.yaml` 和 `skills-lock.json`。
 
 如果你需要格式化这些文件，可以使用否定模式主动包含它们：
 


### PR DESCRIPTION
## Motivation

`skills-lock.json` is generated by the Skills CLI with its own formatting. Applying project formatting rules can introduce unnecessary diffs that are overwritten on the next skill update.

## Changes

Ignore `skills-lock.json` by default in `rs fmt`, alongside the existing lock files. Users can still opt in with `ignorePatterns: ['!skills-lock.json']`. Update the English and Chinese formatting documentation.